### PR TITLE
`UI`: add temperature_widget + warning when engaging during overheat state

### DIFF
--- a/selfdrive/selfdrived/events.py
+++ b/selfdrive/selfdrived/events.py
@@ -336,6 +336,13 @@ def overheat_alert(CP: car.CarParams, CS: car.CarState, sm: messaging.SubMaster,
   return NormalPermanentAlert("System Overheated", f"{temp:.0f} °C")
 
 
+def overheat_no_entry_alert(CP: car.CarParams, CS: car.CarState, sm: messaging.SubMaster, metric: bool, soft_disable_time: int, personality) -> Alert:
+  cpu = max(sm['deviceState'].cpuTempC, default=0.)
+  gpu = max(sm['deviceState'].gpuTempC, default=0.)
+  temp = max((cpu, gpu, sm['deviceState'].memoryTempC))
+  return NoEntryAlert(f"System Overheated ({temp:.0f} °C). Allow device to cool.")
+
+
 def low_memory_alert(CP: car.CarParams, CS: car.CarState, sm: messaging.SubMaster, metric: bool, soft_disable_time: int, personality) -> Alert:
   return NormalPermanentAlert("Low Memory", f"{sm['deviceState'].memoryUsagePercent}% used")
 
@@ -795,7 +802,7 @@ EVENTS: dict[int, dict[str, Alert | AlertCallbackType]] = {
   EventName.overheat: {
     ET.PERMANENT: overheat_alert,
     ET.SOFT_DISABLE: soft_disable_alert("System Overheated"),
-    ET.NO_ENTRY: NoEntryAlert("System Overheated"),
+    ET.NO_ENTRY: overheat_no_entry_alert,
   },
 
   EventName.wrongGear: {

--- a/selfdrive/ui/mici/layouts/home.py
+++ b/selfdrive/ui/mici/layouts/home.py
@@ -16,6 +16,7 @@ HEAD_BUTTON_FONT_SIZE = 40
 HOME_PADDING = 8
 
 NetworkType = log.DeviceState.NetworkType
+ThermalStatus = log.DeviceState.ThermalStatus
 
 NETWORK_TYPES = {
   NetworkType.none: "Offline",
@@ -80,6 +81,36 @@ class NetworkIcon(Widget):
     rl.draw_texture_ex(draw_net_txt, rl.Vector2(draw_x, draw_y), 0.0, 1.0, rl.Color(255, 255, 255, int(255 * 0.9)))
 
 
+class TemperatureStatus(Widget):
+  def __init__(self):
+    super().__init__()
+    self.set_rect(rl.Rectangle(0, 0, 110, 44))
+    self._label = "TEMP OK"
+    self._color = rl.Color(218, 202, 37, int(255 * 0.9))
+
+  def _update_state(self):
+    thermal_status = ui_state.sm['deviceState'].thermalStatus
+
+    if thermal_status == ThermalStatus.green:
+      self._label = "TEMP GOOD"
+      self._color = rl.Color(255, 255, 255, int(255 * 0.9))
+    elif thermal_status == ThermalStatus.yellow:
+      self._label = "TEMP OK"
+      self._color = rl.Color(218, 202, 37, int(255 * 0.9))
+    else:
+      self._label = "TEMP HIGH"
+      self._color = rl.Color(201, 34, 49, int(255 * 0.9))
+
+  def _render(self, _):
+    font = gui_app.font(FontWeight.SEMI_BOLD)
+    text_size = rl.measure_text_ex(font, self._label, 28, 0)
+    pos = rl.Vector2(
+      self._rect.x + (self._rect.width - text_size.x) / 2,
+      self._rect.y + (self._rect.height - text_size.y) / 2,
+    )
+    rl.draw_text_ex(font, self._label, pos, 28, 0, self._color)
+
+
 class MiciHomeLayout(Widget):
   def __init__(self):
     super().__init__()
@@ -99,6 +130,7 @@ class MiciHomeLayout(Widget):
     self._status_bar_layout = HBoxLayout([
       IconWidget("icons_mici/settings.png", (48, 48), opacity=0.9),
       NetworkIcon(),
+      TemperatureStatus(),
       self._experimental_icon,
       self._mic_icon,
     ], spacing=18)


### PR DESCRIPTION
This is an initial PR that adds a basic widget to off-road that shows temperature state just like the TICI has, it also prevents drivers from engaging when it's in overheat state

In draft since UI isn't quite elegant yet.

<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Fingerprint *****

**Car**
Which car (make, model, year) this fingerprint is for

**Route**
A route with the fingerprint

-->

<!--- ***** Template: Car Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 

**Route**

Route: [a route with the bug fix]


-->

<!--- ***** Template: Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 


-->

<!--- ***** Template: Car Port *****

**Checklist**

- [ ] added entry to CAR in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:
- [ ] car harness used (if comma doesn't sell it, put N/A):


-->

<!--- ***** Template: Refactor *****

**Description**

A description of the refactor, including the goals it accomplishes. 

**Verification**

Explain how you tested the refactor for regressions. 


-->

