### PR TITLE
Add touch zone for alerts

### DIFF
--- a/selfdrive/ui/mici/layouts/home.py
+++ b/selfdrive/ui/mici/layouts/home.py
@@ -14,6 +14,7 @@ from openpilot.system.version import RELEASE_BRANCHES
 
 HEAD_BUTTON_FONT_SIZE = 40
 HOME_PADDING = 8
+TOUCH_ZONE_WIDTH = 200
 
 NetworkType = log.DeviceState.NetworkType
 
@@ -84,6 +85,7 @@ class MiciHomeLayout(Widget):
   def __init__(self):
     super().__init__()
     self._on_settings_click: Callable | None = None
+    self._on_alerts_click: Callable | None = None
 
     self._last_refresh = 0
     self._mouse_down_t: None | float = None
@@ -141,13 +143,19 @@ class MiciHomeLayout(Widget):
       self._last_refresh = rl.get_time()
       self._update_params()
 
-  def set_callbacks(self, on_settings: Callable | None = None):
+  def set_callbacks(self, on_settings: Callable | None = None, on_alerts: Callable | None = None):
     self._on_settings_click = on_settings
+    self._on_alerts_click = on_alerts
 
   def _handle_mouse_release(self, mouse_pos: MousePos):
     if not self._did_long_press:
-      if self._on_settings_click:
-        self._on_settings_click()
+      relative_x = mouse_pos.x - self.rect.x
+      if relative_x < TOUCH_ZONE_WIDTH:
+        if self._on_settings_click:
+          self._on_settings_click()
+      elif relative_x > self.rect.width - TOUCH_ZONE_WIDTH:
+        if self._on_alerts_click:
+          self._on_alerts_click()
     self._did_long_press = False
 
   def _get_version_text(self) -> tuple[str, str, str, str] | None:

--- a/selfdrive/ui/mici/layouts/home.py
+++ b/selfdrive/ui/mici/layouts/home.py
@@ -14,6 +14,7 @@ from openpilot.system.version import RELEASE_BRANCHES
 
 HEAD_BUTTON_FONT_SIZE = 40
 HOME_PADDING = 8
+TOUCH_ZONE_WIDTH = 200
 
 NetworkType = log.DeviceState.NetworkType
 
@@ -182,15 +183,14 @@ class MiciHomeLayout(Widget):
 
   def _handle_mouse_release(self, mouse_pos: MousePos):
     if not self._did_long_press:
-      pad = 50
-      pill = self._alerts_pill.rect
-      pill_touch = rl.Rectangle(pill.x - pad, pill.y - pad, pill.width + pad * 2, pill.height + pad * 2)
+      relative_x = mouse_pos.x - self.rect.x
       has_alerts = self._alert_count_callback and self._alert_count_callback() > 0
-      if has_alerts and rl.check_collision_point_rec(mouse_pos, pill_touch):
+      if relative_x < TOUCH_ZONE_WIDTH:
+        if self._on_settings_click:
+          self._on_settings_click()
+      elif has_alerts and relative_x > self.rect.width - TOUCH_ZONE_WIDTH:
         if self._on_alerts_click:
           self._on_alerts_click()
-      elif self._on_settings_click:
-        self._on_settings_click()
     self._did_long_press = False
 
   def _get_version_text(self) -> tuple[str, str, str, str] | None:

--- a/selfdrive/ui/mici/layouts/home.py
+++ b/selfdrive/ui/mici/layouts/home.py
@@ -14,8 +14,8 @@ from openpilot.system.version import RELEASE_BRANCHES
 
 HEAD_BUTTON_FONT_SIZE = 40
 HOME_PADDING = 8
-SETTINGS_ZONE_WIDTH = 268
-ALERTS_ZONE_WIDTH = 160
+SETTINGS_ZONE_WIDTH = 280
+ALERTS_ZONE_WIDTH = 180
 
 NetworkType = log.DeviceState.NetworkType
 

