### PR TITLE
Add pandad and system updated unit tests

### DIFF
--- a/selfdrive/pandad/tests/test_pandad_signature.py
+++ b/selfdrive/pandad/tests/test_pandad_signature.py
@@ -1,0 +1,50 @@
+import pytest
+
+
+from openpilot.selfdrive.pandad.pandad import get_expected_signature
+
+
+class DummyPanda:
+    @staticmethod
+    def get_signature_from_firmware(fn):
+        return b"abc123"
+
+
+def test_get_expected_signature_success(monkeypatch):
+    monkeypatch.setattr(
+        "openpilot.selfdrive.pandad.pandad.Panda",
+        DummyPanda,
+    )
+
+    result = get_expected_signature()
+    assert result == b"abc123"
+
+
+class FailingPanda:
+    @staticmethod
+    def get_signature_from_firmware(fn):
+        raise Exception("failure")
+
+
+def test_get_expected_signature_failure(monkeypatch):
+    monkeypatch.setattr(
+        "openpilot.selfdrive.pandad.pandad.Panda",
+        FailingPanda,
+    )
+
+    result = get_expected_signature()
+    assert result == b""
+
+def test_get_expected_signature_returns_bytes(monkeypatch):
+    class DummyPanda:
+        @staticmethod
+        def get_signature_from_firmware(fn):
+            return b"123"
+
+    monkeypatch.setattr(
+        "openpilot.selfdrive.pandad.pandad.Panda",
+        DummyPanda,
+    )
+
+    result = get_expected_signature()
+    assert isinstance(result, bytes)

--- a/system/updated/tests/test_common_leah.py
+++ b/system/updated/tests/test_common_leah.py
@@ -1,0 +1,30 @@
+import os
+import tempfile
+
+from openpilot.system.updated.common import get_consistent_flag, set_consistent_flag
+
+
+def test_flag_initially_false():
+    with tempfile.TemporaryDirectory() as tmp:
+        assert get_consistent_flag(tmp) is False
+
+
+def test_flag_set_true_creates_file():
+    with tempfile.TemporaryDirectory() as tmp:
+        set_consistent_flag(tmp, True)
+        assert get_consistent_flag(tmp) is True
+        assert os.path.exists(os.path.join(tmp, ".overlay_consistent"))
+
+
+def test_flag_set_false_removes_file():
+    with tempfile.TemporaryDirectory() as tmp:
+        set_consistent_flag(tmp, True)
+        set_consistent_flag(tmp, False)
+        assert get_consistent_flag(tmp) is False
+        assert not os.path.exists(os.path.join(tmp, ".overlay_consistent"))
+
+
+def test_flag_set_false_when_missing_is_safe():
+    with tempfile.TemporaryDirectory() as tmp:
+        set_consistent_flag(tmp, False)
+        assert get_consistent_flag(tmp) is False


### PR DESCRIPTION
Added two new unit test files:

- selfdrive/pandad/tests/test_pandad_signature.py
  - tests get_expected_signature() in pandad.py
  - covers both success and failure cases using mocks

- system/updated/tests/test_common_leah.py
  - tests get_consistent_flag() and set_consistent_flag()
  - covers theinitial state, file creation, removal, and safe behavior when thefile is missing

Both tests passed locally.