### PR TITLE
modeld, dmonitoringmodeld: don't assume single device

### DIFF
--- a/selfdrive/modeld/SConscript
+++ b/selfdrive/modeld/SConscript
@@ -36,22 +36,10 @@ if 'CUDA' in available:
   tg_flags = f'DEV={tg_backend}'
 elif 'QCOM' in available:
   tg_backend = 'QCOM'
-  tg_flags = f'DEV={tg_backend} FLOAT16=1 NOLOCALS=1 JIT_BATCH_SIZE=0 OPENPILOT_HACKS=1'
+  tg_flags = f'DEV={tg_backend} IMAGE=2 FLOAT16=1 NOLOCALS=1 JIT_BATCH_SIZE=0 OPENPILOT_HACKS=1'
 else:
   tg_backend = 'CPU' if arch == 'Darwin' else 'CPU:LLVM'
-  # THREADS=0 is need to prevent bug: https://github.com/tinygrad/tinygrad/issues/14689
-  tg_flags = f'DEV={tg_backend} THREADS=0'
-
-def write_tg_compiled_flags(target, source, env):
-  with open(str(target[0]), "w") as f:
-    json.dump({"DEV": tg_backend}, f)
-    f.write("\n")
-
-compiled_flags_node = lenv.Command(
-  File("models/tg_compiled_flags.json").abspath,
-  tinygrad_files + [Value(tg_backend)],
-  write_tg_compiled_flags,
-)
+  tg_flags = f'DEV={tg_backend}'
 
 # tinygrad calls brew which needs a $HOME in the env
 mac_brew_string = f'HOME={os.path.expanduser("~")}' if arch == 'Darwin' else ''
@@ -61,11 +49,8 @@ for model_name in ['driving_vision', 'driving_policy', 'dmonitoring_model']:
   fn = File(f"models/{model_name}").abspath
   script_files = [File(Dir("#selfdrive/modeld").File("get_model_metadata.py").abspath)]
   cmd = f'{tg_flags} {mac_brew_string} python3 {Dir("#selfdrive/modeld").abspath}/get_model_metadata.py {fn}.onnx'
-  lenv.Command(fn + "_metadata.pkl", [fn + ".onnx"] + tinygrad_files + script_files + [compiled_flags_node], cmd)
+  lenv.Command(fn + "_metadata.pkl", [fn + ".onnx"] + tinygrad_files + script_files, cmd)
 
-image_flag = {
-     'larch64': 'IMAGE=2',
-}.get(arch, 'IMAGE=0')
 modeld_dir = Dir("#selfdrive/modeld").abspath
 compile_modeld_script = [File(f"{modeld_dir}/compile_modeld.py")]
 compile_dm_warp_script = [File(f"{modeld_dir}/compile_dm_warp.py")]
