### PR TITLE
WifiManager: capture NewConnection signal from adding tethering connection

### DIFF
--- a/system/ui/lib/wifi_manager.py
+++ b/system/ui/lib/wifi_manager.py
@@ -210,6 +210,7 @@ class WifiManager:
     def worker():
       self._wait_for_wifi_device()
 
+      # TODO: wait for state thread to start before adding tethering connection, tiny race currently
       self._scan_thread.start()
       self._state_thread.start()
 

--- a/system/ui/lib/wifi_manager.py
+++ b/system/ui/lib/wifi_manager.py
@@ -210,14 +210,16 @@ class WifiManager:
     def worker():
       self._wait_for_wifi_device()
 
+      # Start signal threads before mutating NM so the NewConnection signal
+      # from _add_tethering_connection lands in _connections.
+      self._scan_thread.start()
+      self._state_thread.start()
+
       self._init_connections()
       if Params is not None and self._tethering_ssid not in self._connections:
         self._add_tethering_connection()
 
       self._init_wifi_state()
-
-      self._scan_thread.start()
-      self._state_thread.start()
 
       self._tethering_password = self._get_tethering_password()
       cloudlog.debug("WifiManager initialized")

--- a/system/ui/lib/wifi_manager.py
+++ b/system/ui/lib/wifi_manager.py
@@ -210,8 +210,6 @@ class WifiManager:
     def worker():
       self._wait_for_wifi_device()
 
-      # Start signal threads before mutating NM so the NewConnection signal
-      # from _add_tethering_connection lands in _connections.
       self._scan_thread.start()
       self._state_thread.start()
 


### PR DESCRIPTION
regression from https://github.com/commaai/openpilot/pull/37258, fixes https://github.com/commaai/openpilot/issues/37869

we were creating Hotspot connection before starting signal handler to store its connection id, so after a reboot it would have then worked