### PR TITLE
esim: harden AtClient with retry loops and reconnect

### DIFF
--- a/system/hardware/base.py
+++ b/system/hardware/base.py
@@ -91,12 +91,8 @@ class LPABase(ABC):
   def switch_profile(self, iccid: str) -> None:
     pass
 
-  def process_notifications(self) -> None:
-    pass
-
   def is_comma_profile(self, iccid: str) -> bool:
-    profiles = self.list_profiles()
-    return any(p.iccid == iccid and p.provider == 'Webbing' for p in profiles)
+    return any(iccid.startswith(prefix) for prefix in ('8985235',))
 
 class HardwareBase(ABC):
   @staticmethod

--- a/system/hardware/base.py
+++ b/system/hardware/base.py
@@ -91,8 +91,12 @@ class LPABase(ABC):
   def switch_profile(self, iccid: str) -> None:
     pass
 
+  def process_notifications(self) -> None:
+    pass
+
   def is_comma_profile(self, iccid: str) -> bool:
-    return any(iccid.startswith(prefix) for prefix in ('8985235',))
+    profiles = self.list_profiles()
+    return any(p.iccid == iccid and p.provider == 'Webbing' for p in profiles)
 
 class HardwareBase(ABC):
   @staticmethod

--- a/system/hardware/esim.py
+++ b/system/hardware/esim.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
 import argparse
-import time
 from openpilot.system.hardware import HARDWARE
 
 
@@ -13,16 +12,13 @@ if __name__ == '__main__':
   parser.add_argument('--nickname', nargs=2, metavar=('iccid', 'name'), help='update the nickname for a profile')
   args = parser.parse_args()
 
-  mutated = False
   lpa = HARDWARE.get_sim_lpa()
   if args.switch:
     lpa.switch_profile(args.switch)
-    mutated = True
   elif args.delete:
     confirm = input('are you sure you want to delete this profile? (y/N) ')
     if confirm == 'y':
       lpa.delete_profile(args.delete)
-      mutated = True
     else:
       print('cancelled')
       exit(0)
@@ -32,11 +28,6 @@ if __name__ == '__main__':
     lpa.nickname_profile(args.nickname[0], args.nickname[1])
   else:
     parser.print_help()
-
-  if mutated:
-    HARDWARE.reboot_modem()
-    # eUICC needs a small delay post-reboot before querying profiles
-    time.sleep(.5)
 
   profiles = lpa.list_profiles()
   print(f'\n{len(profiles)} profile{"s" if len(profiles) > 1 else ""}:')

--- a/system/hardware/tici/lpa.py
+++ b/system/hardware/tici/lpa.py
@@ -81,19 +81,17 @@ class AtClient:
         raise RuntimeError(f"AT command failed: {line}")
       lines.append(line)
 
-  def _ensure_serial(self) -> None:
+  def _ensure_serial(self, reconnect: bool = False) -> None:
+    if reconnect:
+      self.channel = None
+      try:
+        if self._serial:
+          self._serial.close()
+      except Exception:
+        pass
+      self._serial = None
     if self._serial is None:
       self._serial = serial.Serial(self._device, baudrate=self._baud, timeout=self._timeout)
-
-  def _reconnect_serial(self) -> None:
-    self.channel = None
-    try:
-      if self._serial:
-        self._serial.close()
-    except Exception:
-      pass
-    self._serial = None
-    self._ensure_serial()
 
   def _get_modem(self):
     import dbus
@@ -124,7 +122,7 @@ class AtClient:
       self._send(cmd)
       return self._expect()
     except serial.SerialException:
-      self._reconnect_serial()
+      self._ensure_serial(reconnect=True)
       self._send(cmd)
       return self._expect()
 
@@ -140,7 +138,7 @@ class AtClient:
       try:
         self._serial.reset_input_buffer()
       except (OSError, serial.SerialException, termios.error):
-        self._reconnect_serial()
+        self._ensure_serial(reconnect=True)
     for line in self.query(f'AT+CCHO="{ISDR_AID}"'):
       if line.startswith("+CCHO:") and (ch := line.split(":", 1)[1].strip()):
         self.channel = ch
@@ -159,7 +157,7 @@ class AtClient:
           # SIM may be stuck (CME ERROR 13) — reset modem via lte.sh
           subprocess.run(['/usr/comma/lte/lte.sh', 'start'], capture_output=True)
           time.sleep(5)
