### PR TITLE
launch_chffrplus.sh: Quote all variables derived from the script's path to avoid edge-case word-splitting

### DIFF
--- a/launch_chffrplus.sh
+++ b/launch_chffrplus.sh
@@ -20,16 +20,16 @@ function agnos_init {
   if [ $(< /VERSION) != "$AGNOS_VERSION" ]; then
     AGNOS_PY="$DIR/system/hardware/tici/agnos.py"
     MANIFEST="$DIR/system/hardware/tici/agnos.json"
-    if $AGNOS_PY --verify $MANIFEST; then
+    if "$AGNOS_PY" --verify "$MANIFEST"; then
       sudo reboot
     fi
-    $DIR/system/hardware/tici/updater $AGNOS_PY $MANIFEST
+    "$DIR/system/hardware/tici/updater" "$AGNOS_PY" "$MANIFEST"
   fi
 }
 
 function launch {
   # Remove orphaned git lock if it exists on boot
-  [ -f "$DIR/.git/index.lock" ] && rm -f $DIR/.git/index.lock
+  [ -f "$DIR/.git/index.lock" ] && rm -f "$DIR/.git/index.lock"
 
   # Check to see if there's a valid overlay-based update available. Conditions
   # are as follows:
@@ -41,7 +41,7 @@ function launch {
   #    that completed successfully and synced to disk.
 
   if [ -f "${DIR}/.overlay_init" ]; then
-    find ${DIR}/.git -newer ${DIR}/.overlay_init | grep -q '.' 2> /dev/null
+    find "${DIR}/.git" -newer "${DIR}/.overlay_init" | grep -q '.' 2> /dev/null
     if [ $? -eq 0 ]; then
       echo "${DIR} has been modified, skipping overlay update installation"
     else
@@ -50,9 +50,9 @@ function launch {
           echo "Valid overlay update found, installing"
           LAUNCHER_LOCATION="${BASH_SOURCE[0]}"
 
-          mv $DIR /data/safe_staging/old_openpilot
-          mv "${STAGING_ROOT}/finalized" $DIR
-          cd $DIR
+          mv "$DIR" /data/safe_staging/old_openpilot
+          mv "${STAGING_ROOT}/finalized" "$DIR"
+          cd "$DIR"
 
           echo "Restarting launch script ${LAUNCHER_LOCATION}"
           unset AGNOS_VERSION
@@ -66,7 +66,7 @@ function launch {
   fi
 
   # handle pythonpath
-  ln -sfn $(pwd) /data/pythonpath
+  ln -sfn "$(pwd)" /data/pythonpath
   export PYTHONPATH="$PWD"
 
   # hardware specific init
@@ -79,7 +79,7 @@ function launch {
 
   # start manager
   cd system/manager
-  if [ ! -f $DIR/prebuilt ]; then
+  if [ ! -f "$DIR/prebuilt" ]; then
     ./build.py
   fi
   ./manager.py


### PR DESCRIPTION
**Description**

This PR fixes path/word-splitting hazards (including an unquoted `rm -f` invocation) in `launch_chffrplus.sh` where command paths and arguments are built from `DIR` (derived from `BASH_SOURCE[0]`).

Changes are intentionally minimal and limited to quoting vulnerable expansions so behavior stays the same while paths containing spaces/special characters work correctly.

No feature changes or logic refactors were introduced.

**Verification**

Confirm all `DIR`-derived command/argument expansions in `launch_chffrplus.sh` are quoted at call sites touched by this PR.