@@ -75,14 +60,14 @@ driving_metadata_deps = [File(f"models/{m}_metadata.pkl").abspath for m in ['dri
 model_w, model_h = MEDMODEL_INPUT_SIZE
 frame_skip = ModelConstants.MODEL_RUN_FREQ // ModelConstants.MODEL_CONTEXT_FREQ
 for cfg in MODELD_CONFIGS:
-  cmd = (f'{tg_flags} {mac_brew_string} {image_flag} python3 {modeld_dir}/compile_modeld.py '
+  cmd = (f'{tg_flags} {mac_brew_string} python3 {modeld_dir}/compile_modeld.py '
          f'--model-size {model_w}x{model_h} '
          f'--nv12 {",".join(str(x) for x in cfg.nv12)} '
          f'--vision-onnx {File("models/driving_vision.onnx").abspath} '
          f'--policy-onnx {File("models/driving_policy.onnx").abspath} '
          f'--output {cfg.pkl_path} --frame-skip {frame_skip}'
          + (' --prepare-only' if cfg.prepare_only else ''))
-  node = lenv.Command(cfg.pkl_path, tinygrad_files + compile_modeld_script + driving_onnx_deps + driving_metadata_deps + [chunker_file, compiled_flags_node], cmd)
+  node = lenv.Command(cfg.pkl_path, tinygrad_files + compile_modeld_script + driving_onnx_deps + driving_metadata_deps + [chunker_file], cmd)
   onnx_sizes_sum = sum(os.path.getsize(f) for f in driving_onnx_deps)
   chunk_targets = get_chunk_paths(cfg.pkl_path, estimate_pickle_max_size(onnx_sizes_sum))
   def do_chunk(target, source, env, pkl=cfg.pkl_path, chunks=chunk_targets):
@@ -91,10 +76,10 @@ for cfg in MODELD_CONFIGS:
 
 dm_w, dm_h = DM_INPUT_SIZE
 for cfg in DM_WARP_CONFIGS:
-  cmd = (f'{tg_flags} {mac_brew_string} {image_flag} python3 {modeld_dir}/compile_dm_warp.py '
+  cmd = (f'{tg_flags} {mac_brew_string} python3 {modeld_dir}/compile_dm_warp.py '
          f'--nv12 {",".join(str(x) for x in cfg.nv12)} --warp-to {dm_w}x{dm_h} '
          f'--output {cfg.pkl_path}')
-  lenv.Command(cfg.pkl_path, tinygrad_files + compile_dm_warp_script + compile_modeld_script + [compiled_flags_node], cmd)
+  lenv.Command(cfg.pkl_path, tinygrad_files + compile_dm_warp_script + compile_modeld_script, cmd)
 
 def tg_compile(flags, model_name):
   pythonpath_string = 'PYTHONPATH="${PYTHONPATH}:' + env.Dir("#tinygrad_repo").abspath + '"'
@@ -104,8 +89,8 @@ def tg_compile(flags, model_name):
   chunk_targets = get_chunk_paths(pkl, estimate_pickle_max_size(os.path.getsize(onnx_path)))
   compile_node = lenv.Command(
     pkl,
-    [onnx_path] + tinygrad_files + [chunker_file, compiled_flags_node],
-    f'{pythonpath_string} {flags} {image_flag} python3 {Dir("#tinygrad_repo").abspath}/examples/openpilot/compile3.py {fn}.onnx {pkl}',
+    [onnx_path] + tinygrad_files + [chunker_file],
+    f'{pythonpath_string} {flags} python3 {Dir("#tinygrad_repo").abspath}/examples/openpilot/compile3.py {fn}.onnx {pkl}',
   )
   def do_chunk(target, source, env):
     chunk_file(pkl, chunk_targets)

--- a/selfdrive/modeld/compile_dm_warp.py
+++ b/selfdrive/modeld/compile_dm_warp.py
@@ -31,7 +31,7 @@ def compile_dm_warp(nv12: NV12Frame, dm_w, dm_h, pkl_path):
     M_inv = Tensor(Tensor.randn(3, 3).mul(8).realize().numpy(), device='NPY')
     Device.default.synchronize()
     st = time.perf_counter()
-    warp_dm_jit(frame, M_inv).realize()
+    warp_dm_jit(input_frame=frame, M_inv=M_inv).realize()
     mt = time.perf_counter()
     Device.default.synchronize()
     et = time.perf_counter()

--- a/selfdrive/modeld/compile_dm_warp.py
+++ b/selfdrive/modeld/compile_dm_warp.py
@@ -13,10 +13,9 @@ from openpilot.selfdrive.modeld.compile_modeld import NV12Frame, warp_perspectiv
 def make_warp_dm(nv12: NV12Frame, dm_w, dm_h):
   cam_w, cam_h, stride, _, _, _ = nv12
   stride_pad = stride - cam_w
-  compute_device = Device.DEFAULT
 
   def warp_dm(input_frame, M_inv):
-    M_inv = M_inv.to(compute_device).realize()
+    M_inv = M_inv.to(Device.DEFAULT).realize()
     return warp_perspective_tinygrad(input_frame[:cam_h*stride], M_inv,
                                      (dm_w, dm_h), (cam_h, cam_w), stride_pad).reshape(-1, dm_h * dm_w)
   return warp_dm

--- a/selfdrive/modeld/compile_dm_warp.py
+++ b/selfdrive/modeld/compile_dm_warp.py
@@ -13,9 +13,10 @@ from openpilot.selfdrive.modeld.compile_modeld import NV12Frame, warp_perspectiv
 def make_warp_dm(nv12: NV12Frame, dm_w, dm_h):
   cam_w, cam_h, stride, _, _, _ = nv12
   stride_pad = stride - cam_w
+  compute_device = Device.DEFAULT
 
   def warp_dm(input_frame, M_inv):
-    M_inv = M_inv.to(Device.DEFAULT).realize()
+    M_inv = M_inv.to(compute_device).realize()
     return warp_perspective_tinygrad(input_frame[:cam_h*stride], M_inv,
                                      (dm_w, dm_h), (cam_h, cam_w), stride_pad).reshape(-1, dm_h * dm_w)
   return warp_dm

--- a/selfdrive/modeld/compile_modeld.py
+++ b/selfdrive/modeld/compile_modeld.py
@@ -107,7 +107,7 @@ def make_input_queues(vision_input_shapes, policy_input_shapes, frame_skip, devi
     'desire_q': ((frame_skip * dp[1], dp[0], dp[2]), 'float32'),
   }
   if devices is None:
-    devices = {k: Device.DEFAULT for k in queues_shapes_dtypes.keys()}
+    devices = dict.fromkeys(queues_shapes_dtypes, Device.DEFAULT)
 
   input_queues = {
     **{k: Tensor.zeros(shape, dtype=dtype, device=devices[k]).contiguous().realize()

--- a/selfdrive/modeld/compile_modeld.py
+++ b/selfdrive/modeld/compile_modeld.py
@@ -107,7 +107,7 @@ def make_input_queues(vision_input_shapes, policy_input_shapes, frame_skip, devi
     'desire_q': ((frame_skip * dp[1], dp[0], dp[2]), 'float32'),
   }
   if devices is None:
-    devices = {k: Device.DEFAULT for k in queues_shapes_dtypes}
+    devices = {k: Device.DEFAULT for k in queues_shapes_dtypes.keys()}
 
   input_queues = {
     **{k: Tensor.zeros(shape, dtype=dtype, device=devices[k]).contiguous().realize()

--- a/selfdrive/modeld/compile_modeld.py
+++ b/selfdrive/modeld/compile_modeld.py
@@ -10,7 +10,6 @@ from tinygrad.tensor import Tensor
 from tinygrad.helpers import Context
 from tinygrad.device import Device
 from tinygrad.engine.jit import TinyJit
-from tinygrad.nn.onnx import OnnxRunner
 
 # https://github.com/tinygrad/tinygrad/issues/15682
 from tinygrad.uop.ops import UOp, Ops
@@ -167,6 +166,7 @@ def compile_modeld(nv12: NV12Frame, model_w, model_h, prepare_only, frame_skip,
 
   print(f"Compiling combined policy JIT for {nv12.width}x{nv12.height} (prepare_only={prepare_only})...")
 
+  from tinygrad.nn.onnx import OnnxRunner
   vision_runner = OnnxRunner(vision_onnx)
   policy_runner = OnnxRunner(policy_onnx)
 

--- a/selfdrive/modeld/compile_modeld.py
+++ b/selfdrive/modeld/compile_modeld.py
@@ -134,13 +134,12 @@ def make_run_policy(vision_runner, policy_runner, nv12: NV12Frame, model_w, mode
   frame_prepare = make_frame_prepare(nv12, model_w, model_h)
   sample_skip_fn = partial(sample_skip, frame_skip=frame_skip)
   sample_desire_fn = partial(sample_desire, frame_skip=frame_skip)
-  compute_device = Device.DEFAULT
 
   def run_policy(img_q, big_img_q, feat_q, desire_q, desire, traffic_convention, tfm, big_tfm, frame, big_frame):
-    tfm = tfm.to(compute_device)
-    big_tfm = big_tfm.to(compute_device)
-    desire = desire.to(compute_device)
-    traffic_convention = traffic_convention.to(compute_device)
+    tfm = tfm.to(Device.DEFAULT)
+    big_tfm = big_tfm.to(Device.DEFAULT)
+    desire = desire.to(Device.DEFAULT)
+    traffic_convention = traffic_convention.to(Device.DEFAULT)
     Tensor.realize(tfm, big_tfm, desire, traffic_convention)
 
     img = shift_and_sample(img_q, frame_prepare(frame, tfm).unsqueeze(0), sample_skip_fn)

--- a/selfdrive/modeld/compile_modeld.py
+++ b/selfdrive/modeld/compile_modeld.py
@@ -4,7 +4,6 @@ import pickle
 import time
 from functools import partial
 from collections import namedtuple
-from typing import Optional
 
 import numpy as np
 from tinygrad.tensor import Tensor
@@ -85,7 +84,7 @@ def make_frame_prepare(nv12: NV12Frame, model_w, model_h):
   return frame_prepare_tinygrad
 
 
-def make_input_queues(vision_input_shapes, policy_input_shapes, frame_skip, devices: Optional[str]=None):
+def make_input_queues(vision_input_shapes, policy_input_shapes, frame_skip, devices=None):
   img = vision_input_shapes['img']  # (1, 12, 128, 256)
   n_frames = img[1] // 6
   img_buf_shape = (frame_skip * (n_frames - 1) + 1, 6, img[2], img[3])

--- a/selfdrive/modeld/compile_modeld.py
+++ b/selfdrive/modeld/compile_modeld.py
@@ -134,12 +134,13 @@ def make_run_policy(vision_runner, policy_runner, nv12: NV12Frame, model_w, mode
   frame_prepare = make_frame_prepare(nv12, model_w, model_h)
   sample_skip_fn = partial(sample_skip, frame_skip=frame_skip)
   sample_desire_fn = partial(sample_desire, frame_skip=frame_skip)
+  compute_device = Device.DEFAULT
 
   def run_policy(img_q, big_img_q, feat_q, desire_q, desire, traffic_convention, tfm, big_tfm, frame, big_frame):
-    tfm = tfm.to(Device.DEFAULT)
-    big_tfm = big_tfm.to(Device.DEFAULT)
-    desire = desire.to(Device.DEFAULT)
-    traffic_convention = traffic_convention.to(Device.DEFAULT)
+    tfm = tfm.to(compute_device)
+    big_tfm = big_tfm.to(compute_device)
+    desire = desire.to(compute_device)
+    traffic_convention = traffic_convention.to(compute_device)
     Tensor.realize(tfm, big_tfm, desire, traffic_convention)
 
     img = shift_and_sample(img_q, frame_prepare(frame, tfm).unsqueeze(0), sample_skip_fn)

--- a/selfdrive/modeld/compile_modeld.py
+++ b/selfdrive/modeld/compile_modeld.py
@@ -4,6 +4,7 @@ import pickle
 import time
 from functools import partial
 from collections import namedtuple
+from typing import Optional
 
 import numpy as np
 from tinygrad.tensor import Tensor
@@ -84,7 +85,7 @@ def make_frame_prepare(nv12: NV12Frame, model_w, model_h):
   return frame_prepare_tinygrad
 
 
-def make_input_queues(vision_input_shapes, policy_input_shapes, frame_skip):
+def make_input_queues(vision_input_shapes, policy_input_shapes, frame_skip, devices: Optional[str]=None):
   img = vision_input_shapes['img']  # (1, 12, 128, 256)
   n_frames = img[1] // 6
   img_buf_shape = (frame_skip * (n_frames - 1) + 1, 6, img[2], img[3])
@@ -99,11 +100,18 @@ def make_input_queues(vision_input_shapes, policy_input_shapes, frame_skip):
     'tfm': np.zeros((3, 3), dtype=np.float32),
     'big_tfm': np.zeros((3, 3), dtype=np.float32),
   }
+  queues_shapes_dtypes = {
+    'img_q': (img_buf_shape, 'uint8'),
+    'big_img_q': (img_buf_shape, 'uint8'),
+    'feat_q': ((frame_skip * (fb[1] - 1) + 1, fb[0], fb[2]), 'float32'),
+    'desire_q': ((frame_skip * dp[1], dp[0], dp[2]), 'float32'),
+  }
+  if devices is None:
+    devices = {k: Device.DEFAULT for k in queues_shapes_dtypes}
+
   input_queues = {
-    'img_q': Tensor.zeros(img_buf_shape, dtype='uint8').contiguous().realize(),
-    'big_img_q': Tensor.zeros(img_buf_shape, dtype='uint8').contiguous().realize(),
-    'feat_q': Tensor.zeros(frame_skip * (fb[1] - 1) + 1, fb[0], fb[2]).contiguous().realize(),
-    'desire_q': Tensor.zeros(frame_skip * dp[1], dp[0], dp[2]).contiguous().realize(),
+    **{k: Tensor.zeros(shape, dtype=dtype, device=devices[k]).contiguous().realize()
+       for k, (shape, dtype) in queues_shapes_dtypes.items()},
     **{k: Tensor(v, device='NPY').realize() for k, v in npy.items()},
   }
   return input_queues, npy

--- a/selfdrive/modeld/dmonitoringmodeld.py
+++ b/selfdrive/modeld/dmonitoringmodeld.py
@@ -44,7 +44,7 @@ class ModelState:
       self.image_warp = pickle.load(f)
     self.warp_input_devices = get_jit_input_devices(self.image_warp)
     self.warp_inputs_np = {'M_inv': np.zeros((3,3), dtype=np.float32)}
-    self.warp_inputs = {k: Tensor(v, device='NPY') for k, v in self.warp_inputs_np}
+    self.warp_inputs = {k: Tensor(v, device='NPY') for k, v in self.warp_inputs_np.items()}
 
   def run(self, buf: VisionBuf, calib: np.ndarray, transform: np.ndarray) -> tuple[np.ndarray, float]:
     self.numpy_inputs['calib'][0,:] = calib

--- a/selfdrive/modeld/dmonitoringmodeld.py
+++ b/selfdrive/modeld/dmonitoringmodeld.py
@@ -1,8 +1,5 @@
 #!/usr/bin/env python3
 import os
-from openpilot.selfdrive.modeld.helpers import MODELS_DIR, CompileConfig, set_tinygrad_backend_from_compiled_flags
-set_tinygrad_backend_from_compiled_flags()
-
 from tinygrad.tensor import Tensor
 import time
 import pickle
@@ -18,6 +15,7 @@ from openpilot.common.transformations.camera import _ar_ox_fisheye, _os_fisheye
 from openpilot.system.camerad.cameras.nv12_info import get_nv12_info
 from openpilot.common.file_chunker import read_file_chunked
 from openpilot.selfdrive.modeld.parse_model_outputs import sigmoid, safe_exp
+from openpilot.selfdrive.modeld.helpers import MODELS_DIR, CompileConfig, get_jit_input_devices
 
 PROCESS_NAME = "selfdrive.modeld.dmonitoringmodeld"
 SEND_RAW_PRED = os.getenv('SEND_RAW_PRED')
@@ -34,18 +32,21 @@ class ModelState:
       self.input_shapes = model_metadata['input_shapes']
       self.output_slices = model_metadata['output_slices']
 
+    self.model_run = pickle.loads(read_file_chunked(str(MODEL_PKL_PATH)))
+    self.model_input_devices = get_jit_input_devices(self.model_run)
+
     self.numpy_inputs = {
       'calib': np.zeros(self.input_shapes['calib'], dtype=np.float32),
     }
 
     self.warp_inputs_np = {'transform': np.zeros((3,3), dtype=np.float32)}
-    self.warp_inputs = {k: Tensor(v, device='NPY') for k,v in self.warp_inputs_np.items()}
     self.frame_buf_params = get_nv12_info(cam_w, cam_h)
     self.tensor_inputs = {k: Tensor(v, device='NPY').realize() for k,v in self.numpy_inputs.items()}
     self._blob_cache : dict[int, Tensor] = {}
-    self.model_run = pickle.loads(read_file_chunked(str(MODEL_PKL_PATH)))
     with open(CompileConfig(cam_w, cam_h, prefix='dm_', prepare_only=True).pkl_path, "rb") as f:
       self.image_warp = pickle.load(f)
+    self.warp_input_devices = get_jit_input_devices(self.image_warp)
+    self.warp_inputs = {'transform': Tensor(self.warp_inputs_np['transform'], device=self.warp_input_devices['M_inv'])}
 
   def run(self, buf: VisionBuf, calib: np.ndarray, transform: np.ndarray) -> tuple[np.ndarray, float]:
     self.numpy_inputs['calib'][0,:] = calib
@@ -55,10 +56,10 @@ class ModelState:
     ptr = buf.data.ctypes.data
     # There is a ringbuffer of imgs, just cache tensors pointing to all of them
     if ptr not in self._blob_cache:
-      self._blob_cache[ptr] = Tensor.from_blob(ptr, (self.frame_buf_params[3],), dtype='uint8')
+      self._blob_cache[ptr] = Tensor.from_blob(ptr, (self.frame_buf_params[3],), dtype='uint8', device=self.warp_input_devices['input_frame'])
 
     self.warp_inputs_np['transform'][:] = transform[:]
-    self.tensor_inputs['input_img'] = self.image_warp(self._blob_cache[ptr], self.warp_inputs['transform']).realize()
+    self.tensor_inputs['input_img'] = self.image_warp(input_frame=self._blob_cache[ptr], M_inv=self.warp_inputs['transform']).realize()
 
     output = self.model_run(**self.tensor_inputs).contiguous().realize().uop.base.buffer.numpy().flatten()
 

--- a/selfdrive/modeld/dmonitoringmodeld.py
+++ b/selfdrive/modeld/dmonitoringmodeld.py
@@ -33,20 +33,18 @@ class ModelState:
       self.output_slices = model_metadata['output_slices']
 
     self.model_run = pickle.loads(read_file_chunked(str(MODEL_PKL_PATH)))
-    self.model_input_devices = get_jit_input_devices(self.model_run)
 
-    self.numpy_inputs = {
-      'calib': np.zeros(self.input_shapes['calib'], dtype=np.float32),
-    }
-
-    self.warp_inputs_np = {'transform': np.zeros((3,3), dtype=np.float32)}
-    self.frame_buf_params = get_nv12_info(cam_w, cam_h)
+    self.numpy_inputs = {'calib': np.zeros(self.input_shapes['calib'], dtype=np.float32)}
     self.tensor_inputs = {k: Tensor(v, device='NPY').realize() for k,v in self.numpy_inputs.items()}
+
+    self.frame_buf_params = get_nv12_info(cam_w, cam_h)
     self._blob_cache : dict[int, Tensor] = {}
+
     with open(CompileConfig(cam_w, cam_h, prefix='dm_', prepare_only=True).pkl_path, "rb") as f:
       self.image_warp = pickle.load(f)
     self.warp_input_devices = get_jit_input_devices(self.image_warp)
-    self.warp_inputs = {'transform': Tensor(self.warp_inputs_np['transform'], device=self.warp_input_devices['M_inv'])}
+    self.warp_inputs_np = {'M_inv': np.zeros((3,3), dtype=np.float32)}
+    self.warp_inputs = {k: Tensor(v, device='NPY') for k, v in self.warp_inputs_np}
 
   def run(self, buf: VisionBuf, calib: np.ndarray, transform: np.ndarray) -> tuple[np.ndarray, float]:
     self.numpy_inputs['calib'][0,:] = calib
@@ -58,9 +56,8 @@ class ModelState:
     if ptr not in self._blob_cache:
       self._blob_cache[ptr] = Tensor.from_blob(ptr, (self.frame_buf_params[3],), dtype='uint8', device=self.warp_input_devices['input_frame'])
 
-    self.warp_inputs_np['transform'][:] = transform[:]
-    self.tensor_inputs['input_img'] = self.image_warp(input_frame=self._blob_cache[ptr], M_inv=self.warp_inputs['transform']).realize()
-
+    self.warp_inputs_np['M_inv'][:] = transform[:]
+    self.tensor_inputs['input_img'] = self.image_warp(input_frame=self._blob_cache[ptr], **self.warp_inputs).realize()
     output = self.model_run(**self.tensor_inputs).contiguous().realize().uop.base.buffer.numpy().flatten()
 
     t2 = time.perf_counter()

--- a/selfdrive/modeld/helpers.py
+++ b/selfdrive/modeld/helpers.py
@@ -1,19 +1,12 @@
-import json
-import os
 from dataclasses import dataclass
 from pathlib import Path
 
 from openpilot.system.camerad.cameras.nv12_info import get_nv12_info
 
 MODELS_DIR = Path(__file__).resolve().parent / 'models'
-COMPILED_FLAGS_PATH = MODELS_DIR / 'tg_compiled_flags.json'
 
-
-def set_tinygrad_backend_from_compiled_flags() -> None:
-  if os.path.isfile(COMPILED_FLAGS_PATH):
-    with open(COMPILED_FLAGS_PATH) as f:
-      os.environ['DEV'] = str(json.load(f)['DEV'])
-
+def get_jit_input_devices(jit) -> dict[str, str]:
+  return {name: info[3] for name, info in zip(jit.captured.expected_names, jit.captured.expected_input_info)}
 
 @dataclass
 class CompileConfig:

--- a/selfdrive/modeld/helpers.py
+++ b/selfdrive/modeld/helpers.py
@@ -6,7 +6,7 @@ from openpilot.system.camerad.cameras.nv12_info import get_nv12_info
 MODELS_DIR = Path(__file__).resolve().parent / 'models'
 
 def get_jit_input_devices(jit) -> dict[str, str]:
-  return {name: info[3] for name, info in zip(jit.captured.expected_names, jit.captured.expected_input_info)}
+  return {name: info[3] for name, info in zip(jit.captured.expected_names, jit.captured.expected_input_info, strict=True)}
 
 @dataclass
 class CompileConfig:

--- a/selfdrive/modeld/modeld.py
+++ b/selfdrive/modeld/modeld.py
@@ -119,7 +119,7 @@ class ModelState:
       # There is a ringbuffer of imgs, just cache tensors pointing to all of them
       cache_key = (key, ptr)
       if cache_key not in self._blob_cache:
-        self._blob_cache[cache_key] = Tensor.from_blob(ptr, (yuv_size,), dtype='uint8', device=self.input_devices['frame']) # TODO use key
+        self._blob_cache[cache_key] = Tensor.from_blob(ptr, (yuv_size,), dtype='uint8', device=self.input_devices['frame'])
       self.full_frames[key] = self._blob_cache[cache_key]
 
     # Model decides when action is completed, so desire input is just a pulse triggered on rising edge

--- a/selfdrive/modeld/modeld.py
+++ b/selfdrive/modeld/modeld.py
@@ -1,8 +1,5 @@
 #!/usr/bin/env python3
 import os
-from openpilot.selfdrive.modeld.helpers import MODELS_DIR, CompileConfig, set_tinygrad_backend_from_compiled_flags
-set_tinygrad_backend_from_compiled_flags()
-
 USBGPU = "USBGPU" in os.environ
 if USBGPU:
   os.environ['DEV'] = 'AMD'
@@ -30,6 +27,7 @@ from openpilot.selfdrive.modeld.compile_modeld import make_input_queues
 from openpilot.selfdrive.modeld.fill_model_msg import fill_model_msg, fill_pose_msg, PublishState
 from openpilot.common.file_chunker import read_file_chunked
 from openpilot.selfdrive.modeld.constants import ModelConstants, Plan
+from openpilot.selfdrive.modeld.helpers import MODELS_DIR, CompileConfig, get_jit_input_devices
 
 
 PROCESS_NAME = "selfdrive.modeld.modeld"
@@ -95,17 +93,19 @@ class ModelState:
     self.prev_desire = np.zeros(ModelConstants.DESIRE_LEN, dtype=np.float32)
 
     self.frame_skip = ModelConstants.MODEL_RUN_FREQ // ModelConstants.MODEL_CONTEXT_FREQ
-    self.input_queues, self.npy = make_input_queues(self.vision_input_shapes, self.policy_input_shapes, self.frame_skip)
     self.full_frames : dict[str, Tensor] = {}
     self._blob_cache : dict[int, Tensor] = {}
     self.parser = Parser()
     self.frame_buf_params = {k: get_nv12_info(cam_w, cam_h) for k in ('img', 'big_img')}
     self.run_policy = pickle.loads(read_file_chunked(CompileConfig(cam_w, cam_h, prefix='driving_', prepare_only=False).pkl_path))
     self.warp_enqueue = pickle.loads(read_file_chunked(CompileConfig(cam_w, cam_h, prefix='driving_', prepare_only=True).pkl_path))
+
+    self.input_devices = get_jit_input_devices(self.run_policy)
+    self.input_queues, self.npy = make_input_queues(self.vision_input_shapes, self.policy_input_shapes, self.frame_skip, self.input_devices)
     self.warp_enqueue(
       **self.input_queues,
-      frame=Tensor.zeros(self.frame_buf_params['img'][3], dtype='uint8').contiguous().realize(),
-      big_frame=Tensor.zeros(self.frame_buf_params['big_img'][3], dtype='uint8').contiguous().realize())
+      frame=Tensor.zeros(self.frame_buf_params['img'][3], dtype='uint8', device=self.input_devices['frame']).contiguous().realize(),
+      big_frame=Tensor.zeros(self.frame_buf_params['big_img'][3], dtype='uint8', device=self.input_devices['big_frame']).contiguous().realize())
 
   def slice_outputs(self, model_outputs: np.ndarray, output_slices: dict[str, slice]) -> dict[str, np.ndarray]:
     parsed_model_outputs = {k: model_outputs[np.newaxis, v] for k,v in output_slices.items()}
@@ -119,7 +119,7 @@ class ModelState:
       # There is a ringbuffer of imgs, just cache tensors pointing to all of them
       cache_key = (key, ptr)
       if cache_key not in self._blob_cache:
-        self._blob_cache[cache_key] = Tensor.from_blob(ptr, (yuv_size,), dtype='uint8')
+        self._blob_cache[cache_key] = Tensor.from_blob(ptr, (yuv_size,), dtype='uint8', device=self.input_devices['frame']) # TODO use key
       self.full_frames[key] = self._blob_cache[cache_key]
 
     # Model decides when action is completed, so desire input is just a pulse triggered on rising edge


### PR DESCRIPTION
choose device at compile time, retrieve from jit at runtime
pre-requisite for usbgpu where we warp on QCOM then run the model on AMD 