### PR TITLE
Fix LSM6DS3 sensors test

### DIFF
--- a/system/sensord/tests/test_sensord.py
+++ b/system/sensord/tests/test_sensord.py
@@ -34,7 +34,7 @@ SensorConfig = namedtuple('SensorConfig', ['type', 'sanity_min', 'sanity_max', '
 ALL_SENSORS = {
   Sensor.lsm6ds3trc: {
     SensorConfig("acceleration", 5, 15),
-    SensorConfig("gyroUncalibrated", 0, .1),
+    SensorConfig("gyroUncalibrated", 0, .15),
     SensorConfig("temperature", 10, 40, 1),  # set for max range of our office
   },
 
@@ -199,7 +199,7 @@ class TestSensord:
 
         key = (sensor, s.type)
         if s.type == 'temperature':
-          measurement_stat = np.mean(sensor_values[key], axis=1)
+          measurement_stat = np.mean(sensor_values[key])
         else:
           measurement_stat = np.mean(np.linalg.norm(sensor_values[key], axis=1))
         err_msg = f"Sensor '{sensor} {s.type}' failed sanity checks {measurement_stat} is not between {s.sanity_min} and {s.sanity_max}"

--- a/system/sensord/tests/test_sensord.py
+++ b/system/sensord/tests/test_sensord.py
@@ -30,12 +30,12 @@ SENSOR_CONFIGURATIONS: list[set] = {
 }.get(HARDWARE.get_device_type(), [])
 
 Sensor = log.SensorEventData.SensorSource
-SensorConfig = namedtuple('SensorConfig', ['type', 'sanity_min', 'sanity_max'])
+SensorConfig = namedtuple('SensorConfig', ['type', 'sanity_min', 'sanity_max', 'std_max'], defaults=[None])
 ALL_SENSORS = {
   Sensor.lsm6ds3trc: {
     SensorConfig("acceleration", 5, 15),
-    SensorConfig("gyroUncalibrated", 0, .2),
-    SensorConfig("temperature", 10, 40),  # set for max range of our office
+    SensorConfig("gyroUncalibrated", 0, .1),
+    SensorConfig("temperature", 10, 40, 1),  # set for max range of our office
   },
 
   Sensor.mmc5603nj: {
@@ -198,9 +198,17 @@ class TestSensord:
           continue
 
         key = (sensor, s.type)
-        mean_norm = np.mean(np.linalg.norm(sensor_values[key], axis=1))
-        err_msg = f"Sensor '{sensor} {s.type}' failed sanity checks {mean_norm} is not between {s.sanity_min} and {s.sanity_max}"
-        assert s.sanity_min <= mean_norm <= s.sanity_max, err_msg
+        if s.type == 'temperature':
+          measurement_stat = np.mean(sensor_values[key], axis=1)
+        else:
+          measurement_stat = np.mean(np.linalg.norm(sensor_values[key], axis=1))
+        err_msg = f"Sensor '{sensor} {s.type}' failed sanity checks {measurement_stat} is not between {s.sanity_min} and {s.sanity_max}"
+        assert s.sanity_min <= measurement_stat <= s.sanity_max, err_msg
+
+        if s.std_max is not None:
+          std_dev = np.std(sensor_values[key], axis=0)
+          err_msg = f"Sensor '{sensor} {s.type}' failed std dev test {std_dev} is not under {s.std_max}"
+          assert np.all(std_dev <= s.std_max), err_msg
 
   def test_sensor_verify_no_interrupts_after_stop(self):
     managed_processes["sensord"].start()

--- a/system/sensord/tests/test_sensord.py
+++ b/system/sensord/tests/test_sensord.py
@@ -230,4 +230,3 @@ class TestSensord:
     time.sleep(1)
     state_two = get_irq_count(self.sensord_irq)
     assert state_one == state_two, "Interrupts received after sensord stop!"
-

--- a/system/sensord/tests/test_sensord.py
+++ b/system/sensord/tests/test_sensord.py
@@ -30,16 +30,16 @@ SENSOR_CONFIGURATIONS: list[set] = {
 }.get(HARDWARE.get_device_type(), [])
 
 Sensor = log.SensorEventData.SensorSource
-SensorConfig = namedtuple('SensorConfig', ['type', 'sanity_min', 'sanity_max', 'std_max'], defaults=[None])
+SensorConfig = namedtuple('SensorConfig', ['type', 'sanity_min', 'sanity_max', 'std_max'])
 ALL_SENSORS = {
   Sensor.lsm6ds3trc: {
-    SensorConfig("acceleration", 5, 15),
-    SensorConfig("gyroUncalibrated", 0, .15),
-    SensorConfig("temperature", 10, 40, 1),  # set for max range of our office
+    SensorConfig("acceleration", 5, 15, 5),
+    SensorConfig("gyroUncalibrated", 0, .15, 0.5),
+    SensorConfig("temperature", 10, 40, 0.5),  # set for max range of our office
   },
 
   Sensor.mmc5603nj: {
-    SensorConfig("magneticUncalibrated", 0, 300),
+    SensorConfig("magneticUncalibrated", 0, 300, 10),
   }
 }
 ALL_SENSORS[Sensor.lsm6ds3] = ALL_SENSORS[Sensor.lsm6ds3trc]
@@ -205,10 +205,9 @@ class TestSensord:
         err_msg = f"Sensor '{sensor} {s.type}' failed sanity checks {measurement_stat} is not between {s.sanity_min} and {s.sanity_max}"
         assert s.sanity_min <= measurement_stat <= s.sanity_max, err_msg
 
-        if s.std_max is not None:
-          std_dev = np.std(sensor_values[key], axis=0)
-          err_msg = f"Sensor '{sensor} {s.type}' failed std dev test {std_dev} is not under {s.std_max}"
-          assert np.all(std_dev <= s.std_max), err_msg
+        std_dev = np.std(sensor_values[key], axis=0)
+        err_msg = f"Sensor '{sensor} {s.type}' failed std dev test {std_dev} is not under {s.std_max}"
+        assert np.all(std_dev <= s.std_max), err_msg
 
   def test_sensor_verify_no_interrupts_after_stop(self):
     managed_processes["sensord"].start()


### PR DESCRIPTION
**Description**
Previously, temperature readout was normalized before range comparison which causes the test to pass the corresponding negative range as well.
We expect the temperature readout of good sensors to be stable within the test period (10s).

- Removes normalization on temperature measurement
- Checks the standard deviation of temperature
- Tightens the allowed gyroscope drift and/or movement during the test

**Verification**
Tests ran on 16 devices passed 50/50 times while a known bad device failed 100/100 times
15 runs on the 16 devices include reasonably shaking the setup. All devices are within the .15 rad/s limit.