### PR TITLE
add bridge target to cabana run script

### DIFF
--- a/tools/cabana/cabana
+++ b/tools/cabana/cabana
@@ -33,6 +33,6 @@ fi
 
 # Build _cabana
 cd "$ROOT"
-scons -j4 tools/cabana/_cabana
+scons -j4 tools/cabana/_cabana cereal/messaging/bridge
 
 exec "$DIR/_cabana" "$@"


### PR DESCRIPTION
The cabana run script builds for convenience, but omitted the cereal/messaging/bridge dependency needed for streaming.