### PR TITLE
add blocked-startup message

### DIFF
--- a/selfdrive/ui/mici/onroad/augmented_road_view.py
+++ b/selfdrive/ui/mici/onroad/augmented_road_view.py
@@ -174,6 +174,8 @@ class AugmentedRoadView(CameraView):
     # update offroad label
     if ui_state.panda_type == log.PandaState.PandaType.unknown:
       self._offroad_label.set_text("system booting")
+    elif ui_state.ignition and not ui_state.started:
+      self._offroad_label.set_text("openpilot can't start\ncheck alerts")
     else:
       self._offroad_label.set_text("start the car to\nuse openpilot")
 


### PR DESCRIPTION
When ignition is on but openpilot can't go onroad, replace the "start the car to use openpilot" text with "openpilot can't start - check alerts" to point the user at the alerts screen.