### PR TITLE
modeld: quiet do_chunk output during scons build

### DIFF
--- a/selfdrive/modeld/SConscript
+++ b/selfdrive/modeld/SConscript
@@ -1,6 +1,5 @@
 import os
 import glob
-from SCons.Action import Action as SAction
 from openpilot.common.file_chunker import chunk_file, get_chunk_paths
 
 Import('env', 'arch')
@@ -46,13 +45,17 @@ def tg_compile(flags, model_name):
   pkl = fn + "_tinygrad.pkl"
   onnx_path = fn + ".onnx"
   chunk_targets = get_chunk_paths(pkl, estimate_pickle_max_size(os.path.getsize(onnx_path)))
+  compile_node = lenv.Command(
+    pkl,
+    [onnx_path] + tinygrad_files + [chunker_file],
+    f'{pythonpath_string} {flags} {image_flag} python3 {Dir("#tinygrad_repo").abspath}/examples/openpilot/compile3.py {fn}.onnx {pkl}',
+  )
   def do_chunk(target, source, env):
     chunk_file(pkl, chunk_targets)
   return lenv.Command(
     chunk_targets,
-    [onnx_path] + tinygrad_files + [chunker_file],
-    [f'{pythonpath_string} {flags} {image_flag} python3 {Dir("#tinygrad_repo").abspath}/examples/openpilot/compile3.py {fn}.onnx {pkl}',
-     SAction(do_chunk, lambda *a, **kw: f'  [CHUNK] {pkl}')]
+    compile_node,
+    do_chunk,
   )
 
 # Compile small models

--- a/selfdrive/modeld/SConscript
+++ b/selfdrive/modeld/SConscript
@@ -1,5 +1,6 @@
 import os
 import glob
+from SCons.Action import Action as SAction
 from openpilot.common.file_chunker import chunk_file, get_chunk_paths
 
 Import('env', 'arch')
@@ -51,7 +52,7 @@ def tg_compile(flags, model_name):
     chunk_targets,
     [onnx_path] + tinygrad_files + [chunker_file],
     [f'{pythonpath_string} {flags} {image_flag} python3 {Dir("#tinygrad_repo").abspath}/examples/openpilot/compile3.py {fn}.onnx {pkl}',
-     do_chunk]
+     SAction(do_chunk, lambda *a, **kw: f'  [CHUNK] {pkl}')]
   )
 
 # Compile small models


### PR DESCRIPTION
## Summary
- Split tinygrad model compile and chunk into separate `Command`s so `do_chunk` only depends on the pkl output, not 1259 tinygrad source files
- Fixes wall of text during scons builds where SCons prints `do_chunk(targets, sources)` with every tinygrad file listed

Introduced in #37292.

## Test plan
- [ ] `scons -n` still parses
- [ ] Clean build on device no longer spews dep list for chunk step

🤖 Generated with [Claude Code](https://claude.com/claude-code)