### PR TITLE
Fixes the debugging of safety after scons removal

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -52,6 +52,9 @@
       "type": "lldb",
       "request": "attach",
       "pid": "${command:pickMyProcess}",
+      "sourceMap": {
+        ".": "${workspaceFolder}/opendbc/safety"
+      },
       "initCommands": [
         "script import time; time.sleep(3)"
       ]


### PR DESCRIPTION
After https://github.com/commaai/opendbc/pull/3194 seems like it was unable to resolve the source of the safety lib. This fix makes it work again.