### PR TITLE
ui diff: raw frame hashes in mp4 metadata instead of lossless recording

### DIFF
--- a/.github/workflows/ui_preview.yaml
+++ b/.github/workflows/ui_preview.yaml
@@ -91,7 +91,6 @@ jobs:
             git config user.name "GitHub Actions Bot"
             git config user.email "<>"
             cp "${{ github.workspace }}/pr_ui/${video}.mp4" .
-            cp "${{ github.workspace }}/pr_ui/${video}.framehash" . 2>/dev/null || true
             git add .
             git commit -m "${name} video for commit ${{ env.SHA }}"
             git push origin "$branch" --force
@@ -113,9 +112,7 @@ jobs:
             diff_name="${name}_diff"
 
             mv "${{ github.workspace }}/pr_ui/${video}.mp4" "${{ github.workspace }}/pr_ui/${video}_proposed.mp4"
-            mv "${{ github.workspace }}/pr_ui/${video}.framehash" "${{ github.workspace }}/pr_ui/${video}_proposed.framehash" 2>/dev/null || true
             cp "${{ github.workspace }}/master_${name}/${video}.mp4" "${{ github.workspace }}/pr_ui/${video}_master.mp4"
-            cp "${{ github.workspace }}/master_${name}/${video}.framehash" "${{ github.workspace }}/pr_ui/${video}_master.framehash" 2>/dev/null || true
 
             diff_exit_code=0
             python3 ${{ github.workspace }}/selfdrive/ui/tests/diff/diff.py \

--- a/.github/workflows/ui_preview.yaml
+++ b/.github/workflows/ui_preview.yaml
@@ -91,6 +91,7 @@ jobs:
             git config user.name "GitHub Actions Bot"
             git config user.email "<>"
             cp "${{ github.workspace }}/pr_ui/${video}.mp4" .
+            cp "${{ github.workspace }}/pr_ui/${video}.framehash" . 2>/dev/null || true
             git add .
             git commit -m "${name} video for commit ${{ env.SHA }}"
             git push origin "$branch" --force
@@ -112,7 +113,9 @@ jobs:
             diff_name="${name}_diff"
 
             mv "${{ github.workspace }}/pr_ui/${video}.mp4" "${{ github.workspace }}/pr_ui/${video}_proposed.mp4"
+            mv "${{ github.workspace }}/pr_ui/${video}.framehash" "${{ github.workspace }}/pr_ui/${video}_proposed.framehash" 2>/dev/null || true
             cp "${{ github.workspace }}/master_${name}/${video}.mp4" "${{ github.workspace }}/pr_ui/${video}_master.mp4"
+            cp "${{ github.workspace }}/master_${name}/${video}.framehash" "${{ github.workspace }}/pr_ui/${video}_master.framehash" 2>/dev/null || true
 
             diff_exit_code=0
             python3 ${{ github.workspace }}/selfdrive/ui/tests/diff/diff.py \

--- a/selfdrive/ui/tests/diff/diff.py
+++ b/selfdrive/ui/tests/diff/diff.py
@@ -40,7 +40,7 @@ def extract_framehashes(video_path: Path) -> list[str]:
   if result.returncode != 0 or not value:
     print(f"WARNING: No framehashes found in metadata of {video_path}")
     return []
-  hashes = value.splitlines()
+  hashes = value.split(",")
   print(f"Loaded {len(hashes)} frame hashes from {video_path}")
   return hashes
 

--- a/selfdrive/ui/tests/diff/diff.py
+++ b/selfdrive/ui/tests/diff/diff.py
@@ -27,7 +27,7 @@ def extract_framehashes(video_path) -> list[str]:
     print(f"WARNING: No framehashes metadata found in {video_path}")
     return []
   hashes = value.splitlines()
-  print(f"Loaded {len(hashes)} pre-computed frame hashes from {video_path} metadata")
+  print(f"Loaded {len(hashes)} frame hashes from {video_path}")
   return hashes
 
 

--- a/selfdrive/ui/tests/diff/diff.py
+++ b/selfdrive/ui/tests/diff/diff.py
@@ -19,23 +19,29 @@ def create_diff_video(video1, video2, output_path):
 
 
 def embed_framehashes(video_path: Path, hashes: list[str]) -> None:
-  """Embed frame hashes into MP4 custom metadata via stream copy with temp file."""
-  # We can't read/write the file simultaneously, so write to a temp file and then replace the original
-  tmp_path = video_path.with_suffix('.tmp.mp4')
-  hash_str = "\n".join(hashes)
+  """Embed frame hashes into MP4 metadata."""
+  tmp_video = video_path.with_suffix('.tmp.mp4')  # we can't edit in place, so write to a temp file first
+  meta_path = video_path.with_suffix('.ffmeta')  # write metadata to a temporary file for ffmpeg input
+  hashes_str = ",".join(hashes)
+  meta_path.write_text(f";FFMETADATA1\nframehashes={hashes_str}\n")
   print(f"Embedding {len(hashes)} frame hashes into {video_path}...")
