### PR TITLE
soundd: fix audio glitch in get_sound_data when frames < sound length

### DIFF
--- a/selfdrive/ui/soundd.py
+++ b/selfdrive/ui/soundd.py
@@ -106,6 +106,8 @@ class Soundd:
         ret[written_frames:written_frames+frames_to_write] = sound_data[current_sound_frame:current_sound_frame+frames_to_write]
         written_frames += frames_to_write
         self.current_sound_frame += frames_to_write
+        current_sound_frame = self.current_sound_frame % len(sound_data)
+        loops = self.current_sound_frame // len(sound_data)
 
     return ret * self.current_volume
 

--- a/selfdrive/ui/tests/test_soundd.py
+++ b/selfdrive/ui/tests/test_soundd.py
@@ -3,7 +3,7 @@ import numpy as np
 from cereal import car
 from cereal import messaging
 from cereal.messaging import SubMaster, PubMaster
-from openpilot.selfdrive.ui.soundd import SELFDRIVE_STATE_TIMEOUT, Soundd, check_selfdrive_timeout_alert, sound_list
+from openpilot.selfdrive.ui.soundd import SELFDRIVE_STATE_TIMEOUT, Soundd, check_selfdrive_timeout_alert
 
 import time
 

--- a/selfdrive/ui/tests/test_soundd.py
+++ b/selfdrive/ui/tests/test_soundd.py
@@ -1,7 +1,9 @@
+import numpy as np
+
 from cereal import car
 from cereal import messaging
 from cereal.messaging import SubMaster, PubMaster
-from openpilot.selfdrive.ui.soundd import SELFDRIVE_STATE_TIMEOUT, check_selfdrive_timeout_alert
+from openpilot.selfdrive.ui.soundd import SELFDRIVE_STATE_TIMEOUT, Soundd, check_selfdrive_timeout_alert, sound_list
 
 import time
 
@@ -33,3 +35,97 @@ class TestSoundd:
 
   # TODO: add test with micd for checking that soundd actually outputs sounds
 
+
+class TestGetSoundData:
+  """Tests for get_sound_data boundary conditions (issue #36285)."""
+
+  def _make_soundd_with_test_sound(self, sound_data, alert=AudibleAlert.engage):
+    s = Soundd.__new__(Soundd)
+    s.current_alert = alert
+    s.current_volume = 1.0
+    s.current_sound_frame = 0
+    s.loaded_sounds = {alert: sound_data}
+    return s
+
+  def test_frames_equal_to_sound_length(self):
+    sound_data = np.arange(50, dtype=np.float32)
+    s = self._make_soundd_with_test_sound(sound_data)
+    result = s.get_sound_data(50)
+    np.testing.assert_array_equal(result, sound_data)
+
+  def test_frames_less_than_sound_length_single_callback(self):
+    sound_data = np.arange(70, dtype=np.float32)
+    s = self._make_soundd_with_test_sound(sound_data)
+    result = s.get_sound_data(50)
+    np.testing.assert_array_equal(result, sound_data[:50])
+    assert s.current_sound_frame == 50
+
+  def test_frames_less_than_sound_wraps_correctly(self):
+    """Regression test for #36285: second callback must wrap to start of sound, not repeat the tail."""
+    sound_data = np.arange(70, dtype=np.float32)
+    s = self._make_soundd_with_test_sound(sound_data, alert=AudibleAlert.promptRepeat)
+
+    # First callback: [0..49]
+    result1 = s.get_sound_data(50)
+    np.testing.assert_array_equal(result1, sound_data[:50])
+
+    # Second callback: should be [50..69, 0..29] (wrap around)
+    result2 = s.get_sound_data(50)
+    expected = np.concatenate([sound_data[50:70], sound_data[0:30]])
+    np.testing.assert_array_equal(result2, expected)
+
+  def test_single_play_stops_after_one_loop(self):
+    """Single-play sound should zero-fill after the sound ends."""
+    sound_data = np.arange(70, dtype=np.float32)
+    s = self._make_soundd_with_test_sound(sound_data)
+
+    result1 = s.get_sound_data(50)
+    np.testing.assert_array_equal(result1, sound_data[:50])
+
+    # Second callback: [50..69] then zeros (single play, no repeat)
+    result2 = s.get_sound_data(50)
+    expected = np.zeros(50, dtype=np.float32)
+    expected[:20] = sound_data[50:70]
+    np.testing.assert_array_equal(result2, expected)
+
+  def test_frames_larger_than_sound_wraps(self):
+    """When frames > sound length, the sound should loop within a single callback."""
+    sound_data = np.arange(30, dtype=np.float32)
+    s = self._make_soundd_with_test_sound(sound_data, alert=AudibleAlert.promptRepeat)
+
+    result = s.get_sound_data(50)
+    expected = np.concatenate([sound_data, sound_data[:20]])
+    np.testing.assert_array_equal(result, expected)
+
+  def test_multiple_consecutive_callbacks(self):
+    """Multiple callbacks should produce a continuous, correctly-wrapped stream."""
+    sound_data = np.arange(70, dtype=np.float32)
+    s = self._make_soundd_with_test_sound(sound_data, alert=AudibleAlert.promptRepeat)
+
+    all_samples = []
+    for _ in range(10):
+      result = s.get_sound_data(50)
+      all_samples.append(result)
+
+    # Verify the full stream is a continuous loop of sound_data
+    full_stream = np.concatenate(all_samples)  # 500 samples total
+    for i in range(len(full_stream)):
+      assert full_stream[i] == sound_data[i % len(sound_data)], \
+        f"Mismatch at index {i}: got {full_stream[i]}, expected {sound_data[i % len(sound_data)]}"
+
+  def test_no_alert_returns_silence(self):
+    s = Soundd.__new__(Soundd)
+    s.current_alert = AudibleAlert.none
+    s.current_volume = 1.0
+    s.current_sound_frame = 0
+    s.loaded_sounds = {}
+
+    result = s.get_sound_data(50)
+    np.testing.assert_array_equal(result, np.zeros(50, dtype=np.float32))
+
+  def test_volume_scaling(self):
+    sound_data = np.ones(50, dtype=np.float32)
+    s = self._make_soundd_with_test_sound(sound_data)
+    s.current_volume = 0.5
+    result = s.get_sound_data(50)
+    np.testing.assert_array_almost_equal(result, np.full(50, 0.5, dtype=np.float32))


