### PR TITLE
qcomgpsd: inject XTRA assistance via AT commands, drop mmcli

### DIFF
--- a/system/qcomgpsd/qcomgpsd.py
+++ b/system/qcomgpsd/qcomgpsd.py
@@ -197,6 +197,8 @@ def inject_assistance():
     fcntl.flock(lock_fd, fcntl.LOCK_EX)
     with Serial(AT_PORT, baudrate=115200, timeout=5) as ser:
       _at_send(ser, "AT+QGPSXTRA=1", strict=True)
+      # clear any stale upload from a prior run so QFUPL doesn't hit +CME ERROR: 407 (file exists)
+      _at_send(ser, 'AT+QFDEL="RAM:xtra3grc.bin"')
       _qfupl(ser, "RAM:xtra3grc.bin", data)
       now = datetime.datetime.now(datetime.UTC).strftime("%Y/%m/%d,%H:%M:%S")
       _at_send(ser, f'AT+QGPSXTRATIME=0,"{now}",1,1,500', strict=True)

--- a/system/qcomgpsd/qcomgpsd.py
+++ b/system/qcomgpsd/qcomgpsd.py
@@ -3,6 +3,7 @@ import os
 import sys
 import signal
 import itertools
+import fcntl
 import math
 import time
 import requests
@@ -91,23 +92,31 @@ def try_setup_logs(diag, logs):
   return setup_logs(diag, logs)
 
 AT_PORT = "/dev/modem_at0"
+AT_LOCK = "/dev/shm/modem_lpa.lock"  # shared with modem.py and LPA
+
+def _at_send(ser: Serial, cmd: str, strict: bool = False) -> str:
+  """Send AT command on an open Serial; return accumulated non-echo lines.
+  If strict, raise on ERROR/+CME ERROR instead of silently returning."""
+  ser.reset_input_buffer()
+  ser.write(f"{cmd}\r".encode())
+  lines = []
+  while True:
+    line = ser.readline()
+    if not line:
+      raise RuntimeError(f"AT command timeout: {cmd}")
+    line = line.decode('utf-8', errors='replace').strip()
+    if line in ("OK", "ERROR") or line.startswith("+CME ERROR"):
+      if strict and line != "OK":
+        raise RuntimeError(f"AT {cmd} -> {line}")
+      break
+    if line and line != cmd:
+      lines.append(line)
+  return '\n'.join(lines)
 
 @retry(attempts=5, delay=1.0)
 def at_cmd(cmd: str) -> str:
   with Serial(AT_PORT, baudrate=115200, timeout=5) as ser:
-    ser.reset_input_buffer()
-    ser.write(f"{cmd}\r".encode())
-    lines = []
-    while True:
-      line = ser.readline()
-      if not line:
-        raise RuntimeError(f"AT command timeout: {cmd}")
-      line = line.decode('utf-8', errors='replace').strip()
-      if line in ("OK", "ERROR") or line.startswith("+CME ERROR"):
-        break
-      if line and line != cmd:
-        lines.append(line)
-  return '\n'.join(lines)
+    return _at_send(ser, cmd)
 
 def gps_enabled() -> bool:
   return "QGPS: 1" in at_cmd("AT+QGPS?")
@@ -144,12 +153,59 @@ def downloader_loop(event):
   except KeyboardInterrupt:
     pass
 
-@retry(attempts=5, delay=0.2, ignore_failure=True)
+def _qfupl(ser: Serial, name: str, data: bytes) -> None:
+  """Upload data to the modem's RAM filesystem via AT+QFUPL."""
+  ser.reset_input_buffer()
+  ser.write(f'AT+QFUPL="{name}",{len(data)},60\r'.encode())
+  # wait for CONNECT
+  deadline = time.monotonic() + 10
+  while time.monotonic() < deadline:
+    line = ser.readline().decode('utf-8', errors='replace').strip()
+    if line == "CONNECT":
+      break
+    if line == "ERROR" or line.startswith("+CME ERROR"):
+      raise RuntimeError(f"QFUPL setup failed: {line}")
+  else:
+    raise RuntimeError("QFUPL: no CONNECT")
+  # stream raw bytes
+  ser.write(data)
+  ser.flush()
+  # expect "+QFUPL: <size>,<checksum>" then "OK"
+  deadline = time.monotonic() + 60
+  saw_qfupl = False
+  while time.monotonic() < deadline:
+    line = ser.readline().decode('utf-8', errors='replace').strip()
+    if line.startswith("+QFUPL:"):
+      saw_qfupl = True
+    elif line == "OK" and saw_qfupl:
+      return
+    elif line == "ERROR" or line.startswith("+CME ERROR"):
+      raise RuntimeError(f"QFUPL failed: {line}")
+  raise RuntimeError("QFUPL: no OK")
+
+@retry(attempts=3, delay=0.5, ignore_failure=True)
 def inject_assistance():