-  cmd = ['ffmpeg', '-v', 'warning', '-i', video_path, '-c', 'copy', '-movflags', '+use_metadata_tags', '-metadata', f'framehashes={hash_str}', '-y', tmp_path]
-  subprocess.run(cmd, check=True)
-  os.replace(tmp_path, video_path)
+  subprocess.run([
+    'ffmpeg', '-v', 'warning', '-i', video_path, '-f', 'ffmetadata', '-i', meta_path,
+    '-map_metadata', '1', '-c', 'copy', '-movflags', '+use_metadata_tags', '-y', tmp_video
+  ], check=True)
+  meta_path.unlink()  # clean up metadata file
+  os.replace(tmp_video, video_path)  # replace original with new video containing metadata
 
 
-def extract_framehashes(video_path) -> list[str]:
-  """Extract pre-computed frame hashes from custom MP4 metadata."""
-  cmd = ['ffprobe', '-v', 'quiet', '-show_entries', 'format_tags=framehashes', '-of', 'default=noprint_wrappers=1:nokey=1', video_path]
-  result = subprocess.run(cmd, capture_output=True, text=True)
+def extract_framehashes(video_path: Path) -> list[str]:
+  """Extract pre-computed frame hashes from MP4 metadata."""
+  result = subprocess.run(
+    ['ffprobe', '-v', 'quiet', '-show_entries', 'format_tags=framehashes', '-of', 'default=noprint_wrappers=1:nokey=1', video_path],
+    capture_output=True, text=True
+  )
   value = result.stdout.strip()
   if result.returncode != 0 or not value:
-    print(f"WARNING: No framehashes metadata found in {video_path}")
+    print(f"WARNING: No framehashes found in metadata of {video_path}")
     return []
   hashes = value.splitlines()
   print(f"Loaded {len(hashes)} frame hashes from {video_path}")

--- a/selfdrive/ui/tests/diff/diff.py
+++ b/selfdrive/ui/tests/diff/diff.py
@@ -24,10 +24,7 @@ def embed_framehashes(video_path: Path, hashes: list[str]) -> None:
   tmp_path = video_path.with_suffix('.tmp.mp4')
   hash_str = "\n".join(hashes)
   print(f"Embedding {len(hashes)} frame hashes into {video_path}...")
-  cmd = [
-    'ffmpeg', '-v', 'warning', '-i', str(video_path), '-c', 'copy', '-movflags', '+use_metadata_tags',
-    '-metadata', f'framehashes={hash_str}', '-y', str(tmp_path)
-  ]
+  cmd = ['ffmpeg', '-v', 'warning', '-i', video_path, '-c', 'copy', '-movflags', '+use_metadata_tags', '-metadata', f'framehashes={hash_str}', '-y', tmp_path]
   subprocess.run(cmd, check=True)
   os.replace(tmp_path, video_path)
 

--- a/selfdrive/ui/tests/diff/diff.py
+++ b/selfdrive/ui/tests/diff/diff.py
@@ -24,7 +24,11 @@ def embed_framehashes(video_path: Path, hashes: list[str]) -> None:
   tmp_path = video_path.with_suffix('.tmp.mp4')
   hash_str = "\n".join(hashes)
   print(f"Embedding {len(hashes)} frame hashes into {video_path}...")
-  cmd = ['ffmpeg', '-v', 'warning', '-i', video_path, '-c', 'copy', '-movflags', '+use_metadata_tags', '-metadata', f'framehashes={hash_str}', '-y', tmp_path]
+  cmd = [
+    'ffmpeg', '-v', 'warning', '-i', str(video_path), '-c', 'copy',
+    '-movflags', '+use_metadata_tags', '-metadata', f'framehashes={hash_str}',
+    '-y', str(tmp_path)
+  ]
   subprocess.run(cmd, check=True)
   os.replace(tmp_path, video_path)
 

--- a/selfdrive/ui/tests/diff/diff.py
+++ b/selfdrive/ui/tests/diff/diff.py
@@ -18,6 +18,20 @@ def create_diff_video(video1, video2, output_path):
   subprocess.run(cmd, capture_output=True, check=True)
 
 
