### PR TITLE
autodetect tg backend: use CPU:LLVM on Linux

### DIFF
--- a/selfdrive/modeld/SConscript
+++ b/selfdrive/modeld/SConscript
@@ -26,7 +26,7 @@ elif 'QCOM' in available:
   tg_backend = 'QCOM'
   tg_flags = f'DEV={tg_backend} FLOAT16=1 NOLOCALS=1 JIT_BATCH_SIZE=0'
 else:
-  tg_backend = 'CPU'
+  tg_backend = 'CPU' if arch == 'Darwin' else 'CPU:LLVM'
   tg_flags = f'DEV={tg_backend} THREADS=0'
 
 def write_tg_compiled_flags(target, source, env):


### PR DESCRIPTION
## Summary
- CPU fallback uses `CPU:LLVM` on Linux instead of `CPU` (which needs clang)
- Keeps `CPU` on Darwin where LLVM isn't available

## Test plan
- [x] Verified model compilation works in CI docker with CUDA backend
- [ ] CI passes on runners without GPU (CPU:LLVM fallback)