### PR TITLE
system: pin audio daemons to the simple sound card

### DIFF
--- a/selfdrive/ui/soundd.py
+++ b/selfdrive/ui/soundd.py
@@ -11,6 +11,7 @@ from openpilot.common.realtime import Ratekeeper
 from openpilot.common.utils import retry
 from openpilot.common.swaglog import cloudlog
 
+from openpilot.system.audio import get_sounddevice_device
 from openpilot.system import micd
 from openpilot.system.hardware import HARDWARE
 
@@ -140,7 +141,16 @@ class Soundd:
     # reload sounddevice to reinitialize portaudio
     sd._terminate()
     sd._initialize()
-    return sd.OutputStream(channels=1, samplerate=SAMPLE_RATE, callback=self.callback, blocksize=SAMPLE_BUFFER)
+    stream_kwargs = {
+      "channels": 1,
+      "samplerate": SAMPLE_RATE,
+      "callback": self.callback,
+      "blocksize": SAMPLE_BUFFER,
+    }
+    device = get_sounddevice_device(sd, is_input=False)
+    if device is not None:
+      stream_kwargs["device"] = device
+    return sd.OutputStream(**stream_kwargs)
 
   def soundd_thread(self):
     # sounddevice must be imported after forking processes

--- a/system/audio.py
+++ b/system/audio.py
@@ -1,0 +1,35 @@
+import os
+
+from openpilot.common.swaglog import cloudlog
+
+
+def _get_audio_device_patterns(direction: str) -> list[str]:
+  env_var = f"OPENPILOT_AUDIO_{direction.upper()}_DEVICE"
+  override = os.getenv(env_var, "").strip()
+  if override:
+    return [pattern.strip() for pattern in override.split(",") if pattern.strip()]
+
+  return [
+    "sdm845-comma-simple-snd-card",
+    "comma-simple",
+    "sdm845-tavil-snd-card",
+  ]
+
+
+def get_sounddevice_device(sd, *, is_input: bool) -> int | None:
+  direction = "input" if is_input else "output"
+  channel_key = "max_input_channels" if is_input else "max_output_channels"
+  patterns = _get_audio_device_patterns(direction)
+
+  devices = sd.query_devices()
+  for pattern in patterns:
+    pattern_lower = pattern.lower()
+    for idx, dev in enumerate(devices):
+      if dev[channel_key] <= 0:
+        continue
+      if pattern_lower in dev["name"].lower():
+        cloudlog.info(f"using {direction} audio device {idx}: {dev['name']}")
+        return idx
+
+  cloudlog.warning(f"no preferred {direction} audio device found, falling back to PortAudio default")
+  return None

--- a/system/micd.py
+++ b/system/micd.py
@@ -8,6 +8,8 @@ from openpilot.common.realtime import Ratekeeper
 from openpilot.common.utils import retry
 from openpilot.common.swaglog import cloudlog
 
+from openpilot.system.audio import get_sounddevice_device
+
 RATE = 10
 FFT_SAMPLES = 1600 # 100ms
 REFERENCE_SPL = 2e-5  # newtons/m^2
@@ -99,7 +101,16 @@ class Mic:
     # reload sounddevice to reinitialize portaudio
     sd._terminate()
     sd._initialize()
-    return sd.InputStream(channels=1, samplerate=SAMPLE_RATE, callback=self.callback, blocksize=SAMPLE_BUFFER)
+    stream_kwargs = {
+      "channels": 1,
+      "samplerate": SAMPLE_RATE,
+      "callback": self.callback,
+      "blocksize": SAMPLE_BUFFER,
+    }
+    device = get_sounddevice_device(sd, is_input=True)
+    if device is not None:
+      stream_kwargs["device"] = device
+    return sd.InputStream(**stream_kwargs)
 
   def micd_thread(self):
     # sounddevice must be imported after forking processes


### PR DESCRIPTION
## Summary
Make `soundd` and `micd` prefer the dedicated comma simple sound card instead of relying on PortAudio's default device selection.

## What changes
- add a small `system.audio` helper that selects preferred input/output devices by name
- prefer the new `sdm845-comma-simple-snd-card` device and fall back to the existing Tavil card name
- thread the explicit device selection into both playback and capture stream creation

## Notes
This is the userspace half of the simple-audio-stack transition. It pairs with commaai/agnos-kernel-sdm845#107 and commaai/agnos-builder#553.