+def embed_framehashes(video_path: Path, hashes: list[str]) -> None:
+  """Embed frame hashes into MP4 custom metadata via stream copy with temp file."""
+  # We can't read/write the file simultaneously, so write to a temp file and then replace the original
+  tmp_path = video_path.with_suffix('.tmp.mp4')
+  hash_str = "\n".join(hashes)
+  cmd = [
+    'ffmpeg', '-v', 'warning', '-i', str(video_path), '-c', 'copy',
+    '-movflags', '+use_metadata_tags', '-metadata', f'framehashes={hash_str}',
+    '-y', str(tmp_path)
+  ]
+  subprocess.run(cmd, check=True)
+  os.replace(tmp_path, video_path)
+
+
 def extract_framehashes(video_path) -> list[str]:
   """Extract pre-computed frame hashes from custom MP4 metadata."""
   cmd = ['ffprobe', '-v', 'quiet', '-show_entries', 'format_tags=framehashes', '-of', 'default=noprint_wrappers=1:nokey=1', video_path]

--- a/selfdrive/ui/tests/diff/diff.py
+++ b/selfdrive/ui/tests/diff/diff.py
@@ -32,12 +32,28 @@ def create_diff_video(video1, video2, output_path):
   subprocess.run(cmd, capture_output=True, check=True)
 
 
-def find_differences(video1, video2) -> tuple[list[int], tuple[int, int]]:
-  print(f"Hashing frames from {video1}...")
-  hashes1 = extract_framehashes(video1)
+def load_framehash_file(video_path) -> list[str] | None:
+  """Load pre-computed frame hashes from a .framehash file if it exists."""
+  hashfile = Path(video_path).with_suffix(".framehash")
+  if not hashfile.exists():
+    return None
+  hashes = [line.strip() for line in hashfile.read_text().splitlines() if line.strip()]
+  print(f"Loaded {len(hashes)} pre-computed frame hashes from {hashfile}")
+  return hashes
 
-  print(f"Hashing frames from {video2}...")
-  hashes2 = extract_framehashes(video2)
+
+def find_differences(video1, video2) -> tuple[list[int], tuple[int, int]]:
+  # Use pre-computed raw frame hashes when available (deterministic across machines),
+  # falling back to extracting hashes from the compressed video
+  hashes1 = load_framehash_file(video1)
+  if hashes1 is None:
+    print(f"Hashing frames from {video1}...")
+    hashes1 = extract_framehashes(video1)
+
+  hashes2 = load_framehash_file(video2)
+  if hashes2 is None:
+    print(f"Hashing frames from {video2}...")
+    hashes2 = extract_framehashes(video2)
 
   print(f"Comparing {len(hashes1)} frames...")
   different_frames = []

--- a/selfdrive/ui/tests/diff/diff.py
+++ b/selfdrive/ui/tests/diff/diff.py
@@ -25,9 +25,8 @@ def embed_framehashes(video_path: Path, hashes: list[str]) -> None:
   hash_str = "\n".join(hashes)
   print(f"Embedding {len(hashes)} frame hashes into {video_path}...")
   cmd = [
-    'ffmpeg', '-v', 'warning', '-i', str(video_path), '-c', 'copy',
-    '-movflags', '+use_metadata_tags', '-metadata', f'framehashes={hash_str}',
-    '-y', str(tmp_path)
+    'ffmpeg', '-v', 'warning', '-i', str(video_path), '-c', 'copy', '-movflags', '+use_metadata_tags',
+    '-metadata', f'framehashes={hash_str}', '-y', str(tmp_path)
   ]
   subprocess.run(cmd, check=True)
   os.replace(tmp_path, video_path)

--- a/selfdrive/ui/tests/diff/diff.py
+++ b/selfdrive/ui/tests/diff/diff.py
@@ -11,20 +11,6 @@ DIFF_OUT_DIR = Path(BASEDIR) / "selfdrive" / "ui" / "tests" / "diff" / "report"
 HTML_TEMPLATE_PATH = Path(__file__).with_name("diff_template.html")
 
 
-def extract_framehashes(video_path):
-  cmd = ['ffmpeg', '-i', video_path, '-map', '0:v:0', '-vsync', '0', '-f', 'framehash', '-hash', 'md5', '-']
-  result = subprocess.run(cmd, capture_output=True, text=True, check=True)
-  hashes = []
-  for line in result.stdout.splitlines():
-    if not line or line.startswith('#'):
-      continue
-    parts = line.split(',')
-    if len(parts) < 4:
-      continue
-    hashes.append(parts[-1].strip())
-  return hashes
-
-
 def create_diff_video(video1, video2, output_path):
   """Create a diff video using ffmpeg blend filter with difference mode."""
   print("Creating diff video...")
@@ -32,30 +18,22 @@ def create_diff_video(video1, video2, output_path):
   subprocess.run(cmd, capture_output=True, check=True)
 
 
