### PR TITLE
installer: update cached remote URL during fork installs

### DIFF
--- a/selfdrive/ui/installer/installer.cc
+++ b/selfdrive/ui/installer/installer.cc
@@ -144,6 +144,7 @@ int cachedFetch(const std::string &cache) {
   LOGD("Fetching with cache: %s", cache.c_str());
 
   run(util::string_format("cp -rp %s %s", cache.c_str(), TMP_INSTALL_PATH).c_str());
+  run(util::string_format("cd %s && git remote set-url origin %s", TMP_INSTALL_PATH, GIT_URL.c_str()).c_str());
   run(util::string_format("cd %s && git remote set-branches --add origin %s", TMP_INSTALL_PATH, migrated_branch.c_str()).c_str());
 
   renderProgress(10);


### PR DESCRIPTION
**Description**
- Added `git remote set-url` during `cachedFetch` to update the origin to the correct fork URL before fetching.
- On comma devices with a preloaded or newly reflashed AGNOS, the cached openpilot repo ships with its remote set to `commaai/openpilot`. When a user installs a fork via custom URL, `cachedFetch` reuses this remote instead of the fork URL, causing the fetch to fail at 10% if the branch doesn't exist in `commaai/openpilot`.
- This only affects first-time fork installations on freshly shipped or reflashed devices that have the preloaded cache.