--- a/selfdrive/ui/mici/layouts/home.py
+++ b/selfdrive/ui/mici/layouts/home.py
@@ -14,7 +14,6 @@ from openpilot.system.version import RELEASE_BRANCHES
 
 HEAD_BUTTON_FONT_SIZE = 40
 HOME_PADDING = 8
-TOUCH_ZONE_WIDTH = 200
 
 NetworkType = log.DeviceState.NetworkType
 
@@ -178,17 +177,20 @@ class MiciHomeLayout(Widget):
                     alert_count_callback: Callable[[], int] | None = None):
     self._on_settings_click = on_settings
     self._on_alerts_click = on_alerts
+    self._alert_count_callback = alert_count_callback
     self._alerts_pill.set_alert_count_callback(alert_count_callback)
 
   def _handle_mouse_release(self, mouse_pos: MousePos):
     if not self._did_long_press:
-      relative_x = mouse_pos.x - self.rect.x
-      if relative_x < TOUCH_ZONE_WIDTH:
-        if self._on_settings_click:
-          self._on_settings_click()
-      elif relative_x > self.rect.width - TOUCH_ZONE_WIDTH:
+      pad = 50
+      pill = self._alerts_pill.rect
+      pill_touch = rl.Rectangle(pill.x - pad, pill.y - pad, pill.width + pad * 2, pill.height + pad * 2)
+      has_alerts = self._alert_count_callback and self._alert_count_callback() > 0
+      if has_alerts and rl.check_collision_point_rec(mouse_pos, pill_touch):
         if self._on_alerts_click:
           self._on_alerts_click()
+      elif self._on_settings_click:
+        self._on_settings_click()
     self._did_long_press = False
 
   def _get_version_text(self) -> tuple[str, str, str, str] | None:

--- a/selfdrive/ui/mici/layouts/home.py
+++ b/selfdrive/ui/mici/layouts/home.py
@@ -14,7 +14,8 @@ from openpilot.system.version import RELEASE_BRANCHES
 
 HEAD_BUTTON_FONT_SIZE = 40
 HOME_PADDING = 8
-TOUCH_ZONE_WIDTH = 200
+SETTINGS_ZONE_WIDTH = 268
+ALERTS_ZONE_WIDTH = 160
 
 NetworkType = log.DeviceState.NetworkType
 
@@ -185,10 +186,10 @@ class MiciHomeLayout(Widget):
     if not self._did_long_press:
       relative_x = mouse_pos.x - self.rect.x
       has_alerts = self._alert_count_callback and self._alert_count_callback() > 0
-      if relative_x < TOUCH_ZONE_WIDTH:
+      if relative_x < SETTINGS_ZONE_WIDTH:
         if self._on_settings_click:
           self._on_settings_click()
-      elif has_alerts and relative_x > self.rect.width - TOUCH_ZONE_WIDTH:
+      elif has_alerts and relative_x > self.rect.width - ALERTS_ZONE_WIDTH:
         if self._on_alerts_click:
           self._on_alerts_click()
     self._did_long_press = False

--- a/selfdrive/ui/mici/layouts/main.py
+++ b/selfdrive/ui/mici/layouts/main.py
@@ -58,7 +58,10 @@ class MiciMainLayout(Scroller):
       gui_app.push_widget(self._onboarding_window)
 
   def _setup_callbacks(self):
-    self._home_layout.set_callbacks(on_settings=lambda: gui_app.push_widget(self._settings_layout))
+    self._home_layout.set_callbacks(
+      on_settings=lambda: gui_app.push_widget(self._settings_layout),
+      on_alerts=lambda: self._scroll_to(self._alerts_layout),
+    )
     self._onroad_layout.set_click_callback(lambda: self._scroll_to(self._home_layout))
     device.add_interactive_timeout_callback(self._on_interactive_timeout)
 


### PR DESCRIPTION
Implements touch zone to switch to alerts view.
280px from left border for settings
180px from right border for alerts
Long press anywhere still toggles experimental mode.


<img width="536" height="240" alt="padding3" src="https://github.com/user-attachments/assets/0e3819e0-7736-4b98-9729-4c152e555667" />
