### PR TITLE
record: smaller clip sizes by adjusting preset

### DIFF
--- a/system/ui/lib/application.py
+++ b/system/ui/lib/application.py
@@ -299,7 +299,7 @@ class GuiApplication:
           '-vf', 'vflip,format=yuv420p',  # Flip vertically and convert to yuv420p
           '-r', str(output_fps),    # Output frame rate (for speed multiplier)
           '-c:v', 'libx264',
-          '-preset', 'ultrafast',
+          '-preset', 'veryfast',
           '-crf', str(RECORD_QUALITY)
         ]
         if RECORD_BITRATE:


### PR DESCRIPTION
Switches the ffmpeg preset from `ultrafast` to `veryfast`. This is a substantial decrease in recording file size while barely increasing the replay/recording time. We likely could go to `faster` even for further reduction.

## Benchmarks for those interested:

**TL;DR:** `op clip --demo` goes from **1888KB** to **605KB** with this PR. The mici UI replay video goes from ~**43.6MB** to ~**33.3MB**, and the tizi one goes from ~**29.5MB** to ~**10.9MB**.

I carefully benchmarked various presets and from what I can tell, `veryfast` provides the best value for both clips and the UI replay. It barely reduces the speed while providing a huge win in file size. This also results in much better quality clips (for big UI at least) since the bitrate can be much higher and still fit in the 9MB file size. The quality remains completely unchanged otherwise.

Here's a list of the available presets, ranging from fastest/largest size to slowest/smallest size:
1. ultrafast (before)
2. superfast
3. veryfast (after)
4. faster
5. fast
6. medium (default)
7. slow
8. slower
9. veryslow


### Here's the UI replay file sizes with various presets:
<img width="757" height="187" alt="image" src="https://github.com/user-attachments/assets/33d1ee01-3308-4852-b27b-ce605e6fb80b" />
<img width="768" height="203" alt="image" src="https://github.com/user-attachments/assets/f43263a5-12e7-4904-9fd8-9cc8a23a1e4c" />

### Here's the files I generated using `op clip --demo` and `op clip --demo --big`:

**Note**: I realized too late there's a 9MB cap of the size by default so you can't really see the original big clip size.

<img width="763" height="382" alt="image" src="https://github.com/user-attachments/assets/8414bf2a-0431-4de3-b58f-5874a6ac6980" />