-          self._reconnect_serial()
+          self._ensure_serial(reconnect=True)
         else:
           time.sleep(2.0)
     raise RuntimeError("Failed to open ISD-R after retries")

--- a/system/hardware/tici/lpa.py
+++ b/system/hardware/tici/lpa.py
@@ -302,7 +302,6 @@ class TiciLPA(LPABase):
     if hasattr(self, '_client'):
       return
     self._client = AtClient(DEFAULT_DEVICE, DEFAULT_BAUD, DEFAULT_TIMEOUT)
-    self._client.open_isdr()
     atexit.register(self._client.close)
 
   def list_profiles(self) -> list[Profile]:

--- a/system/hardware/tici/lpa.py
+++ b/system/hardware/tici/lpa.py
@@ -81,6 +81,10 @@ class AtClient:
         raise RuntimeError(f"AT command failed: {line}")
       lines.append(line)
 
+  def _ensure_serial(self) -> None:
+    if self._serial is None:
+      self._serial = serial.Serial(self._device, baudrate=self._baud, timeout=self._timeout)
+
   def _reconnect_serial(self) -> None:
     self.channel = None
     try:
@@ -88,7 +92,8 @@ class AtClient:
         self._serial.close()
     except Exception:
       pass
-    self._serial = serial.Serial(self._device, baudrate=self._baud, timeout=self._timeout)
+    self._serial = None
+    self._ensure_serial()
 
   def _get_modem(self):
     import dbus
@@ -114,8 +119,7 @@ class AtClient:
   def query(self, cmd: str) -> list[str]:
     if self._use_dbus:
       return self._dbus_query(cmd)
-    if not self._serial:
-      self._serial = serial.Serial(self._device, baudrate=self._baud, timeout=self._timeout)
+    self._ensure_serial()
     try:
       self._send(cmd)
       return self._expect()

--- a/system/hardware/tici/lpa.py
+++ b/system/hardware/tici/lpa.py
@@ -5,14 +5,17 @@ import base64
 import math
 import os
 import serial
+import subprocess
 import sys
+import termios
+import time
 
 from collections.abc import Generator
 
 from openpilot.system.hardware.base import LPABase, Profile
 
 
-DEFAULT_DEVICE = "/dev/ttyUSB2"
+DEFAULT_DEVICE = "/dev/modem_at0"
 DEFAULT_BAUD = 9600
 DEFAULT_TIMEOUT = 5.0
 # https://euicc-manual.osmocom.org/docs/lpa/applet-id/
@@ -20,7 +23,7 @@ ISDR_AID = "A0000005591010FFFFFFFF8900000100"
 MM = "org.freedesktop.ModemManager1"
 MM_MODEM = MM + ".Modem"
 ES10X_MSS = 120
-DEBUG = os.environ.get("DEBUG") == "1"
+DEBUG = True
 
 # TLV Tags
 TAG_ICCID = 0x5A
@@ -39,18 +42,22 @@ class AtClient:
   def __init__(self, device: str, baud: int, timeout: float, debug: bool) -> None:
     self.debug = debug
     self.channel: str | None = None
+    self._device = device
+    self._baud = baud
     self._timeout = timeout
     self._serial: serial.Serial | None = None
-    try:
-      self._serial = serial.Serial(device, baudrate=baud, timeout=timeout)
-      self._serial.reset_input_buffer()
-    except (serial.SerialException, PermissionError, OSError):
-      pass
+    self._use_dbus = not os.path.exists(device)
+    if self.debug:
+      transport = "DBUS" if self._use_dbus else "serial"
+      print(f"AtClient: using {transport} transport", file=sys.stderr)
 
   def close(self) -> None:
     try:
       if self.channel:
-        self.query(f"AT+CCHC={self.channel}")
+        try:
+          self.query(f"AT+CCHC={self.channel}")
+        except (RuntimeError, TimeoutError):
+          pass
         self.channel = None
     finally:
       if self._serial:
@@ -78,6 +85,15 @@ class AtClient:
         raise RuntimeError(f"AT command failed: {line}")
       lines.append(line)
 
+  def _reconnect_serial(self) -> None:
+    self.channel = None
+    try:
+      if self._serial:
+        self._serial.close()
+    except Exception:
+      pass
+    self._serial = serial.Serial(self._device, baudrate=self._baud, timeout=self._timeout)
+
   def _get_modem(self):
     import dbus
     bus = dbus.SystemBus()