-  import subprocess
-  cmd = f"mmcli -m any --timeout 30 --location-inject-assistance-data={ASSIST_DATA_FILE}"
-  subprocess.check_output(cmd, stderr=subprocess.PIPE, shell=True)
-  cloudlog.info("successfully loaded assistance data")
+  try:
+    with open(ASSIST_DATA_FILE, 'rb') as f:
+      data = f.read()
+  except FileNotFoundError:
+    return
+
+  # coordinate with modem.py / LPA over the shared AT-port lock
+  lock_fd = os.open(AT_LOCK, os.O_CREAT | os.O_RDWR, 0o666)
+  try:
+    fcntl.flock(lock_fd, fcntl.LOCK_EX)
+    with Serial(AT_PORT, baudrate=115200, timeout=5) as ser:
+      _at_send(ser, "AT+QGPSXTRA=1", strict=True)
+      _qfupl(ser, "RAM:xtra3grc.bin", data)
+      now = datetime.datetime.now(datetime.UTC).strftime("%Y/%m/%d,%H:%M:%S")
+      _at_send(ser, f'AT+QGPSXTRATIME=0,"{now}",1,1,500', strict=True)
+      _at_send(ser, 'AT+QGPSXTRADATA="RAM:xtra3grc.bin"', strict=True)
+      _at_send(ser, 'AT+QFDEL="RAM:xtra3grc.bin"')
+    cloudlog.info("successfully loaded assistance data")
+  finally:
+    fcntl.flock(lock_fd, fcntl.LOCK_UN)
+    os.close(lock_fd)
 
 @retry(attempts=5, delay=1.0)
 def setup_quectel(diag: ModemDiag) -> bool:


### PR DESCRIPTION
## Summary

Replace the `mmcli -m any --location-inject-assistance-data=...` call in `qcomgpsd` with a direct Quectel AT-command sequence over `/dev/modem_at0`, removing the runtime dependency on ModemManager for GPS assistance data injection.

- **Before**: shelled out to `mmcli`, which called into ModemManager's `Location.InjectAssistanceData` D-Bus method, which in turn issued the QMI LOC-service `Inject Xtra Data` request.
- **After**: a small helper (`_qfupl`) uploads the XTRA file to the modem's RAM filesystem via `AT+QFUPL`, then commits it with `AT+QGPSXTRATIME` / `AT+QGPSXTRADATA`. Coordinates with the rest of AT-port users (`modem.py`, LPA) via the shared `/dev/shm/modem_lpa.lock`.

## Sequence

```
AT+QGPSXTRA=1                                      # enable XTRA (idempotent)
AT+QFDEL="RAM:xtra3grc.bin"                        # clean any stale upload
AT+QFUPL="RAM:xtra3grc.bin",<size>,60              # -> CONNECT, stream bytes, +QFUPL: <size>,<cksum>, OK
AT+QGPSXTRATIME=0,"YYYY/MM/DD,HH:MM:SS",1,1,500    # inject UTC with 500ms uncertainty
AT+QGPSXTRADATA="RAM:xtra3grc.bin"                 # commit to GNSS engine
AT+QFDEL="RAM:xtra3grc.bin"                        # cleanup
```

## Test evidence

Tested on tizi (Quectel EG25-G) running the branch.

Before injection (XTRA cleared via `AT+QGPSDEL=0`):
```
pre: +QGPSXTRADATA: 0,"1980/01/05,19:00:00"
```

After `inject_assistance()`:
```
inject: 0.04s
post: +QGPSXTRADATA: 10080,"2026/04/22,23:00:00"
```

The GNSS engine reports 10080 minutes (7 days) of assistance data valid from the epoch injected, matching what the ModemManager path produced previously.

Also verified:
- Pre-flight `AT+QFDEL` handles the case where a prior run uploaded but didn't cleanup (which otherwise yields `+CME ERROR: 407` / file exists). Reproduced, confirmed fixed.
- Lock coordination: running `inject_assistance()` while `modem.py` is actively using `/dev/modem_at0` blocks correctly on `/dev/shm/modem_lpa.lock` and does not corrupt either side's AT stream.

## Test plan

- [x] Tested on tizi with `modem.py` running concurrently
- [x] Verified `AT+QGPSXTRADATA?` reports valid data post-injection
- [x] Verified pre-flight `QFDEL` prevents stale-file failures across retries