### PR TITLE
sim: fill IMU sensors from metadrive state

### DIFF
--- a/tools/sim/bridge/metadrive/metadrive_process.py
+++ b/tools/sim/bridge/metadrive/metadrive_process.py
@@ -21,7 +21,7 @@ C3_HPR = Vec3(0, 0,0)
 
 
 metadrive_simulation_state = namedtuple("metadrive_simulation_state", ["running", "done", "done_info"])
-metadrive_vehicle_state = namedtuple("metadrive_vehicle_state", ["velocity", "position", "bearing", "steering_angle"])
+metadrive_vehicle_state = namedtuple("metadrive_vehicle_state", ["velocity", "position", "bearing", "steering_angle", "timestamp"])
 
 def apply_metadrive_patches(arrive_dest_done=True):
   # By default, metadrive won't try to use cuda images unless it's used as a sensor for vehicles, so patch that in
@@ -103,7 +103,8 @@ def metadrive_process(dual_camera: bool, config: dict, camera_array, wide_camera
       velocity=vec3(x=float(env.vehicle.velocity[0]), y=float(env.vehicle.velocity[1]), z=0),
       position=env.vehicle.position,
       bearing=float(math.degrees(env.vehicle.heading_theta)),
-      steering_angle=env.vehicle.steering * env.vehicle.MAX_STEERING
+      steering_angle=env.vehicle.steering * env.vehicle.MAX_STEERING,
+      timestamp=time.monotonic(),
     )
     vehicle_state_send.send(vehicle_state)
 

--- a/tools/sim/bridge/metadrive/metadrive_world.py
+++ b/tools/sim/bridge/metadrive/metadrive_world.py
@@ -9,7 +9,7 @@ from multiprocessing import Pipe, Array
 from openpilot.tools.sim.bridge.common import QueueMessage, QueueMessageType
 from openpilot.tools.sim.bridge.metadrive.metadrive_process import (metadrive_process, metadrive_simulation_state,
                                                                     metadrive_vehicle_state)
-from openpilot.tools.sim.lib.common import SimulatorState, World
+from openpilot.tools.sim.lib.common import SimulatorState, World, compute_imu_from_vehicle_state
 from openpilot.tools.sim.lib.camerad import W, H
 
 
@@ -57,6 +57,9 @@ class MetaDriveWorld(World):
     self.vc = [0.0,0.0]
     self.reset_time = 0
     self.should_reset = False
+    self.prev_velocity = None
+    self.prev_bearing = None
+    self.prev_timestamp = None
 
   def apply_controls(self, steer_angle, throttle_out, brake_out):
     if (time.monotonic() - self.reset_time) > 2:
@@ -89,7 +92,20 @@ class MetaDriveWorld(World):
       state.bearing = md_vehicle.bearing
       state.steering_angle = md_vehicle.steering_angle
       state.gps.from_xy(curr_pos)
+      dt = None if self.prev_timestamp is None else (md_vehicle.timestamp - self.prev_timestamp)
+      state.imu.accelerometer, state.imu.gyroscope = compute_imu_from_vehicle_state(
+        md_vehicle.velocity,
+        md_vehicle.bearing,
+        self.prev_velocity,
+        self.prev_bearing,
+        dt,
+      )
+      state.imu.bearing = md_vehicle.bearing
+      state.imu.timestamp_ns = int(md_vehicle.timestamp * 1e9)
       state.valid = True
+      self.prev_velocity = md_vehicle.velocity
+      self.prev_bearing = md_vehicle.bearing
+      self.prev_timestamp = md_vehicle.timestamp
 
       is_engaged = state.is_engaged
       if is_engaged and self.first_engage is None:

--- a/tools/sim/lib/common.py
+++ b/tools/sim/lib/common.py
@@ -32,6 +32,30 @@ class IMUState:
     self.accelerometer: vec3 = vec3(0,0,0)
     self.gyroscope: vec3 = vec3(0,0,0)
     self.bearing: float = 0
+    self.timestamp_ns: int = 0
+
+
+def _normalize_angle_deg(delta_deg: float) -> float:
+  """Normalize an angle delta to [-180, 180)."""
+  return (delta_deg + 180.0) % 360.0 - 180.0
+
+
+def compute_imu_from_vehicle_state(current_velocity: vec3, current_bearing: float,
+                                   previous_velocity: vec3 | None, previous_bearing: float | None,
+                                   dt: float | None) -> tuple[vec3, vec3]:
+  if previous_velocity is None or previous_bearing is None or dt is None:
+    return vec3(0.0, 0.0, 0.0), vec3(0.0, 0.0, 0.0)
+
+  dt = max(dt, 1e-3)
+  accelerometer = vec3(
+    (current_velocity.x - previous_velocity.x) / dt,
+    (current_velocity.y - previous_velocity.y) / dt,
+    (current_velocity.z - previous_velocity.z) / dt,
+  )
+
+  yaw_rate = math.radians(_normalize_angle_deg(current_bearing - previous_bearing)) / dt
+  gyroscope = vec3(0.0, 0.0, yaw_rate)
+  return accelerometer, gyroscope
 
 
 class SimulatorState:

