### PR TITLE
ui: re-apply mici/AugmentedRoadView _calc_frame_matrix caching

### DIFF
--- a/selfdrive/ui/mici/onroad/augmented_road_view.py
+++ b/selfdrive/ui/mici/onroad/augmented_road_view.py
@@ -293,20 +293,15 @@ class AugmentedRoadView(CameraView):
       self.view_from_wide_calib = view_frame_from_device_frame @ wide_from_device @ device_from_calib
 
   def _calc_frame_matrix(self, rect: rl.Rectangle) -> np.ndarray:
-    # Update model_renderer's screen offset every frame so overlay tracks camera
-    # position at 60Hz, even when the cache returns the same projection matrix.
-    self._model_renderer.set_screen_offset(self._content_rect.x, self._content_rect.y)
-
-    v_ego_quantized = round(ui_state.sm['carState'].vEgo, 1)
     cache_key = (
       ui_state.sm.recv_frame['liveCalibration'],
       int(self._content_rect.width),
       int(self._content_rect.height),
       self.stream_type,
-      v_ego_quantized
+      round(ui_state.sm['carState'].vEgo, 1),
     )
 
-    if cache_key == self._matrix_cache_key and self._cached_matrix is not None:
+    if cache_key == self._matrix_cache_key:
       return self._cached_matrix
 
     # Get camera configuration
@@ -325,7 +320,6 @@ class AugmentedRoadView(CameraView):
     kep = calib_transform @ inf_point
 
     # Calculate center points and dimensions
-    x, y = self._content_rect.x, self._content_rect.y
     w, h = self._content_rect.width, self._content_rect.height
     cx, cy = intrinsic[0, 2], intrinsic[1, 2]
 
@@ -352,9 +346,8 @@ class AugmentedRoadView(CameraView):
       [0, 0, 1.0]
     ])
 
-    # Compute video_transform with x=0, y=0 so the cached projection is independent of
-    # the parent rect's screen position. ModelRenderer applies (x, y) as a 2D screen
-    # offset post-projection — translation passes through linearly after the divide.
+    # video_transform is built without rect.x/y so the cached projection stays independent
+    # of screen position; ModelRenderer adds the rect offset at draw time.
     video_transform = np.array([
       [zoom, 0.0, (w / 2 - x_offset) - (cx * zoom)],
       [0.0, zoom, (h / 2 - y_offset) - (cy * zoom)],

--- a/selfdrive/ui/mici/onroad/augmented_road_view.py
+++ b/selfdrive/ui/mici/onroad/augmented_road_view.py
@@ -348,12 +348,16 @@ class AugmentedRoadView(CameraView):
       [0, 0, 1.0]
     ])
 
+    # Compute video_transform with x=0, y=0 so the cached projection is independent of
+    # the parent rect's screen position. ModelRenderer applies (x, y) as a 2D screen
+    # offset post-projection — translation passes through linearly after the divide.
     video_transform = np.array([
-      [zoom, 0.0, (w / 2 + x - x_offset) - (cx * zoom)],
-      [0.0, zoom, (h / 2 + y - y_offset) - (cy * zoom)],
+      [zoom, 0.0, (w / 2 - x_offset) - (cx * zoom)],
+      [0.0, zoom, (h / 2 - y_offset) - (cy * zoom)],
       [0.0, 0.0, 1.0]
     ])
     self._model_renderer.set_transform(video_transform @ calib_transform)
+    self._model_renderer.set_screen_offset(x, y)
 
     return self._cached_matrix
 

--- a/selfdrive/ui/mici/onroad/augmented_road_view.py
+++ b/selfdrive/ui/mici/onroad/augmented_road_view.py
@@ -139,7 +139,7 @@ class AugmentedRoadView(CameraView):
     self.view_from_calib = view_frame_from_device_frame.copy()
     self.view_from_wide_calib = view_frame_from_device_frame.copy()
 
-    self._matrix_cache_key = (0, 0, 0, 0, stream_type)
+    self._matrix_cache_key: tuple | None = None
     self._cached_matrix: np.ndarray | None = None
     self._content_rect = rl.Rectangle()
     self._last_click_time = 0.0

--- a/selfdrive/ui/mici/onroad/augmented_road_view.py
+++ b/selfdrive/ui/mici/onroad/augmented_road_view.py
@@ -301,7 +301,7 @@ class AugmentedRoadView(CameraView):
       round(ui_state.sm['carState'].vEgo, 1),
     )
 
