### PR TITLE
ui: fix 1px flash at bottom of DM camera during onboarding swipe

### DIFF
--- a/selfdrive/ui/mici/layouts/onboarding.py
+++ b/selfdrive/ui/mici/layouts/onboarding.py
@@ -151,8 +151,10 @@ class TrainingGuideDMTutorial(NavWidget):
   def _render(self, _):
     self._dialog.render(self._rect)
 
-    rl.draw_rectangle_gradient_v(int(self._rect.x), int(self._rect.y + self._rect.height - 80),
-                                 int(self._rect.width), 80, rl.BLANK, rl.BLACK)
+    gradient_y = int(self._rect.y + self._rect.height - 80)
+    gradient_h = int(self._rect.y) + int(self._rect.height) - gradient_y
+    rl.draw_rectangle_gradient_v(int(self._rect.x), gradient_y,
+                                 int(self._rect.width), gradient_h, rl.BLANK, rl.BLACK)
 
     # draw white ring around dm icon to indicate progress
     ring_thickness = 8


### PR DESCRIPTION
## Summary
- Fixes 1px camera line flash at the bottom of the screen when swiping up the DM camera view during onboarding
- The gradient overlay's height was a fixed `80`, but `int(y + height - 80) + 80` doesn't always equal `int(y) + int(height)` when `y` is fractional during animation — leaving 1px of uncovered camera image
- Now computes gradient height to match the camera scissor bounds exactly

Regressed in #37649

🤖 Generated with [Claude Code](https://claude.com/claude-code)