### PR TITLE
soundd: update volume while playing alert

### DIFF
--- a/selfdrive/ui/soundd.py
+++ b/selfdrive/ui/soundd.py
@@ -155,7 +155,8 @@ class Soundd:
       while True:
         sm.update(0)
 
-        if sm.updated['soundPressure'] and self.current_alert == AudibleAlert.none: # only update volume filter when not playing alert
+        # Always update volume, even when alert is playing
+        if sm.updated['soundPressure']:
           self.spl_filter_weighted.update(sm["soundPressure"].soundPressureWeightedDb)
           self.current_volume = self.calculate_volume(float(self.spl_filter_weighted.x))
 


### PR DESCRIPTION
the speaker playing the DM warning sound (not unresponsive alert) is not enough to raise the volume noticeably on comma four, so probably fine to always learn now. from https://github.com/commaai/openpilot/pull/37788