### PR TITLE
fix compare_logs crash on list field size changes

### DIFF
--- a/selfdrive/test/process_replay/compare_logs.py
+++ b/selfdrive/test/process_replay/compare_logs.py
@@ -76,7 +76,7 @@ def _diff_capnp_values(v1, v2, path, tolerance):
     for i in range(n):
       yield from _diff_capnp_values(v1[i], v2[i], path + (str(i),), tolerance)
     if n2 > n:
-      yield 'add', dot, list(enumerate(v2[n:], n))
+      yield 'add', dot, [(i, v2[i]) for i in range(n, n2)]
     if n1 > n:
       yield 'remove', dot, list(reversed([(i, v1[i]) for i in range(n, n1)]))
 

--- a/selfdrive/test/process_replay/diff_report.py
+++ b/selfdrive/test/process_replay/diff_report.py
@@ -49,6 +49,8 @@ def diff_format(diffs, ref, new, field) -> list[str]:
   msg_type = field.split(".")[0]
   ref_ts = [(m.logMonoTime, MsgWrap(m)) for m in ref.get(msg_type, [])]
   new_wrapped = [MsgWrap(m) for m in new.get(msg_type, [])]
+  if not ref_ts or not new_wrapped:
+    return format_numeric_diffs(diffs)
   return format_diff(diffs, ref_ts, new_wrapped, field)
 
 


### PR DESCRIPTION
Fix compare_logs crash when a list field changes size between ref and PR.: #37824
Suppressed by process_replay but surfaced by diff_report comment.

Also guard diff_report against top-level Event fields passed in this case, format them numerically instead of binary.