-def extract_metadata_framehashes(video_path) -> list[str] | None:
-  """Extract pre-computed frame hashes from custom MP4 metadata, if present."""
+def extract_framehashes(video_path) -> list[str]:
+  """Extract pre-computed frame hashes from custom MP4 metadata."""
   cmd = ['ffprobe', '-v', 'quiet', '-show_entries', 'format_tags=framehashes', '-of', 'default=noprint_wrappers=1:nokey=1', video_path]
   result = subprocess.run(cmd, capture_output=True, text=True)
   value = result.stdout.strip()
   if result.returncode != 0 or not value:
-    return None
+    print(f"WARNING: No framehashes metadata found in {video_path}")
+    return []
   hashes = value.splitlines()
   print(f"Loaded {len(hashes)} pre-computed frame hashes from {video_path} metadata")
   return hashes
 
 
 def find_differences(video1, video2) -> tuple[list[int], tuple[int, int]]:
-  # Use pre-computed raw frame hashes from MP4 metadata when available (deterministic
-  # across machines), falling back to extracting hashes from the compressed video
-  hashes1 = extract_metadata_framehashes(video1)
-  if hashes1 is None:
-    print(f"Hashing frames from {video1}...")
-    hashes1 = extract_framehashes(video1)
-
-  hashes2 = extract_metadata_framehashes(video2)
-  if hashes2 is None:
-    print(f"Hashing frames from {video2}...")
-    hashes2 = extract_framehashes(video2)
+  hashes1 = extract_framehashes(video1)
+  hashes2 = extract_framehashes(video2)
 
   print(f"Comparing {len(hashes1)} frames...")
   different_frames = []

--- a/selfdrive/ui/tests/diff/diff.py
+++ b/selfdrive/ui/tests/diff/diff.py
@@ -25,10 +25,8 @@ def embed_framehashes(video_path: Path, hashes: list[str]) -> None:
   hashes_str = ",".join(hashes)
   meta_path.write_text(f";FFMETADATA1\nframehashes={hashes_str}\n")
   print(f"Embedding {len(hashes)} frame hashes into {video_path}...")
-  cmd = [
-    'ffmpeg', '-v', 'warning', '-i', video_path, '-f', 'ffmetadata', '-i', meta_path,
-    '-map_metadata', '1', '-c', 'copy', '-movflags', '+use_metadata_tags', '-y', tmp_video
-  ]
+  cmd = ['ffmpeg', '-v', 'warning', '-i', video_path, '-f', 'ffmetadata', '-i', meta_path,
+    '-map_metadata', '1', '-c', 'copy', '-movflags', '+use_metadata_tags', '-y', tmp_video]
   subprocess.run(cmd, check=True)
   meta_path.unlink()  # clean up metadata file
   os.replace(tmp_video, video_path)  # replace original with new video containing metadata

--- a/selfdrive/ui/tests/diff/diff.py
+++ b/selfdrive/ui/tests/diff/diff.py
@@ -32,25 +32,27 @@ def create_diff_video(video1, video2, output_path):
   subprocess.run(cmd, capture_output=True, check=True)
 
 
-def load_framehash_file(video_path) -> list[str] | None:
-  """Load pre-computed frame hashes from a .framehash file if it exists."""
-  hashfile = Path(video_path).with_suffix(".framehash")
-  if not hashfile.exists():
+def extract_metadata_framehashes(video_path) -> list[str] | None:
+  """Extract pre-computed frame hashes from custom MP4 metadata, if present."""
+  cmd = ['ffprobe', '-v', 'quiet', '-show_entries', 'format_tags=framehashes', '-of', 'default=noprint_wrappers=1:nokey=1', video_path]
+  result = subprocess.run(cmd, capture_output=True, text=True)
+  value = result.stdout.strip()
+  if result.returncode != 0 or not value:
     return None
-  hashes = [line.strip() for line in hashfile.read_text().splitlines() if line.strip()]
-  print(f"Loaded {len(hashes)} pre-computed frame hashes from {hashfile}")
+  hashes = value.split(",")
+  print(f"Loaded {len(hashes)} pre-computed frame hashes from {video_path} metadata")
   return hashes
 
 
 def find_differences(video1, video2) -> tuple[list[int], tuple[int, int]]:
-  # Use pre-computed raw frame hashes when available (deterministic across machines),
-  # falling back to extracting hashes from the compressed video
-  hashes1 = load_framehash_file(video1)
+  # Use pre-computed raw frame hashes from MP4 metadata when available (deterministic
+  # across machines), falling back to extracting hashes from the compressed video
+  hashes1 = extract_metadata_framehashes(video1)
   if hashes1 is None:
     print(f"Hashing frames from {video1}...")
     hashes1 = extract_framehashes(video1)
 
-  hashes2 = load_framehash_file(video2)
+  hashes2 = extract_metadata_framehashes(video2)
   if hashes2 is None:
     print(f"Hashing frames from {video2}...")
     hashes2 = extract_framehashes(video2)

