### PR TITLE
remove any stale scons lock on device startup

### DIFF
--- a/launch_chffrplus.sh
+++ b/launch_chffrplus.sh
@@ -7,6 +7,7 @@ source "$DIR/launch_env.sh"
 function agnos_init {
   # TODO: move this to agnos
   sudo rm -f /data/etc/NetworkManager/system-connections/*.nmmeta
+  rm -f /data/scons_cache/config.lock
 
   # set success flag for current boot slot
   sudo abctl --set_success


### PR DESCRIPTION
Resolves #35088.

* Runs on AGNOS only, where the main problem is, the path would be different on PC
* Collected with other items that should be migrated to AGNOS / vamOS.
* No need to check for existence (or for prebuilt) when using `-f`. 