### PR TITLE
use warning as alert icon

### DIFF
--- a/selfdrive/ui/mici/layouts/home.py
+++ b/selfdrive/ui/mici/layouts/home.py
@@ -8,7 +8,7 @@ from openpilot.system.ui.widgets import Widget
 from openpilot.system.ui.widgets.layouts import HBoxLayout
 from openpilot.system.ui.widgets.icon_widget import IconWidget
 from openpilot.system.ui.widgets.label import UnifiedLabel, gui_label
-from openpilot.system.ui.lib.application import gui_app, FontWeight, MousePos, DEFAULT_TEXT_COLOR
+from openpilot.system.ui.lib.application import gui_app, FontWeight, MousePos
 from openpilot.selfdrive.ui.ui_state import ui_state
 from openpilot.system.version import RELEASE_BRANCHES
 
@@ -31,12 +31,15 @@ NETWORK_TYPES = {
 
 
 class AlertsPill(Widget):
+  ICON_OFFSET = 12
+  COUNT_OFFSET = 40
+
   def __init__(self):
     super().__init__()
     self.set_rect(rl.Rectangle(0, 0, 104, 52))
 
     self._pill_bg_txt = gui_app.texture("icons_mici/alerts_pill.png", 104, 52)
-    self._bell_txt = gui_app.texture("icons_mici/alerts_bell.png", 28, 30)
+    self._warning_txt = gui_app.texture("icons_mici/offroad_alerts/red_warning.png", 36, 36)
     self._alert_count_callback: Callable[[], int] | None = None
 
   def set_alert_count_callback(self, callback: Callable[[], int] | None):
@@ -48,13 +51,13 @@ class AlertsPill(Widget):
       pill_w, pill_h = self._pill_bg_txt.width, self._pill_bg_txt.height
       rl.draw_texture_ex(self._pill_bg_txt, rl.Vector2(self.rect.x, self.rect.y), 0.0, 1.0, rl.WHITE)
 
-      bell_x = self.rect.x + 20
-      bell_y = self.rect.y + (pill_h - self._bell_txt.height) / 2
-      rl.draw_texture_ex(self._bell_txt, rl.Vector2(bell_x, bell_y), 0.0, 1.0, DEFAULT_TEXT_COLOR)
+      warn_x = self.rect.x + self.ICON_OFFSET
+      warn_y = self.rect.y + (pill_h - self._warning_txt.height) / 2
+      rl.draw_texture_ex(self._warning_txt, rl.Vector2(warn_x, warn_y), 0.0, 1.0, rl.WHITE)
 
-      count_rect = rl.Rectangle(self.rect.x, self.rect.y, pill_w - 20, pill_h)
+      count_rect = rl.Rectangle(self.rect.x + self.COUNT_OFFSET, self.rect.y, pill_w - self.COUNT_OFFSET, pill_h)
       gui_label(count_rect, str(alert_count), font_size=36,
-                alignment=rl.GuiTextAlignment.TEXT_ALIGN_RIGHT,
+                alignment=rl.GuiTextAlignment.TEXT_ALIGN_CENTER,
                 alignment_vertical=rl.GuiTextAlignmentVertical.TEXT_ALIGN_MIDDLE)
 
 


### PR DESCRIPTION
Use the the existing `red_warning.png` in the alerts pill to make pending alerts more visually urgent