@@ -100,35 +116,74 @@ class AtClient:
     return lines
 
   def query(self, cmd: str) -> list[str]:
-    if self._serial:
+    if self._use_dbus:
+      return self._dbus_query(cmd)
+    if not self._serial:
+      self._serial = serial.Serial(self._device, baudrate=self._baud, timeout=self._timeout)
+    try:
       self._send(cmd)
       return self._expect()
-    return self._dbus_query(cmd)
+    except serial.SerialException:
+      self._reconnect_serial()
+      self._send(cmd)
+      return self._expect()
 
-  def open_isdr(self) -> None:
-    # close any stale logical channel from a previous crashed session
-    try:
-      self.query("AT+CCHC=1")
-    except RuntimeError:
-      pass
+  def _open_isdr_once(self) -> None:
+    if self.channel:
+      try:
+        self.query(f"AT+CCHC={self.channel}")
+      except RuntimeError:
+        pass
+      self.channel = None
+    # drain any unsolicited responses before opening
+    if self._serial and not self._use_dbus:
+      try:
+        self._serial.reset_input_buffer()
+      except (OSError, serial.SerialException, termios.error):
+        self._reconnect_serial()
     for line in self.query(f'AT+CCHO="{ISDR_AID}"'):
       if line.startswith("+CCHO:") and (ch := line.split(":", 1)[1].strip()):
         self.channel = ch
         return
     raise RuntimeError("Failed to open ISD-R application")
 
-  def send_apdu(self, apdu: bytes) -> tuple[bytes, int, int]:
-    if not self.channel:
-      raise RuntimeError("Logical channel is not open")
-    hex_payload = apdu.hex().upper()
-    for line in self.query(f'AT+CGLA={self.channel},{len(hex_payload)},"{hex_payload}"'):
-      if line.startswith("+CGLA:"):
-        parts = line.split(":", 1)[1].split(",", 1)
-        if len(parts) == 2:
-          data = bytes.fromhex(parts[1].strip().strip('"'))
-          if len(data) >= 2:
-            return data[:-2], data[-2], data[-1]
-    raise RuntimeError("Missing +CGLA response")
+  def open_isdr(self) -> None:
+    for attempt in range(10):
+      try:
+        self._open_isdr_once()
+        return
+      except (RuntimeError, TimeoutError, termios.error) as e:
+        if self.debug:
+          print(f"open_isdr failed, trying again", file=sys.stderr)
+        if attempt == 3:
+          # SIM may be stuck (CME ERROR 13) — reset modem via lte.sh
+          subprocess.run(['/usr/comma/lte/lte.sh', 'start'], capture_output=True)
+          time.sleep(5)
+          self._reconnect_serial()
+        else:
+          time.sleep(2.0)
+    raise RuntimeError("Failed to open ISD-R after retries")
+
+  def send_apdu(self, apdu: bytes, max_retries: int = 3) -> tuple[bytes, int, int]:
+    for attempt in range(max_retries):
+      try:
+        if not self.channel:
+          self.open_isdr()
+        hex_payload = apdu.hex().upper()
+        for line in self.query(f'AT+CGLA={self.channel},{len(hex_payload)},"{hex_payload}"'):
+          if line.startswith("+CGLA:"):
+            parts = line.split(":", 1)[1].split(",", 1)
+            if len(parts) == 2:
+              data = bytes.fromhex(parts[1].strip().strip('"'))
+              if len(data) >= 2:
+                return data[:-2], data[-2], data[-1]
+        raise RuntimeError("Missing +CGLA response")
+      except (RuntimeError, ValueError):
+        self.channel = None
+        if attempt == max_retries - 1:
+          raise
+        time.sleep(1 + attempt)
+    raise RuntimeError("send_apdu failed")
 
 
 # --- TLV utilities ---

--- a/system/hardware/tici/lpa.py
+++ b/system/hardware/tici/lpa.py
@@ -47,9 +47,6 @@ class AtClient:
     self._timeout = timeout
     self._serial: serial.Serial | None = None
     self._use_dbus = not os.path.exists(device)
-    if self.debug:
-      transport = "DBUS" if self._use_dbus else "serial"
-      print(f"AtClient: using {transport} transport", file=sys.stderr)
 
   def close(self) -> None:
     try:
