### PR TITLE
ui replay: add scrolling to tizi replay

### DIFF
--- a/selfdrive/ui/tests/diff/replay_script.py
+++ b/selfdrive/ui/tests/diff/replay_script.py
@@ -465,7 +465,7 @@ def build_tizi_script(pm: PubMaster, main_layout, script: Script) -> None:
   do_onboarding()
   # regulatory info
   script.click(2000, 970)  # regulatory button
-  scroll_down(height * 1.5)  # scroll regulatory info
+  scroll_down(int(height * 1.5))  # scroll regulatory info
   script.click(2000, 970)  # OK
   # scroll device settings
   scroll_down()

--- a/selfdrive/ui/tests/diff/replay_script.py
+++ b/selfdrive/ui/tests/diff/replay_script.py
@@ -474,7 +474,7 @@ def build_tizi_script(pm: PubMaster, main_layout, script: Script) -> None:
     script.click(2000, 800)  # open language selection
     if i == 0:
       scroll_down()  # scroll languages
-      script.click(1000, 500)  # select a language (Chinese, requires unifont)
+      script.click(1000, 500)  # select unifont language
     else:
       script.click(1000, 300)  # reset to English
     script.click(1500, 900)  # confirm language

--- a/selfdrive/ui/tests/diff/replay_script.py
+++ b/selfdrive/ui/tests/diff/replay_script.py
@@ -467,7 +467,18 @@ def build_tizi_script(pm: PubMaster, main_layout, script: Script) -> None:
   script.click(2000, 970)  # regulatory button
   scroll_down(height * 1.5)  # scroll regulatory info
   script.click(2000, 970)  # OK
-  scroll_down()  # scroll device settings
+  # scroll device settings
+  scroll_down()
+  # change language
+  for i in range(2):
+    script.click(2000, 800)  # open language selection
+    if i == 0:
+      scroll_down()  # scroll languages
+      script.click(1000, 500)  # select a language (Chinese, requires unifont)
+    else:
+      script.click(1000, 300)  # reset to English
+    script.click(1500, 900)  # confirm language
+  # reboot/shutdown
   script.click(950, 960)  # reboot
   script.click(1500, 750)  # confirm reboot
   script.click(1800, 960)  # shutdown

--- a/selfdrive/ui/tests/diff/replay_script.py
+++ b/selfdrive/ui/tests/diff/replay_script.py
@@ -510,6 +510,7 @@ def build_tizi_script(pm: PubMaster, main_layout, script: Script) -> None:
   script.click(1600, 900)  # confirm selection
   script.click(2000, 800)  # uninstall
   script.click(650, 750)  # cancel uninstall
+  scroll_down()  # scroll software settings
 
   # === Settings - Firehose ===
   script.click(278, 845)

--- a/selfdrive/ui/tests/diff/replay_script.py
+++ b/selfdrive/ui/tests/diff/replay_script.py
@@ -447,7 +447,7 @@ def build_tizi_script(pm: PubMaster, main_layout, script: Script) -> None:
   script.click(620, 950)  # close alerts
 
   # === Settings (click sidebar settings button) ===
-  script.click(150, 90)
+  script.click(150, 90)  # open settings (device panel)
 
   # === Settings - Device ===
   # pair device
@@ -474,7 +474,7 @@ def build_tizi_script(pm: PubMaster, main_layout, script: Script) -> None:
   script.click(1500, 750)  # confirm shutdown
 
   # === Settings - Network ===
-  script.click(278, 450)
+  script.click(278, 450)  # open network panel
   # TODO: mock networks
   script.click(1880, 100)  # advanced network settings
 
@@ -491,14 +491,14 @@ def build_tizi_script(pm: PubMaster, main_layout, script: Script) -> None:
   script.click(630, 80)  # back from advanced network
 
   # === Settings - Toggles ===