--- a/selfdrive/ui/tests/diff/diff.py
+++ b/selfdrive/ui/tests/diff/diff.py
@@ -25,19 +25,19 @@ def embed_framehashes(video_path: Path, hashes: list[str]) -> None:
   hashes_str = ",".join(hashes)
   meta_path.write_text(f";FFMETADATA1\nframehashes={hashes_str}\n")
   print(f"Embedding {len(hashes)} frame hashes into {video_path}...")
-  subprocess.run([
+  cmd = [
     'ffmpeg', '-v', 'warning', '-i', video_path, '-f', 'ffmetadata', '-i', meta_path,
     '-map_metadata', '1', '-c', 'copy', '-movflags', '+use_metadata_tags', '-y', tmp_video
-    ], check=True)
+  ]
+  subprocess.run(cmd, check=True)
   meta_path.unlink()  # clean up metadata file
   os.replace(tmp_video, video_path)  # replace original with new video containing metadata
 
 
 def extract_framehashes(video_path: Path) -> list[str]:
   """Extract pre-computed frame hashes from MP4 metadata."""
-  result = subprocess.run([
-    'ffprobe', '-v', 'quiet', '-show_entries', 'format_tags=framehashes', '-of', 'default=noprint_wrappers=1:nokey=1', video_path
-    ], capture_output=True, text=True)
+  cmd = ['ffprobe', '-v', 'quiet', '-show_entries', 'format_tags=framehashes', '-of', 'default=noprint_wrappers=1:nokey=1', video_path]
+  result = subprocess.run(cmd, capture_output=True, text=True)
   value = result.stdout.strip()
   if result.returncode != 0 or not value:
     print(f"WARNING: No framehashes found in metadata of {video_path}")

--- a/selfdrive/ui/tests/diff/diff.py
+++ b/selfdrive/ui/tests/diff/diff.py
@@ -24,11 +24,7 @@ def embed_framehashes(video_path: Path, hashes: list[str]) -> None:
   tmp_path = video_path.with_suffix('.tmp.mp4')
   hash_str = "\n".join(hashes)
   print(f"Embedding {len(hashes)} frame hashes into {video_path}...")
-  cmd = [
-    'ffmpeg', '-v', 'warning', '-i', video_path, '-c', 'copy',
-    '-movflags', '+use_metadata_tags', '-metadata', f'framehashes={hash_str}',
-    '-y', tmp_path
-  ]
+  cmd = ['ffmpeg', '-v', 'warning', '-i', video_path, '-c', 'copy', '-movflags', '+use_metadata_tags', '-metadata', f'framehashes={hash_str}', '-y', tmp_path]
   subprocess.run(cmd, check=True)
   os.replace(tmp_path, video_path)
 

--- a/selfdrive/ui/tests/diff/diff.py
+++ b/selfdrive/ui/tests/diff/diff.py
@@ -39,7 +39,7 @@ def extract_metadata_framehashes(video_path) -> list[str] | None:
   value = result.stdout.strip()
   if result.returncode != 0 or not value:
     return None
-  hashes = value.split(",")
+  hashes = value.splitlines()
   print(f"Loaded {len(hashes)} pre-computed frame hashes from {video_path} metadata")
   return hashes
 

--- a/selfdrive/ui/tests/diff/diff.py
+++ b/selfdrive/ui/tests/diff/diff.py
@@ -23,10 +23,11 @@ def embed_framehashes(video_path: Path, hashes: list[str]) -> None:
   # We can't read/write the file simultaneously, so write to a temp file and then replace the original
   tmp_path = video_path.with_suffix('.tmp.mp4')
   hash_str = "\n".join(hashes)
+  print(f"Embedding {len(hashes)} frame hashes into {video_path}...")
   cmd = [
-    'ffmpeg', '-v', 'warning', '-i', str(video_path), '-c', 'copy',
+    'ffmpeg', '-v', 'warning', '-i', video_path, '-c', 'copy',
     '-movflags', '+use_metadata_tags', '-metadata', f'framehashes={hash_str}',
-    '-y', str(tmp_path)
+    '-y', tmp_path
   ]
   subprocess.run(cmd, check=True)
   os.replace(tmp_path, video_path)

--- a/selfdrive/ui/tests/diff/diff.py
+++ b/selfdrive/ui/tests/diff/diff.py
@@ -28,17 +28,16 @@ def embed_framehashes(video_path: Path, hashes: list[str]) -> None:
   subprocess.run([
     'ffmpeg', '-v', 'warning', '-i', video_path, '-f', 'ffmetadata', '-i', meta_path,
     '-map_metadata', '1', '-c', 'copy', '-movflags', '+use_metadata_tags', '-y', tmp_video
-  ], check=True)
+    ], check=True)
   meta_path.unlink()  # clean up metadata file
   os.replace(tmp_video, video_path)  # replace original with new video containing metadata
 
 
 def extract_framehashes(video_path: Path) -> list[str]:
   """Extract pre-computed frame hashes from MP4 metadata."""
