### PR TITLE
dmonitoringmodeld: keep warp output/model input tensor

### DIFF
--- a/selfdrive/modeld/compile_modeld.py
+++ b/selfdrive/modeld/compile_modeld.py
@@ -147,10 +147,10 @@ def make_warp_dm(cam_w, cam_h, dm_w, dm_h):
   stride, y_height, _, _ = get_nv12_info(cam_w, cam_h)
   stride_pad = stride - cam_w
 
-  def warp_dm(input_frame, M_inv):
+  def warp_dm(out, input_frame, M_inv):
     M_inv = M_inv.to(Device.DEFAULT).realize()
     result = warp_perspective_tinygrad(input_frame[:cam_h*stride], M_inv, (dm_w, dm_h), (cam_h, cam_w), stride_pad).reshape(-1, dm_h * dm_w)
-    return result
+    out.assign(result)
   return warp_dm
 
 
@@ -269,12 +269,13 @@ def compile_dm_warp(cam_w, cam_h, pkl_path):
   warp_dm = make_warp_dm(cam_w, cam_h, dm_w, dm_h)
   warp_dm_jit = TinyJit(warp_dm, prune=True)
 
+  out = Tensor.zeros(1, dm_h * dm_w, dtype='uint8').contiguous().realize()
   for i in range(10):
     inputs = [Tensor.randint(yuv_size, low=0, high=256, dtype='uint8').realize(),
               Tensor(Tensor.randn(3, 3).mul(8).realize().numpy(), device='NPY')]
     Device.default.synchronize()
     st = time.perf_counter()
-    warp_dm_jit(*inputs)
+    warp_dm_jit(out, *inputs)
     mt = time.perf_counter()
     Device.default.synchronize()
     et = time.perf_counter()

--- a/selfdrive/modeld/compile_modeld.py
+++ b/selfdrive/modeld/compile_modeld.py
@@ -151,6 +151,8 @@ def make_warp_dm(cam_w, cam_h, dm_w, dm_h):
     M_inv = M_inv.to(Device.DEFAULT).realize()
     result = warp_perspective_tinygrad(input_frame[:cam_h*stride], M_inv, (dm_w, dm_h), (cam_h, cam_w), stride_pad).reshape(-1, dm_h * dm_w)
     out.assign(result)
+    # return out so prune=True keeps the assign kernels
+    return out
   return warp_dm
 
 

--- a/selfdrive/modeld/dmonitoringmodeld.py
+++ b/selfdrive/modeld/dmonitoringmodeld.py
@@ -42,6 +42,7 @@ class ModelState:
     self.warp_inputs = {k: Tensor(v, device='NPY') for k,v in self.warp_inputs_np.items()}
     self.frame_buf_params = None
     self.tensor_inputs = {k: Tensor(v, device='NPY').realize() for k,v in self.numpy_inputs.items()}
+    self.tensor_inputs['input_img'] = Tensor.zeros(self.input_shapes['input_img'], dtype='uint8').contiguous().realize()
     self._blob_cache : dict[int, Tensor] = {}
     self.image_warp = None
     self.model_run = pickle.loads(read_file_chunked(str(MODEL_PKL_PATH)))
@@ -62,7 +63,7 @@ class ModelState:
       self._blob_cache[ptr] = Tensor.from_blob(ptr, (self.frame_buf_params[3],), dtype='uint8')
 
     self.warp_inputs_np['transform'][:] = transform[:]
-    self.tensor_inputs['input_img'] = self.image_warp(self._blob_cache[ptr], self.warp_inputs['transform']).realize()
+    self.image_warp(self.tensor_inputs['input_img'], self._blob_cache[ptr], self.warp_inputs['transform'])
 
     output = self.model_run(**self.tensor_inputs).contiguous().realize().uop.base.buffer.numpy().flatten()
 


### PR DESCRIPTION
<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Fingerprint *****

**Car**
Which car (make, model, year) this fingerprint is for

**Route**
A route with the fingerprint

-->

<!--- ***** Template: Car Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 

**Route**

Route: [a route with the bug fix]


-->

<!--- ***** Template: Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 


-->

<!--- ***** Template: Car Port *****

**Checklist**

- [ ] added entry to CAR in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:
- [ ] car harness used (if comma doesn't sell it, put N/A):


-->

<!--- ***** Template: Refactor *****

**Description**

A description of the refactor, including the goals it accomplishes. 

**Verification**

Explain how you tested the refactor for regressions. 


-->