-  script.click(278, 600)
+  script.click(278, 600)  # open toggles panel
   for _ in range(2):
     script.click(1200, 280)  # toggle experimental mode description
   scroll_down()  # scroll toggles
 
   # === Settings - Software ===
   script.setup(lambda: setup_update_available(False), wait_after=0)  # start with no update available
-  script.click(278, 720)  # software
+  script.click(278, 720)  # open software panel
   for _ in range(2):
     script.click(720, 120)  # toggle current release notes
   script.setup(setup_update_available)  # set update available
@@ -513,12 +513,12 @@ def build_tizi_script(pm: PubMaster, main_layout, script: Script) -> None:
   scroll_down()  # scroll software settings
 
   # === Settings - Firehose ===
-  script.click(278, 845)
+  script.click(278, 845)  # open firehose panel
   scroll_down()  # scroll firehose panel
 
   # === Settings - Developer (set CarParamsPersistent first) ===
   script.setup(setup_developer_params, wait_after=0)
-  script.click(278, 950)
+  script.click(278, 950)  # open developer panel
   script.click(1930, 470)  # SSH keys (keyboard)
   script.click(1930, 115)  # click cancel on keyboard
   script.click(2000, 960)  # toggle alpha long

--- a/selfdrive/ui/tests/diff/replay_script.py
+++ b/selfdrive/ui/tests/diff/replay_script.py
@@ -468,6 +468,10 @@ def build_tizi_script(pm: PubMaster, main_layout, script: Script) -> None:
   scroll_down(height * 1.5)  # scroll regulatory info
   script.click(2000, 970)  # OK
   scroll_down()  # scroll device settings
+  script.click(950, 960)  # reboot
+  script.click(1500, 750)  # confirm reboot
+  script.click(1800, 960)  # shutdown
+  script.click(1500, 750)  # confirm shutdown
 
   # === Settings - Network ===
   script.click(278, 450)

--- a/selfdrive/ui/tests/diff/replay_script.py
+++ b/selfdrive/ui/tests/diff/replay_script.py
@@ -377,6 +377,18 @@ def build_mici_script(pm: PubMaster, main_layout, script: Script) -> None:
 
 def build_tizi_script(pm: PubMaster, main_layout, script: Script) -> None:
   """Build the replay script for the tizi layout."""