@@ -152,9 +149,9 @@ class AtClient:
       try:
         self._open_isdr_once()
         return
-      except (RuntimeError, TimeoutError, termios.error) as e:
+      except (RuntimeError, TimeoutError, termios.error):
         if self.debug:
-          print(f"open_isdr failed, trying again", file=sys.stderr)
+          print("open_isdr failed, trying again", file=sys.stderr)
         if attempt == 3:
           # SIM may be stuck (CME ERROR 13) — reset modem via lte.sh
           subprocess.run(['/usr/comma/lte/lte.sh', 'start'], capture_output=True)

--- a/system/hardware/tici/lpa.py
+++ b/system/hardware/tici/lpa.py
@@ -23,7 +23,7 @@ ISDR_AID = "A0000005591010FFFFFFFF8900000100"
 MM = "org.freedesktop.ModemManager1"
 MM_MODEM = MM + ".Modem"
 ES10X_MSS = 120
-DEBUG = True
+DEBUG = os.environ.get("DEBUG") == "1"
 
 # TLV Tags
 TAG_ICCID = 0x5A

--- a/system/hardware/tici/lpa.py
+++ b/system/hardware/tici/lpa.py
@@ -12,6 +12,7 @@ import time
 
 from collections.abc import Generator
 
+from openpilot.common.swaglog import cloudlog
 from openpilot.system.hardware.base import LPABase, Profile
 
 
@@ -39,8 +40,7 @@ def b64e(data: bytes) -> str:
 
 
 class AtClient:
-  def __init__(self, device: str, baud: int, timeout: float, debug: bool) -> None:
-    self.debug = debug
+  def __init__(self, device: str, baud: int, timeout: float) -> None:
     self.channel: str | None = None
     self._device = device
     self._baud = baud
@@ -61,7 +61,7 @@ class AtClient:
         self._serial.close()
 
   def _send(self, cmd: str) -> None:
-    if self.debug:
+    if DEBUG:
       print(f"SER >> {cmd}", file=sys.stderr)
     self._serial.write((cmd + "\r").encode("ascii"))
 
@@ -74,7 +74,7 @@ class AtClient:
       line = raw.decode(errors="ignore").strip()
       if not line:
         continue
-      if self.debug:
+      if DEBUG:
         print(f"SER << {line}", file=sys.stderr)
       if line == "OK":
         return lines
@@ -100,14 +100,14 @@ class AtClient:
     return bus.get_object(MM, modem_path)
 
   def _dbus_query(self, cmd: str) -> list[str]:
-    if self.debug:
+    if DEBUG:
       print(f"DBUS >> {cmd}", file=sys.stderr)
     try:
       result = str(self._get_modem().Command(cmd, math.ceil(self._timeout), dbus_interface=MM_MODEM, timeout=self._timeout))
     except Exception as e:
       raise RuntimeError(f"AT command failed: {e}") from e
     lines = [line.strip() for line in result.splitlines() if line.strip()]
-    if self.debug:
+    if DEBUG:
       for line in lines:
         print(f"DBUS << {line}", file=sys.stderr)
     return lines
@@ -150,8 +150,7 @@ class AtClient:
         self._open_isdr_once()
         return
       except (RuntimeError, TimeoutError, termios.error):
-        if self.debug:
-          print("open_isdr failed, trying again", file=sys.stderr)
+        cloudlog.warning("open_isdr attempt %d failed, retrying", attempt + 1)
         if attempt == 3:
           # SIM may be stuck (CME ERROR 13) — reset modem via lte.sh
           subprocess.run(['/usr/comma/lte/lte.sh', 'start'], capture_output=True)
@@ -302,7 +301,7 @@ class TiciLPA(LPABase):
   def __init__(self):
     if hasattr(self, '_client'):
       return
-    self._client = AtClient(DEFAULT_DEVICE, DEFAULT_BAUD, DEFAULT_TIMEOUT, debug=DEBUG)
+    self._client = AtClient(DEFAULT_DEVICE, DEFAULT_BAUD, DEFAULT_TIMEOUT)
     self._client.open_isdr()
     atexit.register(self._client.close)
 

--- a/system/hardware/tici/lpa.py
+++ b/system/hardware/tici/lpa.py
@@ -23,6 +23,10 @@ ISDR_AID = "A0000005591010FFFFFFFF8900000100"
 MM = "org.freedesktop.ModemManager1"
 MM_MODEM = MM + ".Modem"
 ES10X_MSS = 120
