### PR TITLE
bump msgq: drop scons build

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -191,14 +191,21 @@ common = [_common, 'json11', 'zmq']
 Export('common')
 
 # Build messaging (cereal + msgq + socketmaster + their dependencies)
-# Enable swaglog include in submodules
-env_swaglog = env.Clone()
-env_swaglog['CXXFLAGS'].append('-DSWAGLOG="\\"common/swaglog.h\\""')
-SConscript(['msgq_repo/SConscript'], exports={'env': env_swaglog})
+# Build msgq via its own build system (produces .a libs and Cython .so bindings)
+msgq_repo = Dir('#msgq_repo')
+libmsgq = File('#msgq_repo/libmsgq.a')
+libvisionipc = File('#msgq_repo/libvisionipc.a')
+msgq_python = File('#msgq_repo/msgq/ipc_pyx.so')
+env.Command([libmsgq, libvisionipc, msgq_python], [], f'cd {msgq_repo.abspath} && python build.py')
+env.AlwaysBuild(libmsgq)
+
+msgq = libmsgq
+visionipc = libvisionipc
+Export('msgq', 'visionipc', 'msgq_python')
 
 SConscript(['cereal/SConscript'])
 
-Import('socketmaster', 'msgq')
+Import('socketmaster')
 messaging = [socketmaster, msgq, 'capnp', 'kj',]
 Export('messaging')
 

--- a/SConstruct
+++ b/SConstruct
@@ -196,7 +196,8 @@ msgq_repo = Dir('#msgq_repo')
 libmsgq = File('#msgq_repo/libmsgq.a')
 libvisionipc = File('#msgq_repo/libvisionipc.a')
 msgq_python = File('#msgq_repo/msgq/ipc_pyx.so')
-env.Command([libmsgq, libvisionipc, msgq_python], [], f'cd {msgq_repo.abspath} && python build.py')
+env.Command([libmsgq, libvisionipc, msgq_python], [],
+            f'cd {msgq_repo.abspath} && EXTRA_CXXFLAGS=\'-DSWAGLOG="common/swaglog.h"\' python build.py')
 env.AlwaysBuild(libmsgq)
 
 msgq = libmsgq


### PR DESCRIPTION
## Summary
- Removes `SConscript(['msgq_repo/SConscript'])` and the now-unused `env_swaglog` clone
- Replaces with `env.Command()` that invokes msgq's new `build.py` to produce `libmsgq.a`, `libvisionipc.a`, and `ipc_pyx.so`
- Exports `msgq`, `visionipc`, and `msgq_python` as `File()` references for downstream SConscripts

## Dependencies
- Depends on https://github.com/commaai/msgq/pull/680 (msgq scons removal) being merged first
- Submodule bump to be added once that lands

## Test plan
- [ ] Merge msgq PR commaai/msgq#680
- [ ] Bump msgq submodule to new master
- [ ] Verify `scons -j$(nproc)` builds successfully
- [ ] Run full CI