### PR DESCRIPTION
## Summary

Fix boundary condition bug in `Soundd.get_sound_data()` where `current_sound_frame` and `loops` were not recomputed after each chunk write inside the while loop. When the audio callback requested fewer frames than the sound's total length, subsequent callbacks duplicated the tail of the sound instead of wrapping around to the beginning.

- Add per-iteration recomputation of `current_sound_frame` and `loops` inside the while loop (2 lines)
- Add 8 regression tests covering wrap-around, single-play stop, multi-callback continuity, and volume scaling

Fixes #36285

<details>
<summary>Before (bug reproduction)</summary>

```
============================================================
Test: frames=50, sound_data length=70, infinite looping
============================================================

Callback 1 (frames=50):
  current_sound_frame after: 50
  result: [0. 1. 2. 3. 4. 5. 6. 7. 8. 9.]...[45. 46. 47. 48. 49.]
  Correct (should be [0..49]): True

Callback 2 (frames=50):
  current_sound_frame after: 100
  result: [50. 51. 52. 53. 54. 55. 56. 57. 58. 59. 60. 61. 62. 63. 64. 65. 66. 67.
 68. 69. 50. 51. 52. 53. 54. 55. 56. 57. 58. 59. 60. 61. 62. 63. 64. 65.
 66. 67. 68. 69. 50. 51. 52. 53. 54. 55. 56. 57. 58. 59.]
  Expected: [50. 51. 52. 53. 54. 55. 56. 57. 58. 59. 60. 61. 62. 63. 64. 65. 66. 67.
 68. 69.  0.  1.  2.  3.  4.  5.  6.  7.  8.  9. 10. 11. 12. 13. 14. 15.
 16. 17. 18. 19. 20. 21. 22. 23. 24. 25. 26. 27. 28. 29.]
  Correct (should be [50..69, 0..29]): False

  >>> BUG CONFIRMED: second callback does NOT wrap correctly!
  >>> Got duplicated tail data instead of wrapping to start

============================================================
Test: frames=50, sound_data length=70, single play (num_loops=1)
============================================================

Callback 2 (frames=50):
  current_sound_frame after: 100
  result: [50. 51. 52. 53. 54. 55. 56. 57. 58. 59. 60. 61. 62. 63. 64. 65. 66. 67.
 68. 69. 50. 51. 52. 53. 54. 55. 56. 57. 58. 59. 60. 61. 62. 63. 64. 65.
 66. 67. 68. 69. 50. 51. 52. 53. 54. 55. 56. 57. 58. 59.]
  Expected: [50. 51. 52. 53. 54. 55. 56. 57. 58. 59. 60. 61. 62. 63. 64. 65. 66. 67.
 68. 69.  0.  0.  0.  0.  0.  0.  0.  0.  0.  0.  0.  0.  0.  0.  0.  0.
  0.  0.  0.  0.  0.  0.  0.  0.  0.  0.  0.  0.  0.  0.]
  Correct (should be [50..69, zeros]): False

  >>> BUG CONFIRMED: single-play boundary also broken!

============================================================
SOME TESTS FAILED - BUG CONFIRMED
============================================================
```

</details>

<details>
<summary>After (bug fixed)</summary>

```
============================================================
Test: frames=50, sound_data length=70, infinite looping
============================================================

Callback 2 (frames=50):
  current_sound_frame after: 100
  result: [50. 51. 52. 53. 54. 55. 56. 57. 58. 59. 60. 61. 62. 63. 64. 65. 66. 67.
 68. 69.  0.  1.  2.  3.  4.  5.  6.  7.  8.  9. 10. 11. 12. 13. 14. 15.
 16. 17. 18. 19. 20. 21. 22. 23. 24. 25. 26. 27. 28. 29.]
  Correct (should be [50..69, 0..29]): True

============================================================
Test: frames=50, sound_data length=70, single play (num_loops=1)
============================================================

Callback 2 (frames=50):
  current_sound_frame after: 70
  result: [50. 51. 52. 53. 54. 55. 56. 57. 58. 59. 60. 61. 62. 63. 64. 65. 66. 67.
 68. 69.  0.  0.  0.  0.  0.  0.  0.  0.  0.  0.  0.  0.  0.  0.  0.  0.
  0.  0.  0.  0.  0.  0.  0.  0.  0.  0.  0.  0.  0.  0.]
  Correct (should be [50..69, zeros]): True

============================================================
ALL TESTS PASSED
============================================================

test_soundd_standalone.py 8 passed in 0.21s
```

</details>

## Test plan
- [x] Standalone bug reproduction script (before/after comparison)
- [x] 8 unit tests in `test_soundd_standalone.py`: boundary wrap, single-play stop, multi-callback stream, silence, volume scaling
- [x] Tests added to `selfdrive/ui/tests/test_soundd.py` for CI integration