### PR TITLE
updated: complete branch migration dict for mici and tizi

### DIFF
--- a/system/updated/tests/test_updated.py
+++ b/system/updated/tests/test_updated.py
@@ -1,0 +1,38 @@
+import pytest
+
+from openpilot.common.params import Params
+from openpilot.system.updated.updated import Updater
+
+
+@pytest.mark.parametrize(("device_type", "branch", "expected"), [
+  ("tizi", "release3", "release-tizi"),
+  ("tizi", "release3-staging", "release-tizi-staging"),
+  ("mici", "release3", "release-mici"),
+  ("mici", "release3-staging", "release-mici-staging"),
+])
+def test_target_branch_migration_from_current_branch(mocker, device_type, branch, expected):
+  params = Params()
+  params.remove("UpdaterTargetBranch")
+
+  mocker.patch("openpilot.system.updated.updated.HARDWARE.get_device_type", return_value=device_type)
+  mocker.patch.object(Updater, "get_branch", return_value=branch)
+
+  assert Updater().target_branch == expected
+
+
+@pytest.mark.parametrize(("device_type", "branch", "expected"), [
+  ("tizi", "release3", "release-tizi"),
+  ("tizi", "release3-staging", "release-tizi-staging"),
+  ("mici", "release3", "release-mici"),
+  ("mici", "release3-staging", "release-mici-staging"),
+])
+def test_target_branch_migration_from_param(mocker, device_type, branch, expected):
+  params = Params()
+  params.put("UpdaterTargetBranch", branch)
+
+  mocker.patch("openpilot.system.updated.updated.HARDWARE.get_device_type", return_value=device_type)
+
+  try:
+    assert Updater().target_branch == expected
+  finally:
+    params.remove("UpdaterTargetBranch")

--- a/system/updated/updated.py
+++ b/system/updated/updated.py
@@ -244,6 +244,9 @@ class Updater:
       b = self.get_branch(BASEDIR)
     b = {
       ("tizi", "release3"): "release-tizi",
+      ("tizi", "release3-staging"): "release-tizi-staging",
+      ("mici", "release3"): "release-mici",
+      ("mici", "release3-staging"): "release-mici-staging",
     }.get((HARDWARE.get_device_type(), b), b)
     return b
 


### PR DESCRIPTION
The PR I made a while back #37719 led me down a rabbit hole regarding TIZI and MICI installation checks.
installer.cc seems to have some branch mappings for release3 that don't appear in updated.py

- In August 26, 2025 in commit 8450f9f33 tici mappings were added to the target_branch function as well as a single TIZI entry
- Two days later on August 28, 2025 commit 3e2549f2b, all tici entries were removed leaving only ("tizi", "release3") -> "release-tizi"
- Then, on October 16, 2025, commit e1ad4daf8 added branch migration to installer.cc. 
system/version.py was changed to recognize release-tizi-staging as a release branch as well. However, updated.py was not changed.

**_I suspect the target_branch function in updated.py was supposed to have the staging branches added like they were in installer.cc_**

I've also provided a test for the target_branch function in updated.py