-  result = subprocess.run(
-    ['ffprobe', '-v', 'quiet', '-show_entries', 'format_tags=framehashes', '-of', 'default=noprint_wrappers=1:nokey=1', video_path],
-    capture_output=True, text=True
-  )
+  result = subprocess.run([
+    'ffprobe', '-v', 'quiet', '-show_entries', 'format_tags=framehashes', '-of', 'default=noprint_wrappers=1:nokey=1', video_path
+    ], capture_output=True, text=True)
   value = result.stdout.strip()
   if result.returncode != 0 or not value:
     print(f"WARNING: No framehashes found in metadata of {video_path}")

--- a/selfdrive/ui/tests/diff/replay.py
+++ b/selfdrive/ui/tests/diff/replay.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python3
+import hashlib
 import os
 import argparse
 import coverage
 import pyray as rl
 
+from pathlib import Path
 from tqdm import tqdm
 from typing import Literal
 from collections.abc import Callable
@@ -51,6 +53,13 @@ def run_replay(variant: LayoutVariant) -> None:
   from openpilot.selfdrive.ui.ui_state import ui_state, device  # Import within OpenpilotPrefix context so param values are setup correctly
   from openpilot.system.ui.lib.application import gui_app  # Import here for accurate coverage
   from openpilot.selfdrive.ui.tests.diff.replay_script import build_script
+
+  # Write per-frame MD5 hashes of raw pixel data for deterministic diff comparison.
+  # This allows the video itself to use lossy encoding (smaller files) while still
+  # detecting exact frame differences across machines with different codec behavior.
+  framehash_path = Path(os.environ['RECORD_OUTPUT']).with_suffix(".framehash")
+  framehash_file = open(framehash_path, 'w')
+  gui_app.set_frame_data_callback(lambda data: framehash_file.write(hashlib.md5(data).hexdigest() + '\n'))
 
   gui_app.init_window("ui diff test", fps=FPS)
 
@@ -107,9 +116,11 @@ def run_replay(variant: LayoutVariant) -> None:
         break
 
   gui_app.close()
+  framehash_file.close()
 
   print(f"Total frames: {frame}")
   print(f"Video saved to: {os.environ['RECORD_OUTPUT']}")
+  print(f"Frame hashes saved to: {framehash_path}")
 
 
 def main():
@@ -122,7 +133,6 @@ def main():
   if args.big:
     os.environ["BIG"] = "1"
   os.environ["RECORD"] = "1"
-  os.environ["RECORD_QUALITY"] = "0"  # Use CRF 0 ("lossless" encode) for deterministic output across different machines
   os.environ["RECORD_OUTPUT"] = os.path.join(DIFF_OUT_DIR, os.environ.get("RECORD_OUTPUT", f"{variant}_ui_replay.mp4"))
 
   print(f"Running {variant} UI replay...")

--- a/selfdrive/ui/tests/diff/replay.py
+++ b/selfdrive/ui/tests/diff/replay.py
@@ -120,6 +120,7 @@ def run_replay(variant: LayoutVariant) -> None:
   video_path = os.environ['RECORD_OUTPUT']
   tmp_path = video_path + ".tmp.mp4"
   hash_str = "\n".join(frame_hashes)