+OPEN_ISDR_RETRIES = 10
+OPEN_ISDR_RETRY_DELAY_S = 0.25
+OPEN_ISDR_RESET_ATTEMPT = 5
+SEND_APDU_RETRIES = 3
 DEBUG = os.environ.get("DEBUG") == "1"
 
 # TLV Tags
@@ -146,24 +150,20 @@ class AtClient:
     raise RuntimeError("Failed to open ISD-R application")
 
   def open_isdr(self) -> None:
-    for attempt in range(10):
+    for attempt in range(OPEN_ISDR_RETRIES):
       try:
         self._open_isdr_once()
         return
-      except (RuntimeError, TimeoutError, termios.error):
-        from openpilot.common.swaglog import cloudlog
-        cloudlog.warning("open_isdr attempt %d failed, retrying", attempt + 1)
-        if attempt == 3:
-          # SIM may be stuck (CME ERROR 13) — reset modem via lte.sh
+      except (RuntimeError, TimeoutError, termios.error, serial.SerialException):
+        time.sleep(OPEN_ISDR_RETRY_DELAY_S)
+        if attempt == OPEN_ISDR_RESET_ATTEMPT:
+          # reset modem via lte.sh
           subprocess.run(['/usr/comma/lte/lte.sh', 'start'], capture_output=True)
-          time.sleep(5)
-          self._ensure_serial(reconnect=True)
-        else:
-          time.sleep(2.0)
+          self._serial = None  # serial port will be re-opened on next attempt
     raise RuntimeError("Failed to open ISD-R after retries")
 
-  def send_apdu(self, apdu: bytes, max_retries: int = 3) -> tuple[bytes, int, int]:
-    for attempt in range(max_retries):
+  def send_apdu(self, apdu: bytes) -> tuple[bytes, int, int]:
+    for attempt in range(SEND_APDU_RETRIES):
       try:
         if not self.channel:
           self.open_isdr()
@@ -178,9 +178,8 @@ class AtClient:
         raise RuntimeError("Missing +CGLA response")
       except (RuntimeError, ValueError):
         self.channel = None
-        if attempt == max_retries - 1:
+        if attempt == SEND_APDU_RETRIES - 1:
           raise
-        time.sleep(1 + attempt)
     raise RuntimeError("send_apdu failed")
 
 

--- a/system/hardware/tici/lpa.py
+++ b/system/hardware/tici/lpa.py
@@ -12,7 +12,6 @@ import time
 
 from collections.abc import Generator
 
-from openpilot.common.swaglog import cloudlog
 from openpilot.system.hardware.base import LPABase, Profile
 
 
@@ -150,6 +149,7 @@ class AtClient:
         self._open_isdr_once()
         return
       except (RuntimeError, TimeoutError, termios.error):
+        from openpilot.common.swaglog import cloudlog
         cloudlog.warning("open_isdr attempt %d failed, retrying", attempt + 1)
         if attempt == 3:
           # SIM may be stuck (CME ERROR 13) — reset modem via lte.sh


### PR DESCRIPTION
split from https://github.com/commaai/openpilot/pull/37742

## Summary
- AtClient: lazy serial open, `_ensure_serial(reconnect)` for recovery, retry in `query` on `SerialException`
- `open_isdr`: retry loop (10 attempts, 250ms backoff, lte.sh modem reset at attempt 5)
- `send_apdu`: retry loop (3 attempts, auto-reopen channel on failure)
- Retry/delay constants extracted to top of file
- `DEBUG` gated by env var instead of hardcoded `True`
- `esim.py`: remove redundant modem reboot (handled internally by LPA now)

## Test plan

Deployed to mici and tizi, ran 30x `list_profiles` stress test on both devices.

### mici (comma mici, 725dfb9b) - 30/30 OK
```
[ 1] 4 profiles  active=mobi1     0.11s  OK
...
[30] 4 profiles  active=mobi1     0.09s  OK
Total: 30/30 OK, 0 failures
```

### tizi (comma tizi, bb546e42) - 30/30 OK
```
[ 1] 3 profiles  active=mm1       0.11s  OK
...
[30] 3 profiles  active=mm1       0.08s  OK
Total: 30/30 OK, 0 failures
```