-    if cache_key == self._matrix_cache_key:
+    if cache_key == self._matrix_cache_key and self._cached_matrix is not None:
       return self._cached_matrix
 
     # Get camera configuration

--- a/selfdrive/ui/mici/onroad/augmented_road_view.py
+++ b/selfdrive/ui/mici/onroad/augmented_road_view.py
@@ -293,6 +293,10 @@ class AugmentedRoadView(CameraView):
       self.view_from_wide_calib = view_frame_from_device_frame @ wide_from_device @ device_from_calib
 
   def _calc_frame_matrix(self, rect: rl.Rectangle) -> np.ndarray:
+    # Update model_renderer's screen offset every frame so overlay tracks camera
+    # position at 60Hz, even when the cache returns the same projection matrix.
+    self._model_renderer.set_screen_offset(self._content_rect.x, self._content_rect.y)
+
     v_ego_quantized = round(ui_state.sm['carState'].vEgo, 1)
     cache_key = (
       ui_state.sm.recv_frame['liveCalibration'],
@@ -357,7 +361,6 @@ class AugmentedRoadView(CameraView):
       [0.0, 0.0, 1.0]
     ])
     self._model_renderer.set_transform(video_transform @ calib_transform)
-    self._model_renderer.set_screen_offset(x, y)
 
     return self._cached_matrix
 

--- a/selfdrive/ui/mici/onroad/augmented_road_view.py
+++ b/selfdrive/ui/mici/onroad/augmented_road_view.py
@@ -346,8 +346,7 @@ class AugmentedRoadView(CameraView):
       [0, 0, 1.0]
     ])
 
