### PR TITLE
modeld: group npy -> qcom copies to avoid graph breaks

### DIFF
--- a/selfdrive/modeld/compile_modeld.py
+++ b/selfdrive/modeld/compile_modeld.py
@@ -148,7 +148,7 @@ def make_warp_dm(cam_w, cam_h, dm_w, dm_h):
   stride_pad = stride - cam_w
 
   def warp_dm(input_frame, M_inv):
-    M_inv = M_inv.to(Device.DEFAULT)
+    M_inv = M_inv.to(Device.DEFAULT).realize()
     result = warp_perspective_tinygrad(input_frame[:cam_h*stride], M_inv, (dm_w, dm_h), (cam_h, cam_w), stride_pad).reshape(-1, dm_h * dm_w)
     return result
   return warp_dm
@@ -270,7 +270,7 @@ def compile_dm_warp(cam_w, cam_h, pkl_path):
   warp_dm_jit = TinyJit(warp_dm, prune=True)
 
   for i in range(10):
-    inputs = [Tensor(np.random.randint(0, 256, yuv_size, dtype=np.uint8)).realize(),
+    inputs = [Tensor.randint(yuv_size, low=0, high=256, dtype='uint8').realize(),
               Tensor(Tensor.randn(3, 3).mul(8).realize().numpy(), device='NPY')]
     Device.default.synchronize()
     st = time.perf_counter()

--- a/selfdrive/modeld/compile_modeld.py
+++ b/selfdrive/modeld/compile_modeld.py
@@ -162,10 +162,11 @@ def make_run_policy(vision_runner, policy_runner, cam_w, cam_h,
   sample_desire_fn = partial(sample_desire, frame_skip=frame_skip)
 
   def run_policy(img_q, big_img_q, feat_q, desire_q, desire, traffic_convention, tfm, big_tfm, frame, big_frame):
-    tfm = tfm.to(Device.DEFAULT).realize()
-    big_tfm = big_tfm.to(Device.DEFAULT).realize()
-    desire = desire.to(Device.DEFAULT).realize()
-    traffic_convention = traffic_convention.to(Device.DEFAULT).realize()
+    tfm = tfm.to(Device.DEFAULT)
+    big_tfm = big_tfm.to(Device.DEFAULT)
+    desire = desire.to(Device.DEFAULT)
+    traffic_convention = traffic_convention.to(Device.DEFAULT)
+    Tensor.realize(tfm, big_tfm, desire, traffic_convention)
 
     img = shift_and_sample(img_q, frame_prepare(frame, tfm).unsqueeze(0), sample_skip_fn)
     big_img = shift_and_sample(big_img_q, frame_prepare(big_frame, big_tfm).unsqueeze(0), sample_skip_fn)

--- a/selfdrive/modeld/compile_modeld.py
+++ b/selfdrive/modeld/compile_modeld.py
@@ -162,8 +162,13 @@ def make_run_policy(vision_runner, policy_runner, cam_w, cam_h,
   sample_desire_fn = partial(sample_desire, frame_skip=frame_skip)
 
   def run_policy(img_q, big_img_q, feat_q, desire_q, desire, traffic_convention, tfm, big_tfm, frame, big_frame):
-    img = shift_and_sample(img_q, frame_prepare(frame, tfm.to(Device.DEFAULT)).unsqueeze(0), sample_skip_fn)
-    big_img = shift_and_sample(big_img_q, frame_prepare(big_frame, big_tfm.to(Device.DEFAULT)).unsqueeze(0), sample_skip_fn)
+    tfm = tfm.to(Device.DEFAULT).realize()
+    big_tfm = big_tfm.to(Device.DEFAULT).realize()
+    desire = desire.to(Device.DEFAULT).realize()
+    traffic_convention = traffic_convention.to(Device.DEFAULT).realize()
+
+    img = shift_and_sample(img_q, frame_prepare(frame, tfm).unsqueeze(0), sample_skip_fn)
+    big_img = shift_and_sample(big_img_q, frame_prepare(big_frame, big_tfm).unsqueeze(0), sample_skip_fn)
 
     if prepare_only:
       return img, big_img
@@ -172,9 +177,9 @@ def make_run_policy(vision_runner, policy_runner, cam_w, cam_h,
 
     new_feat = vision_out[:, vision_features_slice].reshape(1, -1).unsqueeze(0)
     feat_buf = shift_and_sample(feat_q, new_feat, sample_skip_fn)
-    desire_buf = shift_and_sample(desire_q, desire.to(Device.DEFAULT).reshape(1, 1, -1), sample_desire_fn)
+    desire_buf = shift_and_sample(desire_q, desire.reshape(1, 1, -1), sample_desire_fn)
 
-    inputs = {'features_buffer': feat_buf, 'desire_pulse': desire_buf, 'traffic_convention': traffic_convention.to(Device.DEFAULT)}
+    inputs = {'features_buffer': feat_buf, 'desire_pulse': desire_buf, 'traffic_convention': traffic_convention}
     policy_out = next(iter(policy_runner(inputs).values())).cast('float32')
 
     return vision_out, policy_out
@@ -210,10 +215,11 @@ def compile_modeld(cam_w, cam_h, prepare_only, pkl_path):
   def random_inputs_run_fn(fn, seed, test_val=None, test_buffers=None, expect_match=True):
     input_queues, npy = make_input_queues(vision_input_shapes, policy_input_shapes, frame_skip)
     np.random.seed(seed)
+    Tensor.manual_seed(seed)
 
     for i in range(N_RUNS):
-      frame = Tensor(np.random.randint(0, 256, yuv_size, dtype=np.uint8)).realize()
-      big_frame = Tensor(np.random.randint(0, 256, yuv_size, dtype=np.uint8)).realize()
+      frame = Tensor.randint(yuv_size, low=0, high=256, dtype='uint8').realize()
+      big_frame = Tensor.randint(yuv_size, low=0, high=256, dtype='uint8').realize()
       for v in npy.values():
         v[:] = np.random.randn(*v.shape).astype(v.dtype)
       Device.default.synchronize()


### PR DESCRIPTION
```
=== 902b702d5f3cabf8/00000003--2cfecd006b ===
gitBranch: release-mici (a1af07d967be163b06eecbd39fd56fd4dc8a8366)
field                            active mean(ms)  min(ms)  max(ms)  count
modelV2.modelExecutionTime            0    28.13    24.92   181.75  18818
modelV2.modelExecutionTime            1    30.77    26.38    33.20   3200
driverStateV2.gpuExecutionTime        0    13.29    11.99   737.59  18799
driverStateV2.gpuExecutionTime        1    14.82    12.45    17.12   3202

=== 902b702d5f3cabf8/0000000e--c1303f84a0 ===
gitBranch: master (4988a62b310b536fb5336c35151eb2df56e37d97)
field                            active mean(ms)  min(ms)  max(ms)  count
modelV2.modelExecutionTime            0    24.51    22.65    29.47   6995
modelV2.modelExecutionTime            1    25.40    22.73    30.34   3934
driverStateV2.gpuExecutionTime        0    18.80    16.08   114.83   6987
driverStateV2.gpuExecutionTime        1    18.90    16.30    27.96   3933

=== 902b702d5f3cabf8/0000000a--12974a33b2 ===
gitBranch: modeld-speedup (90ac75d52b764b6295b29da22c7b2f2f5cda3868)
field                            active mean(ms)  min(ms)  max(ms)  count
modelV2.modelExecutionTime            0    23.73    22.16    29.16   8795
modelV2.modelExecutionTime            1    24.59    21.84    27.61   3271
driverStateV2.gpuExecutionTime        0    17.66    15.82   113.53   8781
driverStateV2.gpuExecutionTime        1    18.56    16.03    23.76   3270
```