### PR TITLE
Set fan to 100% when thermally blocked onroad

### DIFF
--- a/system/hardware/hardwared.py
+++ b/system/hardware/hardwared.py
@@ -323,6 +323,9 @@ def hardware_thread(end_event, hw_queue) -> None:
     show_alert = (not onroad_conditions["device_temp_good"] or not startup_conditions["device_temp_engageable"]) and onroad_conditions["ignition"]
     set_offroad_alert_if_changed("Offroad_TemperatureTooHigh", show_alert, extra_text=extra_text)
 
+    if show_alert:
+      msg.deviceState.fanSpeedPercentDesired = 100
+
     # *** registration check ***
     if not PC:
       # we enforce this for our software, but you are welcome
@@ -421,9 +424,10 @@ def hardware_thread(end_event, hw_queue) -> None:
     statlog.gauge("fan_speed_percent_desired", msg.deviceState.fanSpeedPercentDesired)
     statlog.gauge("screen_brightness_percent", msg.deviceState.screenBrightnessPercent)
 
-    # report to server once every 10 minutes
+    # report to server once every 10 minutes, or every 1s when thermally blocked
     rising_edge_started = should_start and not should_start_prev
-    if rising_edge_started or (count % int(600. / DT_HW)) == 0:
+    status_packet_interval = 1. if show_alert else 600.
+    if rising_edge_started or (count % int(status_packet_interval / DT_HW)) == 0:
       dat = {
         'count': count,
         'pandaStates': [strip_deprecated_keys(p.to_dict()) for p in pandaStates],


### PR DESCRIPTION
When the device is too hot to go ONROAD or overheating while ONROAD:
- Force fan to 100% to recover as fast as possible
- Log STATUS_PACKET every 1s instead of 10min to capture thermal recovery and detect car moving to see forced convection cooling effect on the windshield