+  print(f"Embedding {len(frame_hashes)} raw frame hashes into video metadata...")
   # We can't read/write the file simultaneously, so write to a temp file (without reencoding) and then replace the original
   subprocess.run([
     'ffmpeg', '-v', 'warning', '-i', video_path, '-c', 'copy', '-movflags',

--- a/selfdrive/ui/tests/diff/replay.py
+++ b/selfdrive/ui/tests/diff/replay.py
@@ -120,7 +120,7 @@ def run_replay(variant: LayoutVariant) -> None:
   video_path = os.environ['RECORD_OUTPUT']
   tmp_path = video_path + ".tmp.mp4"
   hash_str = "\n".join(frame_hashes)
-  # We can't edit the file in place, so we write to a temp file (without reencoding) and then replace the original
+  # We can't read/write the file simultaneously, so write to a temp file (without reencoding) and then replace the original
   subprocess.run([
     'ffmpeg', '-v', 'warning', '-i', video_path, '-c', 'copy', '-movflags',
     '+use_metadata_tags', '-metadata', f'framehashes={hash_str}', '-y', tmp_path

--- a/selfdrive/ui/tests/diff/replay.py
+++ b/selfdrive/ui/tests/diff/replay.py
@@ -128,7 +128,7 @@ def run_replay(variant: LayoutVariant) -> None:
   ], check=True)
   os.replace(tmp_path, video_path)
 
-  print(f"Total frames: {frame}")
+  print(f"Total frames: {frame - 1}")
   print(f"Video saved to: {video_path}")
 
 

--- a/selfdrive/ui/tests/diff/replay.py
+++ b/selfdrive/ui/tests/diff/replay.py
@@ -116,11 +116,10 @@ def run_replay(variant: LayoutVariant) -> None:
 
   gui_app.close()
 
-  # Embed raw frame hashes into the MP4 as custom metadata so the diff tool can compare
-  # pre-encode pixel data without needing a separate sidecar file
+  # Embed raw frame hashes into the MP4 as custom metadata so the diff tool can compare them later
   video_path = os.environ['RECORD_OUTPUT']
   tmp_path = video_path + ".tmp.mp4"
-  hash_str = ",".join(frame_hashes)
+  hash_str = "\n".join(frame_hashes)
   subprocess.run([
     'ffmpeg', '-v', 'warning', '-i', video_path, '-c', 'copy', '-movflags',
     '+use_metadata_tags', '-metadata', f'framehashes={hash_str}', '-y', tmp_path

--- a/selfdrive/ui/tests/diff/replay.py
+++ b/selfdrive/ui/tests/diff/replay.py
@@ -120,6 +120,7 @@ def run_replay(variant: LayoutVariant) -> None:
   video_path = os.environ['RECORD_OUTPUT']
   tmp_path = video_path + ".tmp.mp4"
   hash_str = "\n".join(frame_hashes)
+  # We can't edit the file in place, so we write to a temp file (without reencoding) and then replace the original
   subprocess.run([
     'ffmpeg', '-v', 'warning', '-i', video_path, '-c', 'copy', '-movflags',
     '+use_metadata_tags', '-metadata', f'framehashes={hash_str}', '-y', tmp_path

--- a/selfdrive/ui/tests/diff/replay.py
+++ b/selfdrive/ui/tests/diff/replay.py
@@ -2,10 +2,10 @@
 import hashlib
 import os
 import argparse
+import subprocess
 import coverage
 import pyray as rl
 
-from pathlib import Path
 from tqdm import tqdm
 from typing import Literal
 from collections.abc import Callable
@@ -54,12 +54,11 @@ def run_replay(variant: LayoutVariant) -> None:
   from openpilot.system.ui.lib.application import gui_app  # Import here for accurate coverage
   from openpilot.selfdrive.ui.tests.diff.replay_script import build_script
 
-  # Write per-frame MD5 hashes of raw pixel data for deterministic diff comparison.
-  # This allows the video itself to use lossy encoding (smaller files) while still
-  # detecting exact frame differences across machines with different codec behavior.
-  framehash_path = Path(os.environ['RECORD_OUTPUT']).with_suffix(".framehash")
-  framehash_file = open(framehash_path, 'w')
-  gui_app.set_frame_data_callback(lambda data: framehash_file.write(hashlib.md5(data).hexdigest() + '\n'))
+  # Collect per-frame MD5 hashes of raw pixel data for deterministic diff comparison.
+  # These are embedded in the MP4 metadata after recording, so the video itself can use lossy encoding (smaller files)
+  # while still detecting exact frame differences across machines with different codec behavior.
+  frame_hashes: list[str] = []
+  gui_app.set_frame_data_callback(lambda data: frame_hashes.append(hashlib.md5(data).hexdigest()))
 
   gui_app.init_window("ui diff test", fps=FPS)
 
@@ -116,11 +115,20 @@ def run_replay(variant: LayoutVariant) -> None:
         break
 
   gui_app.close()
-  framehash_file.close()
+
+  # Embed raw frame hashes into the MP4 as custom metadata so the diff tool can compare
+  # pre-encode pixel data without needing a separate sidecar file
+  video_path = os.environ['RECORD_OUTPUT']
+  tmp_path = video_path + ".tmp.mp4"
+  hash_str = ",".join(frame_hashes)
+  subprocess.run([
+    'ffmpeg', '-v', 'warning', '-i', video_path, '-c', 'copy', '-movflags',
+    '+use_metadata_tags', '-metadata', f'framehashes={hash_str}', '-y', tmp_path
+  ], check=True)
+  os.replace(tmp_path, video_path)
 
   print(f"Total frames: {frame}")
-  print(f"Video saved to: {os.environ['RECORD_OUTPUT']}")
-  print(f"Frame hashes saved to: {framehash_path}")
+  print(f"Video saved to: {video_path}")
 
 
 def main():

--- a/selfdrive/ui/tests/diff/replay.py
+++ b/selfdrive/ui/tests/diff/replay.py
@@ -2,10 +2,10 @@
 import hashlib
 import os
 import argparse
-import subprocess
 import coverage
 import pyray as rl
 
+from pathlib import Path
 from tqdm import tqdm
 from typing import Literal
 from collections.abc import Callable
@@ -14,7 +14,7 @@ from openpilot.common.api import Api
 from openpilot.common.basedir import BASEDIR
 from openpilot.common.params import Params
 from openpilot.common.prefix import OpenpilotPrefix
-from openpilot.selfdrive.ui.tests.diff.diff import DIFF_OUT_DIR
+from openpilot.selfdrive.ui.tests.diff.diff import DIFF_OUT_DIR, embed_framehashes
 from openpilot.system.updated.updated import parse_release_notes
 from openpilot.system.version import terms_version, training_version
 
@@ -116,17 +116,9 @@ def run_replay(variant: LayoutVariant) -> None:
 
   gui_app.close()
 
+  video_path = Path(os.environ['RECORD_OUTPUT'])
   # Embed raw frame hashes into the MP4 as custom metadata so the diff tool can compare them later
-  video_path = os.environ['RECORD_OUTPUT']
-  tmp_path = video_path + ".tmp.mp4"
-  hash_str = "\n".join(frame_hashes)
-  print(f"Embedding {len(frame_hashes)} raw frame hashes into video metadata...")
-  # We can't read/write the file simultaneously, so write to a temp file (without reencoding) and then replace the original
-  subprocess.run([
-    'ffmpeg', '-v', 'warning', '-i', video_path, '-c', 'copy', '-movflags',
-    '+use_metadata_tags', '-metadata', f'framehashes={hash_str}', '-y', tmp_path
-  ], check=True)
-  os.replace(tmp_path, video_path)
+  embed_framehashes(video_path, frame_hashes)
 
   print(f"Total frames: {frame - 1}")
   print(f"Video saved to: {video_path}")

--- a/system/ui/lib/application.py
+++ b/system/ui/lib/application.py
@@ -215,6 +215,7 @@ class GuiApplication:
     self._ffmpeg_thread: threading.Thread | None = None
     self._ffmpeg_stop_event: threading.Event | None = None
     self._textures: dict[str, rl.Texture] = {}
+    self._frame_data_callback: Callable[[bytes], None] | None = None
     self._target_fps: int = _DEFAULT_FPS
     self._last_fps_log_time: float = time.monotonic()
     self._frame = 0
@@ -241,6 +242,9 @@ class GuiApplication:
   @property
   def frame(self):
     return self._frame
+
+  def set_frame_data_callback(self, callback: Callable[[bytes], None]):
+    self._frame_data_callback = callback
 
   def set_show_touches(self, show: bool):
     self._show_touches = show
@@ -628,6 +632,8 @@ class GuiApplication:
           image = rl.load_image_from_texture(self._render_texture.texture)
           data_size = image.width * image.height * 4
           data = bytes(rl.ffi.buffer(image.data, data_size))
+          if self._frame_data_callback:
+            self._frame_data_callback(data)
           self._ffmpeg_queue.put(data)  # Async write via background thread
           rl.unload_image(image)
 


### PR DESCRIPTION
### Summary:
Instead of hashing the frames on demand for comparison (requires lossless recording), this hashes the frames during recording in replays and stores them in the mp4's metadata, so later the diff tool can compare the raw frames instead of the compressed ones, while still recording with compression.

**Note:** Requires https://github.com/commaai/dependencies/pull/49

### Problem this solves:
As the UI replay script gets longer, the video sizes drastically increase due to lossless recording required for accurate frame comparison. The tizi replay went from ~**9MB** to ~**29MB** in #37468, and the mici replay goes to ~**43MB** in #37641. This is very inefficient since the HTML report loads both of them plus the diff, and can cause the clips to not play properly on slower connections. Also, I think if they get too large the workflow that uploads them will fail since Github has a max file size limit.

With this PR, the new sizes will be ~**11MB** for tizi and ~**10MB** for mici (after the longer script is merged). If necessary, we could also increase the compression ratio with `RECORD_QUALITY`, which I left in the code for such a purpose.

This also improves performance during diffing as it no longer has to wait to get the frame hashes.

### Alternatives I considered:
1. Re-encoding the videos with compression and using those for the diff report, while keeping the lossless versions for comparison. However, if the files get too large, we won't be able to push them to Github during the workflow so this doesn't seem like a good long-term solution.

2. Storing the framehashes in a separate file instead of in the video's metadata. Less code overall, but adding additional files makes it more difficult for testing as well as more complex for the workflow. It doesn't seem ideal to require another file along with each video.

### Caveats:
The diff videos may show artifacts.