### PR TITLE
cruise: fix test_cruise_speed assertion

### DIFF
--- a/selfdrive/car/tests/test_cruise_speed.py
+++ b/selfdrive/car/tests/test_cruise_speed.py
@@ -93,7 +93,7 @@ class TestVCruiseHelper:
         self.enable(V_CRUISE_INITIAL * CV.KPH_TO_MS, False)
 
       # Expected diff on enabling. Speed should not change on falling edge of pressed
-      assert not pressed == self.v_cruise_helper.v_cruise_kph == self.v_cruise_helper.v_cruise_kph_last
+      assert (not pressed) == (self.v_cruise_helper.v_cruise_kph == self.v_cruise_helper.v_cruise_kph_last)
 
   def test_resume_in_standstill(self):
     """


### PR DESCRIPTION
Operator precedence made this assertion vacuous:

```python
assert not pressed == self.v_cruise_helper.v_cruise_kph == self.v_cruise_helper.v_cruise_kph_last
```

Parses as `not (pressed == v_cruise_kph == v_cruise_kph_last)`, a chained equality between a bool and two kph values. Since `v_cruise_kph` is 40 after enabling, the inner chain is always False, so the assert always passes.