-    # video_transform is built without rect.x/y so the cached projection stays independent
-    # of screen position; ModelRenderer adds the rect offset at draw time.
+    # built without rect.x/y so cache stays hot during scroll. ModelRenderer adds offset at draw time
     video_transform = np.array([
       [zoom, 0.0, (w / 2 - x_offset) - (cx * zoom)],
       [0.0, zoom, (h / 2 - y_offset) - (cy * zoom)],

--- a/selfdrive/ui/mici/onroad/augmented_road_view.py
+++ b/selfdrive/ui/mici/onroad/augmented_road_view.py
@@ -139,9 +139,7 @@ class AugmentedRoadView(CameraView):
     self.view_from_calib = view_frame_from_device_frame.copy()
     self.view_from_wide_calib = view_frame_from_device_frame.copy()
 
-    self._last_calib_time: float = 0
-    self._last_rect_dims = (0.0, 0.0)
-    self._last_stream_type = stream_type
+    self._matrix_cache_key = (0, 0, 0, 0, stream_type)
     self._cached_matrix: np.ndarray | None = None
     self._content_rect = rl.Rectangle()
     self._last_click_time = 0.0
@@ -295,10 +293,19 @@ class AugmentedRoadView(CameraView):
       self.view_from_wide_calib = view_frame_from_device_frame @ wide_from_device @ device_from_calib
 
   def _calc_frame_matrix(self, rect: rl.Rectangle) -> np.ndarray:
+    v_ego_quantized = round(ui_state.sm['carState'].vEgo, 1)
+    cache_key = (
+      ui_state.sm.recv_frame['liveCalibration'],
+      int(self._content_rect.width),
+      int(self._content_rect.height),
+      self.stream_type,
+      v_ego_quantized
+    )
+
+    if cache_key == self._matrix_cache_key and self._cached_matrix is not None:
+      return self._cached_matrix
+
     # Get camera configuration
-    # TODO: cache with vEgo?
-    calib_time = ui_state.sm.recv_frame['liveCalibration']
-    current_dims = (self._content_rect.width, self._content_rect.height)
     device_camera = self.device_camera or DEFAULT_DEVICE_CAMERA
     is_wide_camera = self.stream_type == WIDE_CAM
     intrinsic = device_camera.ecam.intrinsics if is_wide_camera else device_camera.fcam.intrinsics
@@ -334,9 +341,7 @@ class AugmentedRoadView(CameraView):
       x_offset, y_offset = 0, 0
 
     # Cache the computed transformation matrix to avoid recalculations
-    self._last_calib_time = calib_time
-    self._last_rect_dims = current_dims
-    self._last_stream_type = self.stream_type
+    self._matrix_cache_key = cache_key
     self._cached_matrix = np.array([
       [zoom * 2 * cx / w, 0, -x_offset / w * 2],
       [0, zoom * 2 * cy / h, -y_offset / h * 2],

--- a/selfdrive/ui/mici/onroad/model_renderer.py
+++ b/selfdrive/ui/mici/onroad/model_renderer.py
@@ -72,14 +72,12 @@ class ModelRenderer(Widget):
     self._torque_filter = FirstOrderFilter(0, 0.1, 1 / gui_app.target_fps)
     self._ll_color_filter = FirstOrderFilter(0.0, 0.1, 1 / gui_app.target_fps)
 
-    # Transform matrix (3x3 for car space to screen space)
+    # Transform matrix (3x3 for car space to screen space). Projection is done at the parent
+    # rect's origin (x=y=0); each draw method translates by self._rect.x/y so the cached
+    # projection stays independent of screen position (cache hot during scroll).
     self._car_space_transform = np.zeros((3, 3), dtype=np.float32)
     self._transform_dirty = True
     self._clip_region = None
-
-    # 2D screen offset applied post-projection; lets the cached projection stay independent
-    # of the parent rect's screen position so cache key doesn't include xy.
-    self._screen_offset = np.zeros(2, dtype=np.float32)
 
     self._exp_gradient = Gradient(
       start=(0.0, 1.0),  # Bottom of path
@@ -96,10 +94,6 @@ class ModelRenderer(Widget):
   def set_transform(self, transform: np.ndarray):
     self._car_space_transform = transform.astype(np.float32)
     self._transform_dirty = True
-
-  def set_screen_offset(self, dx: float, dy: float):
-    self._screen_offset[0] = dx
-    self._screen_offset[1] = dy
 
   def _render(self, rect: rl.Rectangle):
     sm = ui_state.sm
@@ -229,7 +223,8 @@ class ModelRenderer(Widget):
     if not self._experimental_mode:
       return
 
-    max_len = min(len(self._path.projected_points) // 2, len(self._acceleration_x))
+    path_pts = self._path.projected_points + np.array([self._rect.x, self._rect.y], dtype=np.float32)
+    max_len = min(len(path_pts) // 2, len(self._acceleration_x))
 
     segment_colors = []
     gradient_stops = []
@@ -237,7 +232,7 @@ class ModelRenderer(Widget):
     i = 0
     while i < max_len:
       # Some points (screen space) are out of frame (rect space)
-      track_y = self._path.projected_points[i][1]
+      track_y = path_pts[i][1]
       if track_y < self._rect.y or track_y > (self._rect.y + self._rect.height):
         i += 1
         continue
@@ -315,12 +310,14 @@ class ModelRenderer(Widget):
   def _draw_lane_lines(self):
     """Draw lane lines and road edges"""
     """Two closest lines should be green (lane line or road edges)"""
+    offset = np.array([self._rect.x, self._rect.y], dtype=np.float32)
+
     for i, lane_line in enumerate(self._lane_lines):
       if lane_line.projected_points.size == 0:
         continue
 
       color = self._get_ll_color(float(self._lane_line_probs[i]), i in (1, 2), i in (0, 1))
-      draw_polygon(self._rect, lane_line.projected_points + self._screen_offset, color)
+      draw_polygon(self._rect, lane_line.projected_points + offset, color)
 
     for i, road_edge in enumerate(self._road_edges):
       if road_edge.projected_points.size == 0:
@@ -328,7 +325,7 @@ class ModelRenderer(Widget):
 
       # if closest lane lines are not confident, make road edges green
       color = self._get_ll_color(float(1.0 - self._road_edge_stds[i]), float(self._lane_line_probs[i + 1]) < 0.25, i == 0)
-      draw_polygon(self._rect, road_edge.projected_points + self._screen_offset, color)
+      draw_polygon(self._rect, road_edge.projected_points + offset, color)
 
   def _draw_path(self, sm):
     """Draw path with dynamic coloring based on mode and throttle state."""
@@ -338,14 +335,16 @@ class ModelRenderer(Widget):
     allow_throttle = sm['longitudinalPlan'].allowThrottle or not self._longitudinal_control
     self._blend_filter.update(int(allow_throttle))
 
+    path_pts = self._path.projected_points + np.array([self._rect.x, self._rect.y], dtype=np.float32)
+
     if self._experimental_mode:
       # Draw with acceleration coloring
       if ui_state.status == UIStatus.DISENGAGED:
-        draw_polygon(self._rect, self._path.projected_points + self._screen_offset, rl.Color(0, 0, 0, 90))
+        draw_polygon(self._rect, path_pts, rl.Color(0, 0, 0, 90))
       elif len(self._exp_gradient.colors) > 1:
-        draw_polygon(self._rect, self._path.projected_points + self._screen_offset, gradient=self._exp_gradient)
+        draw_polygon(self._rect, path_pts, gradient=self._exp_gradient)
       else:
-        draw_polygon(self._rect, self._path.projected_points + self._screen_offset, rl.Color(255, 255, 255, 30))
+        draw_polygon(self._rect, path_pts, rl.Color(255, 255, 255, 30))
     else:
       # Blend throttle/no throttle colors based on transition
       blend_factor = round(self._blend_filter.x * 100) / 100
@@ -358,9 +357,9 @@ class ModelRenderer(Widget):
       )
 
       if ui_state.status == UIStatus.DISENGAGED:
-        draw_polygon(self._rect, self._path.projected_points + self._screen_offset, rl.Color(0, 0, 0, 90))
+        draw_polygon(self._rect, path_pts, rl.Color(0, 0, 0, 90))
       else:
-        draw_polygon(self._rect, self._path.projected_points + self._screen_offset, gradient=gradient)
+        draw_polygon(self._rect, path_pts, gradient=gradient)
 
   def _draw_lead_indicator(self):
     # Draw lead vehicles if available

--- a/selfdrive/ui/mici/onroad/model_renderer.py
+++ b/selfdrive/ui/mici/onroad/model_renderer.py
@@ -72,7 +72,7 @@ class ModelRenderer(Widget):
     self._torque_filter = FirstOrderFilter(0, 0.1, 1 / gui_app.target_fps)
     self._ll_color_filter = FirstOrderFilter(0.0, 0.1, 1 / gui_app.target_fps)
 
-    # 3x3 car space -> rect-origin space; draw methods translate by self._rect.x/y so cache stays hot during scroll
+    # 3x3 car space -> rect-origin space (draw methods add rect.x/y)
     self._car_space_transform = np.zeros((3, 3), dtype=np.float32)
     self._transform_dirty = True
     self._clip_region = None
@@ -306,8 +306,7 @@ class ModelRenderer(Widget):
     return color
 
   def _draw_lane_lines(self):
-    """Draw lane lines and road edges"""
-    """Two closest lines should be green (lane line or road edges)"""
+    """Draw lane lines and road edges. Two closest lines should be green (lane line or road edges)."""
     offset = np.array([self._rect.x, self._rect.y], dtype=np.float32)
 
     for i, lane_line in enumerate(self._lane_lines):

--- a/selfdrive/ui/mici/onroad/model_renderer.py
+++ b/selfdrive/ui/mici/onroad/model_renderer.py
@@ -72,9 +72,7 @@ class ModelRenderer(Widget):
     self._torque_filter = FirstOrderFilter(0, 0.1, 1 / gui_app.target_fps)
     self._ll_color_filter = FirstOrderFilter(0.0, 0.1, 1 / gui_app.target_fps)
 
-    # Transform matrix (3x3 for car space to screen space). Projection is done at the parent
-    # rect's origin (x=y=0); each draw method translates by self._rect.x/y so the cached
-    # projection stays independent of screen position (cache hot during scroll).
+    # 3x3 car space -> rect-origin space; draw methods translate by self._rect.x/y so cache stays hot during scroll
     self._car_space_transform = np.zeros((3, 3), dtype=np.float32)
     self._transform_dirty = True
     self._clip_region = None

--- a/selfdrive/ui/mici/onroad/model_renderer.py
+++ b/selfdrive/ui/mici/onroad/model_renderer.py
@@ -77,6 +77,10 @@ class ModelRenderer(Widget):
     self._transform_dirty = True
     self._clip_region = None
 
+    # 2D screen offset applied post-projection; lets the cached projection stay independent
+    # of the parent rect's screen position so cache key doesn't include xy.
+    self._screen_offset = np.zeros(2, dtype=np.float32)
+
     self._exp_gradient = Gradient(
       start=(0.0, 1.0),  # Bottom of path
       end=(0.0, 0.0),  # Top of path
@@ -92,6 +96,10 @@ class ModelRenderer(Widget):
   def set_transform(self, transform: np.ndarray):
     self._car_space_transform = transform.astype(np.float32)
     self._transform_dirty = True
+
+  def set_screen_offset(self, dx: float, dy: float):
+    self._screen_offset[0] = dx
+    self._screen_offset[1] = dy
 
   def _render(self, rect: rl.Rectangle):
     sm = ui_state.sm
@@ -312,7 +320,7 @@ class ModelRenderer(Widget):
         continue
 
       color = self._get_ll_color(float(self._lane_line_probs[i]), i in (1, 2), i in (0, 1))
-      draw_polygon(self._rect, lane_line.projected_points, color)
+      draw_polygon(self._rect, lane_line.projected_points + self._screen_offset, color)
 
     for i, road_edge in enumerate(self._road_edges):
       if road_edge.projected_points.size == 0:
@@ -320,7 +328,7 @@ class ModelRenderer(Widget):
 
       # if closest lane lines are not confident, make road edges green
       color = self._get_ll_color(float(1.0 - self._road_edge_stds[i]), float(self._lane_line_probs[i + 1]) < 0.25, i == 0)
-      draw_polygon(self._rect, road_edge.projected_points, color)
+      draw_polygon(self._rect, road_edge.projected_points + self._screen_offset, color)
 
   def _draw_path(self, sm):
     """Draw path with dynamic coloring based on mode and throttle state."""
@@ -333,11 +341,11 @@ class ModelRenderer(Widget):
     if self._experimental_mode:
       # Draw with acceleration coloring
       if ui_state.status == UIStatus.DISENGAGED:
-        draw_polygon(self._rect, self._path.projected_points, rl.Color(0, 0, 0, 90))
+        draw_polygon(self._rect, self._path.projected_points + self._screen_offset, rl.Color(0, 0, 0, 90))
       elif len(self._exp_gradient.colors) > 1:
-        draw_polygon(self._rect, self._path.projected_points, gradient=self._exp_gradient)
+        draw_polygon(self._rect, self._path.projected_points + self._screen_offset, gradient=self._exp_gradient)
       else:
-        draw_polygon(self._rect, self._path.projected_points, rl.Color(255, 255, 255, 30))
+        draw_polygon(self._rect, self._path.projected_points + self._screen_offset, rl.Color(255, 255, 255, 30))
     else:
       # Blend throttle/no throttle colors based on transition
       blend_factor = round(self._blend_filter.x * 100) / 100
@@ -350,9 +358,9 @@ class ModelRenderer(Widget):
       )
 
       if ui_state.status == UIStatus.DISENGAGED:
-        draw_polygon(self._rect, self._path.projected_points, rl.Color(0, 0, 0, 90))
+        draw_polygon(self._rect, self._path.projected_points + self._screen_offset, rl.Color(0, 0, 0, 90))
       else:
-        draw_polygon(self._rect, self._path.projected_points, gradient=gradient)
+        draw_polygon(self._rect, self._path.projected_points + self._screen_offset, gradient=gradient)
 
   def _draw_lead_indicator(self):
     # Draw lead vehicles if available


### PR DESCRIPTION
Re-applies @deanlee's #36669 (reverted by #36749) and addresses the scroll desync that prompted the revert.

The cached `video_transform` is built with `x=y=0`, so the cache key doesn't depend on the parent rect's screen position. `ModelRenderer` adds `rect.x/y` to projected points at draw time. Cache stays hot during home<->onroad swipe; model overlay still tracks the camera at 60Hz because the offset is a cheap per-frame add.

Per-frame `_update_model` work drops from 60Hz to ~20Hz (model publish rate).

Measured on comma four (engaged onroad, AGNOS 18.1):
- Before: `uiDebug.drawTimeMillis` p50 ~8.7ms, fps drops during scroll
- After: ~5.6ms, no fps drop during scroll (sustained 59fps)

Test plan
- [x] Manual: engaged onroad, idle and during home<->onroad swipe — overlay stays glued to camera
- [x] Measured: `uiDebug.drawTimeMillis` p50 dropped, no fps drop during scroll