--- a/tools/sim/lib/simulated_sensors.py
+++ b/tools/sim/lib/simulated_sensors.py
@@ -21,11 +21,12 @@ class SimulatedSensors:
     self.last_dmon_update = 0
 
   def send_imu_message(self, simulator_state: 'SimulatorState'):
+    imu_timestamp = simulator_state.imu.timestamp_ns
     for _ in range(5):
       dat = messaging.new_message('accelerometer', valid=True)
       dat.accelerometer.sensor = 4
       dat.accelerometer.type = 0x10
-      dat.accelerometer.timestamp = dat.logMonoTime  # TODO: use the IMU timestamp
+      dat.accelerometer.timestamp = imu_timestamp if imu_timestamp > 0 else dat.logMonoTime
       dat.accelerometer.init('acceleration')
       dat.accelerometer.acceleration.v = [simulator_state.imu.accelerometer.x, simulator_state.imu.accelerometer.y, simulator_state.imu.accelerometer.z]
       self.pm.send('accelerometer', dat)
@@ -34,7 +35,7 @@ class SimulatedSensors:
       dat = messaging.new_message('gyroscope', valid=True)
       dat.gyroscope.sensor = 5
       dat.gyroscope.type = 0x10
-      dat.gyroscope.timestamp = dat.logMonoTime  # TODO: use the IMU timestamp
+      dat.gyroscope.timestamp = imu_timestamp if imu_timestamp > 0 else dat.logMonoTime
       dat.gyroscope.init('gyroUncalibrated')
       dat.gyroscope.gyroUncalibrated.v = [simulator_state.imu.gyroscope.x, simulator_state.imu.gyroscope.y, simulator_state.imu.gyroscope.z]
       self.pm.send('gyroscope', dat)

--- a/tools/sim/tests/test_common.py
+++ b/tools/sim/tests/test_common.py
@@ -1,0 +1,47 @@
+import math
+
+import pytest
+
+from openpilot.tools.sim.lib.common import compute_imu_from_vehicle_state, vec3
+
+
+def test_compute_imu_first_sample_is_zero():
+  accel, gyro = compute_imu_from_vehicle_state(
+    current_velocity=vec3(1.0, 2.0, 0.0),
+    current_bearing=10.0,
+    previous_velocity=None,
+    previous_bearing=None,
+    dt=None,
+  )
+
+  assert accel == vec3(0.0, 0.0, 0.0)
+  assert gyro == vec3(0.0, 0.0, 0.0)
+
+
+def test_compute_imu_accel_and_yaw_rate():
+  accel, gyro = compute_imu_from_vehicle_state(
+    current_velocity=vec3(10.0, 4.0, 0.0),
+    current_bearing=40.0,
+    previous_velocity=vec3(0.0, 0.0, 0.0),
+    previous_bearing=10.0,
+    dt=2.0,
+  )
+
+  assert accel == vec3(5.0, 2.0, 0.0)
+  assert gyro.x == 0.0
+  assert gyro.y == 0.0
+  assert gyro.z == pytest.approx(math.radians(15.0))
+
+
+def test_compute_imu_wraps_bearing_delta():
+  _, gyro = compute_imu_from_vehicle_state(
+    current_velocity=vec3(0.0, 0.0, 0.0),
+    current_bearing=10.0,
+    previous_velocity=vec3(0.0, 0.0, 0.0),
+    previous_bearing=350.0,
+    dt=1.0,
+  )
+
+  assert gyro.x == 0.0
+  assert gyro.y == 0.0
+  assert gyro.z == pytest.approx(math.radians(20.0))


### PR DESCRIPTION
**Description**

Fixes simulator IMU values being left at zero by populating IMU state from MetaDrive vehicle state.

Changes:
- derive accelerometer values from velocity deltas
- derive gyroscope yaw rate from wrapped bearing deltas
- add simulator timestamp to vehicle state and propagate IMU timestamp to accel/gyro messages
- add focused unit tests for IMU computation (initial sample, normal delta, bearing wraparound)

Issue: #33721

**Verification**

- `ruff check tools/sim/lib/common.py tools/sim/bridge/metadrive/metadrive_process.py tools/sim/bridge/metadrive/metadrive_world.py tools/sim/lib/simulated_sensors.py tools/sim/tests/test_common.py`
- `pytest -o addopts='' --confcutdir=tools/sim/tests tools/sim/tests/test_common.py`
