### PR TITLE
render all nav stack widgets

### DIFF
--- a/system/ui/lib/application.py
+++ b/system/ui/lib/application.py
@@ -225,6 +225,7 @@ class GuiApplication:
     self._window_close_requested = False
     self._nav_stack: list[object] = []
     self._nav_stack_ticks: list[Callable[[], None]] = []
+    self._nav_stack_widgets_to_render = 1 if self.big_ui() else 2
 
     self._mouse = MouseState(self._scale)
     self._mouse_events: list[MouseEvent] = []
@@ -383,9 +384,7 @@ class GuiApplication:
     if len(self._nav_stack) > 0:
       prev_widget = self._nav_stack[-1]
       # TODO: change these to touch_valid
-      prev_widget.hide_event()
       prev_widget.set_enabled(False)
-      prev_widget.set_visible(False)
 
     self._nav_stack.append(widget)
     widget.show_event()
@@ -405,9 +404,7 @@ class GuiApplication:
     # only re-enable previous widget if popping top widget
     if idx_to_pop == len(self._nav_stack) - 1:
       prev_widget = self._nav_stack[idx_to_pop - 1]
-      prev_widget.show_event()
       prev_widget.set_enabled(True)
-      prev_widget.set_visible(True)
 
     widget = self._nav_stack.pop(idx_to_pop)
     widget.hide_event()
@@ -615,10 +612,11 @@ class GuiApplication:
         for tick in self._nav_stack_ticks:
           tick()
 
-        # Render all widgets
-        for widget in self._nav_stack:
+        # Render all widgets but update the state of only the top ones
+        bottom_widgets = len(self._nav_stack) - self._nav_stack_widgets_to_render
+        for i, widget in enumerate(self._nav_stack):
+          widget._allow_update_state = i >= bottom_widgets
           widget.render(rl.Rectangle(0, 0, self.width, self.height))
-
         yield True
 
         if self._scale != 1.0:

--- a/system/ui/lib/application.py
+++ b/system/ui/lib/application.py
@@ -225,7 +225,6 @@ class GuiApplication:
     self._window_close_requested = False
     self._nav_stack: list[object] = []
     self._nav_stack_ticks: list[Callable[[], None]] = []
-    self._nav_stack_widgets_to_render = 1 if self.big_ui() else 2
 
     self._mouse = MouseState(self._scale)
     self._mouse_events: list[MouseEvent] = []
@@ -384,7 +383,9 @@ class GuiApplication:
     if len(self._nav_stack) > 0:
       prev_widget = self._nav_stack[-1]
       # TODO: change these to touch_valid
+      prev_widget.hide_event()
       prev_widget.set_enabled(False)
+      prev_widget.set_visible(False)
 
     self._nav_stack.append(widget)
     widget.show_event()
@@ -404,7 +405,9 @@ class GuiApplication:
     # only re-enable previous widget if popping top widget
     if idx_to_pop == len(self._nav_stack) - 1:
       prev_widget = self._nav_stack[idx_to_pop - 1]
+      prev_widget.show_event()
       prev_widget.set_enabled(True)
+      prev_widget.set_visible(True)
 
     widget = self._nav_stack.pop(idx_to_pop)
     widget.hide_event()
@@ -612,8 +615,8 @@ class GuiApplication:
         for tick in self._nav_stack_ticks:
           tick()
 
-        # Only render top widgets
-        for widget in self._nav_stack[-self._nav_stack_widgets_to_render:]:
+        # Render all widgets
+        for widget in self._nav_stack:
           widget.render(rl.Rectangle(0, 0, self.width, self.height))
 
         yield True

--- a/system/ui/widgets/__init__.py
+++ b/system/ui/widgets/__init__.py
@@ -43,6 +43,7 @@ class Widget(abc.ABC):
     self._click_callback: Callable[[], None] | None = None
     self._multi_touch = False
     self.__was_awake = True
+    self._allow_update_state = True
 
   @property
   def rect(self) -> rl.Rectangle:
@@ -107,7 +108,8 @@ class Widget(abc.ABC):
     if rect is not None:
       self.set_rect(rect)
 
-    self._update_state()
+    if (self._allow_update_state):
+      self._update_state()
 
     if self._click_release_time is not None and rl.get_time() >= self._click_release_time:
       self._click_release_time = None


### PR DESCRIPTION
From #37621, I assume we want to render all elements and then hide and freeze previous ones. However, the only thing that confuses me is that the animation itself is different compared to other versions.

Closes: #37621

<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Fingerprint *****

**Car**
Which car (make, model, year) this fingerprint is for

**Route**
A route with the fingerprint

-->

<!--- ***** Template: Car Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 

**Route**

Route: [a route with the bug fix]


-->

<!--- ***** Template: Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 


-->

<!--- ***** Template: Car Port *****

**Checklist**

- [ ] added entry to CAR in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:
- [ ] car harness used (if comma doesn't sell it, put N/A):


-->

<!--- ***** Template: Refactor *****

**Description**

A description of the refactor, including the goals it accomplishes. 

**Verification**

Explain how you tested the refactor for regressions. 


-->