+  from openpilot.system.ui.lib.application import gui_app
+
+  width, height = gui_app.width, gui_app.height
+  center = (width // 2, height // 2)
+
+  SWIPE_DISTANCE = height // 3  # roughly a full page scroll for toggles
+  SWIPE_DURATION = 5
+  SWIPE_WAIT = FPS * 3 // 4
+
+  def scroll_down(distance: int = SWIPE_DISTANCE, duration_frames: int = SWIPE_DURATION, wait_after: int = SWIPE_WAIT) -> None:
+    """Drag upward from the center (scroll down)."""
+    script.drag(*center, DIR_UP, distance, duration_frames, wait_after)
 
   def make_home_refresh_setup(fn: Callable) -> Callable:
     """Return setup function that calls the given function to modify state and forces an immediate refresh on the home layout."""
@@ -427,9 +439,11 @@ def build_tizi_script(pm: PubMaster, main_layout, script: Script) -> None:
 
   # === Update Available (auto-transitions via HomeLayout refresh) ===
   script.setup(make_home_refresh_setup(setup_update_available))
+  scroll_down()  # scroll release notes
 
   # === Offroad Alerts (auto-transitions via HomeLayout refresh, overrides update) ===
   script.setup(make_home_refresh_setup(setup_offroad_alerts))
+  scroll_down()  # scroll alerts
   script.click(620, 950)  # close alerts
 
   # === Settings (click sidebar settings button) ===
@@ -451,12 +465,15 @@ def build_tizi_script(pm: PubMaster, main_layout, script: Script) -> None:
   do_onboarding()
   # regulatory info
   script.click(2000, 970)  # regulatory button
+  scroll_down(height * 1.5)  # scroll regulatory info
   script.click(2000, 970)  # OK
+  scroll_down()  # scroll device settings
 
   # === Settings - Network ===
   script.click(278, 450)
   # TODO: mock networks
   script.click(1880, 100)  # advanced network settings
+  scroll_down()  # scroll advanced network settings
 
   # Keyboard (tethering password)
   script.click(2000, 420, wait_after=FAST_CLICK)  # open tether password keyboard
@@ -471,7 +488,9 @@ def build_tizi_script(pm: PubMaster, main_layout, script: Script) -> None:
 
   # === Settings - Toggles ===
   script.click(278, 600)
-  script.click(1200, 280)  # expand experimental mode description
+  for _ in range(2):
+    script.click(1200, 280)  # toggle experimental mode description
+  scroll_down()  # scroll toggles
 
   # === Settings - Software ===
   script.setup(lambda: setup_update_available(False), wait_after=0)  # start with no update available
@@ -482,6 +501,7 @@ def build_tizi_script(pm: PubMaster, main_layout, script: Script) -> None:
   for _ in range(2):
     script.click(720, 450)  # toggle new release notes
   script.click(2000, 630)  # open select branch dialog
+  scroll_down()  # scroll branches
   script.click(1000, 300)  # select 1st option
   script.click(1600, 900)  # confirm selection
   script.click(2000, 800)  # uninstall
@@ -489,6 +509,7 @@ def build_tizi_script(pm: PubMaster, main_layout, script: Script) -> None:
 
   # === Settings - Firehose ===
   script.click(278, 845)
+  scroll_down()  # scroll firehose panel
 
   # === Settings - Developer (set CarParamsPersistent first) ===
   script.setup(setup_developer_params, wait_after=0)
@@ -497,6 +518,7 @@ def build_tizi_script(pm: PubMaster, main_layout, script: Script) -> None:
   script.click(1930, 115)  # click cancel on keyboard
   script.click(2000, 960)  # toggle alpha long
   script.click(1500, 875)  # confirm
+  scroll_down()  # scroll developer options
 
   # === Close settings ===
   script.click(250, 160)

--- a/selfdrive/ui/tests/diff/replay_script.py
+++ b/selfdrive/ui/tests/diff/replay_script.py
@@ -477,7 +477,6 @@ def build_tizi_script(pm: PubMaster, main_layout, script: Script) -> None:
   script.click(278, 450)
   # TODO: mock networks
   script.click(1880, 100)  # advanced network settings
-  scroll_down()  # scroll advanced network settings
 
   # Keyboard (tethering password)
   script.click(2000, 420, wait_after=FAST_CLICK)  # open tether password keyboard
@@ -488,6 +487,7 @@ def build_tizi_script(pm: PubMaster, main_layout, script: Script) -> None:
   script.click(2050, 250, wait_after=FAST_CLICK)  # toggle show/hide password
   script.click(2000, 950)  # confirm (close keyboard)
 
+  scroll_down()  # scroll advanced network settings
   script.click(630, 80)  # back from advanced network
 
   # === Settings - Toggles ===

--- a/selfdrive/ui/tests/diff/replay_script.py
+++ b/selfdrive/ui/tests/diff/replay_script.py
@@ -535,6 +535,8 @@ def build_tizi_script(pm: PubMaster, main_layout, script: Script) -> None:
   script.click(2000, 960)  # toggle alpha long
   script.click(1500, 875)  # confirm
   scroll_down()  # scroll developer options
+  for _ in range(2):
+    script.click(2000, 960)  # toggle UI debug mode
 
   # === Close settings ===
   script.click(250, 160)


### PR DESCRIPTION
Add the following to the tizi replay script:

1. Scroll update release notes
2. Scroll offroad alerts
3. Scroll regulatory info
4. Scroll down every settings panel
5. Select language (unifont)
6. Reboot and power off buttons
7. Scroll software branch modal

Increases tizi coverage 63% -> 65%

Unfortunately, the video file size goes from 11MB to 37MB due to lack of compression for motion (CRF=0).