### PR TITLE
Do not map tici to tizi release

### DIFF
--- a/selfdrive/ui/installer/installer.cc
+++ b/selfdrive/ui/installer/installer.cc
@@ -48,7 +48,7 @@ Font font_display;
 const bool tici_device = Hardware::get_device_type() == cereal::InitData::DeviceType::TICI ||
                          Hardware::get_device_type() == cereal::InitData::DeviceType::TIZI;
 
-std::vector<std::string> tici_prebuilt_branches = {"release3", "release3-staging", "nightly", "nightly-dev"};
+std::vector<std::string> tici_prebuilt_branches = {"release3", "release-tici", "release3-staging", "nightly", "nightly-dev"};
 std::string migrated_branch;
 
 void branchMigration() {

--- a/selfdrive/ui/installer/installer.cc
+++ b/selfdrive/ui/installer/installer.cc
@@ -48,7 +48,7 @@ Font font_display;
 const bool tici_device = Hardware::get_device_type() == cereal::InitData::DeviceType::TICI ||
                          Hardware::get_device_type() == cereal::InitData::DeviceType::TIZI;
 
-std::vector<std::string> tici_prebuilt_branches = {"release3", "release-tizi", "release3-staging", "nightly", "nightly-dev"};
+std::vector<std::string> tici_prebuilt_branches = {"release3", "release3-staging", "nightly", "nightly-dev"};
 std::string migrated_branch;
 
 void branchMigration() {


### PR DESCRIPTION
**Description**

Openpilot was flashing the wrong firmware to my C3 when I was building a custom fork. The issue was because the openpilot installer is defining release-tizi as a prebuilt branch for the tici device. This causes the tici device to download tizi firmware

The fix is an easy one liner. Just remove release-tizi from the list of prebuilt branches for tici devices in selfdrive\ui\installer\installer.cc

**Verification**

The fix was tested on my Comma 3. After installing my custom fork, the C3 booted without asking me to update the firmware. Previously, the C3 would perform a firmware update after installing the fork. After rebooting the device would show "Wrong firmware detected" and I would have to reflash the device from my computer and start over.