### PR TITLE
remove -n auto to reduce the pytest --co to <1s

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,7 +126,7 @@ allow-direct-references = true
 
 [tool.pytest.ini_options]
 minversion = "6.0"
-addopts = "--ignore=openpilot/ --ignore=opendbc/ --ignore=panda/ --ignore=rednose_repo/ --ignore=tinygrad_repo/ --ignore=teleoprtc_repo/ --ignore=msgq/  -Werror --strict-config --strict-markers --durations=10 -n auto --dist=loadgroup"
+addopts = "--ignore=openpilot/ --ignore=opendbc/ --ignore=panda/ --ignore=rednose_repo/ --ignore=tinygrad_repo/ --ignore=teleoprtc_repo/ --ignore=msgq/  -Werror --strict-config --strict-markers --durations=10"
 cpp_files = "test_*"
 cpp_harness = "selfdrive/test/cpp_harness.py"
 python_files = "test_*.py"

--- a/selfdrive/ui/mici/tests/test_widget_leaks.py
+++ b/selfdrive/ui/mici/tests/test_widget_leaks.py
@@ -1,26 +1,6 @@
-import pyray as rl
-rl.set_config_flags(rl.ConfigFlags.FLAG_WINDOW_HIDDEN)
 import gc
 import weakref
 import pytest
-from openpilot.system.ui.lib.application import gui_app
-from openpilot.system.ui.widgets import Widget
-
-# mici dialogs
-from openpilot.selfdrive.ui.mici.layouts.onboarding import TrainingGuide as MiciTrainingGuide, OnboardingWindow as MiciOnboardingWindow
-from openpilot.selfdrive.ui.mici.onroad.driver_camera_dialog import DriverCameraDialog as MiciDriverCameraDialog
-from openpilot.selfdrive.ui.mici.widgets.pairing_dialog import PairingDialog as MiciPairingDialog
-from openpilot.selfdrive.ui.mici.widgets.dialog import BigDialog, BigConfirmationDialog, BigInputDialog
-from openpilot.selfdrive.ui.mici.layouts.settings.device import MiciFccModal
-
-# tici dialogs
-from openpilot.selfdrive.ui.onroad.driver_camera_dialog import DriverCameraDialog as TiciDriverCameraDialog
-from openpilot.selfdrive.ui.layouts.onboarding import OnboardingWindow as TiciOnboardingWindow
-from openpilot.selfdrive.ui.widgets.pairing_dialog import PairingDialog as TiciPairingDialog
-from openpilot.system.ui.widgets.confirm_dialog import ConfirmDialog
-from openpilot.system.ui.widgets.option_dialog import MultiOptionDialog
-from openpilot.system.ui.widgets.html_render import HtmlModal
-from openpilot.system.ui.widgets.keyboard import Keyboard
 
 # FIXME: known small leaks not worth worrying about at the moment
 KNOWN_LEAKS = {
@@ -52,7 +32,8 @@ KNOWN_LEAKS = {
 }
 
 
-def get_child_widgets(widget: Widget) -> list[Widget]:
+def get_child_widgets(widget) -> list:
+  from openpilot.system.ui.widgets import Widget
   children = []
   for val in widget.__dict__.values():
     items = val if isinstance(val, (list, tuple)) else (val,)
@@ -62,6 +43,28 @@ def get_child_widgets(widget: Widget) -> list[Widget]:
 
 @pytest.mark.skip(reason="segfaults")
 def test_dialogs_do_not_leak():
+  # Lazy-load heavy UI imports only when test actually runs.
+  # Since the test is marked as skipped, this code won't run during normal test runs, preventing unnecessary imports and potential side effects.
+  import pyray as rl
+  rl.set_config_flags(rl.ConfigFlags.FLAG_WINDOW_HIDDEN)
+  from openpilot.system.ui.lib.application import gui_app
+
+  # mici dialogs
+  from openpilot.selfdrive.ui.mici.layouts.onboarding import TrainingGuide as MiciTrainingGuide, OnboardingWindow as MiciOnboardingWindow
+  from openpilot.selfdrive.ui.mici.onroad.driver_camera_dialog import DriverCameraDialog as MiciDriverCameraDialog
+  from openpilot.selfdrive.ui.mici.widgets.pairing_dialog import PairingDialog as MiciPairingDialog
+  from openpilot.selfdrive.ui.mici.widgets.dialog import BigDialog, BigConfirmationDialog, BigInputDialog
+  from openpilot.selfdrive.ui.mici.layouts.settings.device import MiciFccModal
+
+  # tici dialogs
+  from openpilot.selfdrive.ui.onroad.driver_camera_dialog import DriverCameraDialog as TiciDriverCameraDialog
+  from openpilot.selfdrive.ui.layouts.onboarding import OnboardingWindow as TiciOnboardingWindow
+  from openpilot.selfdrive.ui.widgets.pairing_dialog import PairingDialog as TiciPairingDialog
+  from openpilot.system.ui.widgets.confirm_dialog import ConfirmDialog
+  from openpilot.system.ui.widgets.option_dialog import MultiOptionDialog
+  from openpilot.system.ui.widgets.html_render import HtmlModal
+  from openpilot.system.ui.widgets.keyboard import Keyboard
+
   gui_app.init_window("ref-test")
 
   leaked_widgets = set()


### PR DESCRIPTION
<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Fingerprint *****

**Car**
Which car (make, model, year) this fingerprint is for

**Route**
A route with the fingerprint

-->

<!--- ***** Template: Car Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 

**Route**

Route: [a route with the bug fix]


-->

<!--- ***** Template: Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 


-->

<!--- ***** Template: Car Port *****

**Checklist**

- [ ] added entry to CAR in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:
- [ ] car harness used (if comma doesn't sell it, put N/A):


-->

<!--- ***** Template: Refactor *****

**Description**

A description of the refactor, including the goals it accomplishes. 

**Verification**

Explain how you tested the refactor for regressions. 


-->

