### PR TITLE
modem: register cellular DNS with systemd-resolved

### DIFF
--- a/selfdrive/test/test_onroad.py
+++ b/selfdrive/test/test_onroad.py
@@ -68,7 +68,7 @@ PROCS = {
   "system.loggerd.deleter": 1.0,
   "./pandad": 19.0,
   "system.qcomgpsd.qcomgpsd": 1.0,
-  #"system.hardware.tici.modem": 2.0,
+  "system.hardware.tici.modem": 2.0,
 }
 
 TIMINGS = {

--- a/system/hardware/tici/modem.py
+++ b/system/hardware/tici/modem.py
@@ -150,7 +150,7 @@ class PPPSession:
                 ["sudo", "resolvectl", "default-route", "ppp0", "yes"]):
       r = subprocess.run(cmd, capture_output=True, text=True)
       if r.returncode != 0:
-        logging.warning(f"resolvectl failed ({' '.join(cmd[1:])}): {r.stderr.strip()}")
+        logging.warning(f"resolvectl failed ({' '.join(cmd[1:])}): {r.stderr.strip()}; killing PPP session to retry DNS install")
         self.kill()
         return False
     logging.info(f"resolvectl: ppp0 DNS = {dns_servers}")

--- a/system/hardware/tici/modem.py
+++ b/system/hardware/tici/modem.py
@@ -142,6 +142,20 @@ class PPPSession:
     self._peer = peer
     return True
 
+  def maybe_install_dns(self, dns_servers: list[str]) -> bool:
+    """Register DNS servers with systemd-resolved; kill the session on failure to force a retry."""
+    if not dns_servers:
+      return False
+    for cmd in (["sudo", "resolvectl", "dns", "ppp0", *dns_servers],
+                ["sudo", "resolvectl", "default-route", "ppp0", "yes"]):
+      r = subprocess.run(cmd, capture_output=True, text=True)
+      if r.returncode != 0:
+        logging.warning(f"resolvectl failed ({' '.join(cmd[1:])}): {r.stderr.strip()}")
+        self.kill()
+        return False
+    logging.info(f"resolvectl: ppp0 DNS = {dns_servers}")
+    return True
+
   @staticmethod
   def cleanup_routes():
     subprocess.run(["sudo", "ip", "route", "del", "default", "dev", "ppp0"], capture_output=True)
@@ -451,8 +465,8 @@ class Modem:
             peer = parts[parts.index("peer") + 1].split("/")[0]
           break
       if ip:
-        if self._ppp.maybe_install_routes(ip, peer) and not self._push_cellular_dns():
-          self._ppp.kill()
+        if self._ppp.maybe_install_routes(ip, peer):
+          self._ppp.maybe_install_dns(self._read_cellular_dns())
         return {"ip_address": ip, "connected": True}
       if self.S["connected"]:
         return {"connected": False, "ip_address": ""}
@@ -460,10 +474,10 @@ class Modem:
       pass
     return {}
 
-  def _push_cellular_dns(self) -> bool:
+  def _read_cellular_dns(self) -> list[str]:
     v = self._atv(f"AT+CGCONTRDP={DIAL_CID}", "+CGCONTRDP:")
     if not v:
-      return False
+      return []
     # +CGCONTRDP: <cid>,<bearer_id>,<apn>,<local_addr>,<gw_addr>,<dns_prim>,<dns_sec>,...
     fields = [f.strip().strip('"') for f in v.split(",")]
     dns_servers = []
@@ -472,16 +486,7 @@ class Modem:
         dns_servers.append(str(IPv4Address(d)))
       except (AddressValueError, ValueError):
         pass
-    if not dns_servers:
-      return False
-    for cmd in (["sudo", "resolvectl", "dns", "ppp0", *dns_servers],
-                ["sudo", "resolvectl", "default-route", "ppp0", "yes"]):
-      r = subprocess.run(cmd, capture_output=True, text=True)
-      if r.returncode != 0:
-        logging.warning(f"resolvectl failed ({' '.join(cmd[1:])}): {r.stderr.strip()}")
-        return False
-    logging.info(f"resolvectl: ppp0 DNS = {dns_servers}")
-    return True
+    return dns_servers
 
   def _poll_byte_counters(self) -> dict:
     try:

--- a/system/hardware/tici/modem.py
+++ b/system/hardware/tici/modem.py
@@ -114,17 +114,17 @@ class PPPSession:
   def fails(self) -> int:
     return self._fails
 
-  def maybe_install_routes(self, ip: str, peer: str):
+  def maybe_install_routes(self, ip: str, peer: str) -> bool:
     """Install routes if peer changed; kill the session on failure so the state machine reconnects."""
     if not peer or peer == self._peer:
-      return
+      return False
     try:
       IPv4Address(ip)
       IPv4Address(peer)
     except AddressValueError:
       logging.warning(f"refusing route install with non-IPv4 ip={ip!r} peer={peer!r}")
       self.kill()
-      return
+      return False
     self.cleanup_routes()
     cmds = [
       ["sudo", "ip", "route", "add", "default", "via", peer, "dev", "ppp0", "metric", "1000"],
@@ -137,9 +137,10 @@ class PPPSession:
         logging.warning(f"route install failed ({' '.join(cmd[1:])}): {r.stderr.strip()}")
         self.cleanup_routes()
         self.kill()
-        return
+        return False
     logging.info(f"route set up for {ip} via {peer}")
     self._peer = peer
+    return True
 
   @staticmethod
   def cleanup_routes():
@@ -148,6 +149,7 @@ class PPPSession:
     # rules don't have a flush; delete until none remain
     while subprocess.run(["sudo", "ip", "rule", "del", "table", "1000"], capture_output=True).returncode == 0:
       pass
+    subprocess.run(["sudo", "resolvectl", "revert", "ppp0"], capture_output=True)
 
 
 class Modem:
@@ -449,13 +451,32 @@ class Modem:
             peer = parts[parts.index("peer") + 1].split("/")[0]
           break
       if ip:
-        self._ppp.maybe_install_routes(ip, peer)
+        if self._ppp.maybe_install_routes(ip, peer):
+          self._push_cellular_dns()
         return {"ip_address": ip, "connected": True}
       if self.S["connected"]:
         return {"connected": False, "ip_address": ""}
     except Exception:
       pass
     return {}
+
+  def _push_cellular_dns(self):
+    v = self._atv(f"AT+CGCONTRDP={DIAL_CID}", "+CGCONTRDP:")
+    if not v:
+      return
+    # +CGCONTRDP: <cid>,<bearer_id>,<apn>,<local_addr>,<gw_addr>,<dns_prim>,<dns_sec>,...
+    fields = [f.strip().strip('"') for f in v.split(",")]
+    dns_servers = []
+    for d in fields[5:7]:
+      try:
+        dns_servers.append(str(IPv4Address(d)))
+      except (AddressValueError, ValueError):
+        pass
+    if not dns_servers:
+      return
+    subprocess.run(["sudo", "resolvectl", "dns", "ppp0", *dns_servers], capture_output=True)
+    subprocess.run(["sudo", "resolvectl", "default-route", "ppp0", "yes"], capture_output=True)
+    logging.info(f"resolvectl: ppp0 DNS = {dns_servers}")
 
   def _poll_byte_counters(self) -> dict:
     try:

--- a/system/hardware/tici/modem.py
+++ b/system/hardware/tici/modem.py
@@ -451,8 +451,8 @@ class Modem:
             peer = parts[parts.index("peer") + 1].split("/")[0]
           break
       if ip:
-        if self._ppp.maybe_install_routes(ip, peer):
-          self._push_cellular_dns()
+        if self._ppp.maybe_install_routes(ip, peer) and not self._push_cellular_dns():
+          self._ppp.kill()
         return {"ip_address": ip, "connected": True}
       if self.S["connected"]:
         return {"connected": False, "ip_address": ""}
@@ -460,10 +460,10 @@ class Modem:
       pass
     return {}
 
-  def _push_cellular_dns(self):
+  def _push_cellular_dns(self) -> bool:
     v = self._atv(f"AT+CGCONTRDP={DIAL_CID}", "+CGCONTRDP:")
     if not v:
-      return
+      return False
     # +CGCONTRDP: <cid>,<bearer_id>,<apn>,<local_addr>,<gw_addr>,<dns_prim>,<dns_sec>,...
     fields = [f.strip().strip('"') for f in v.split(",")]
     dns_servers = []
@@ -473,10 +473,15 @@ class Modem:
       except (AddressValueError, ValueError):
         pass
     if not dns_servers:
-      return
-    subprocess.run(["sudo", "resolvectl", "dns", "ppp0", *dns_servers], capture_output=True)
-    subprocess.run(["sudo", "resolvectl", "default-route", "ppp0", "yes"], capture_output=True)
+      return False
+    for cmd in (["sudo", "resolvectl", "dns", "ppp0", *dns_servers],
+                ["sudo", "resolvectl", "default-route", "ppp0", "yes"]):
+      r = subprocess.run(cmd, capture_output=True, text=True)
+      if r.returncode != 0:
+        logging.warning(f"resolvectl failed ({' '.join(cmd[1:])}): {r.stderr.strip()}")
+        return False
     logging.info(f"resolvectl: ppp0 DNS = {dns_servers}")
+    return True
 
   def _poll_byte_counters(self) -> dict:
     try:

--- a/system/hardware/tici/modem.py
+++ b/system/hardware/tici/modem.py
@@ -145,6 +145,7 @@ class PPPSession:
   def maybe_install_dns(self, dns_servers: list[str]) -> bool:
     """Register DNS servers with systemd-resolved; kill the session on failure to force a retry."""
     if not dns_servers:
+      logging.warning("no cellular DNS servers reported by modem")
       return False
     for cmd in (["sudo", "resolvectl", "dns", "ppp0", *dns_servers],
                 ["sudo", "resolvectl", "default-route", "ppp0", "yes"]):

--- a/system/hardware/tici/modem.py
+++ b/system/hardware/tici/modem.py
@@ -145,7 +145,6 @@ class PPPSession:
   def maybe_install_dns(self, dns_servers: list[str]) -> bool:
     """Register DNS servers with systemd-resolved; kill the session on failure to force a retry."""
     if not dns_servers:
-      logging.warning("no cellular DNS servers reported by modem")
       return False
     for cmd in (["sudo", "resolvectl", "dns", "ppp0", *dns_servers],
                 ["sudo", "resolvectl", "default-route", "ppp0", "yes"]):
@@ -487,6 +486,8 @@ class Modem:
         dns_servers.append(str(IPv4Address(d)))
       except (AddressValueError, ValueError):
         pass
+    if not dns_servers:
+      logging.warning(f"no cellular DNS servers reported by modem: {v!r}")
     return dns_servers
 
   def _poll_byte_counters(self) -> dict:

--- a/system/hardware/tici/modem.py
+++ b/system/hardware/tici/modem.py
@@ -150,7 +150,7 @@ class PPPSession:
                 ["sudo", "resolvectl", "default-route", "ppp0", "yes"]):
       r = subprocess.run(cmd, capture_output=True, text=True)
       if r.returncode != 0:
-        logging.warning(f"resolvectl failed ({' '.join(cmd[1:])}): {r.stderr.strip()}; killing PPP session to retry DNS install")
+        logging.warning(f"resolvectl failed ({' '.join(cmd[1:])}): {r.stderr.strip()}")
         self.kill()
         return False
     logging.info(f"resolvectl: ppp0 DNS = {dns_servers}")

--- a/system/manager/process_config.py
+++ b/system/manager/process_config.py
@@ -106,7 +106,7 @@ procs = [
   PythonProcess("lateral_maneuversd", "tools.lateral_maneuvers.lateral_maneuversd", lat_maneuver),
   PythonProcess("radard", "selfdrive.controls.radard", only_onroad),
   PythonProcess("hardwared", "system.hardware.hardwared", always_run),
-  PythonProcess("modem", "system.hardware.tici.modem", always_run, enabled=False),
+  PythonProcess("modem", "system.hardware.tici.modem", always_run, enabled=TICI),
   PythonProcess("tombstoned", "system.tombstoned", always_run, enabled=not PC),
   PythonProcess("updated", "system.updated.updated", only_offroad, enabled=not PC),
   PythonProcess("uploader", "system.loggerd.uploader", always_run),


### PR DESCRIPTION
route confirming working: https://connect.comma.ai/01d0cc62a37a1155/0000000e--9040f31646

on wifi, DNS servers are established properly through NM. when wifi isn't connected, dns is never setup by modem.py so though the network link is established, device cannot connect to the internet

modem.py needs to set the modem's negotiated DNS servers into resolved

mici with wifi forgotten:
```
$ ssh comma@comma-8c451d878d4a6cb0 "echo '=== ip rule ==='; ip rule show; echo; echo '=== main table ==='; ip route show table main; echo; echo '=== local table ==='; ip route show table local; echo; echo '=== table 1000 ==='; ip route show table 1000; echo; echo '=== table default ==='; ip route show table default; echo; echo '=== all numeric tables ==='; ip route show table all 2>&1 | awk '{for(i=1;i<=NF;i++)if(\$i==\"table\")print \$(i+1)}' | sort -u; echo; echo '=== ppp0 addr ==='; ip -4 addr show ppp0; echo; echo '=== resolvectl status (full) ==='; resolvectl status; echo; echo '=== /etc/resolv.conf ==='; cat /etc/resolv.conf; echo; echo '=== modem state ==='; jq '{state, iccid, ip_address, operator, network_type, registration}' /dev/shm/modem"
=== ip rule ===
0:	from all lookup local
32765:	from 10.211.163.246 lookup 1000
32766:	from all lookup main
32767:	from all lookup default

=== main table ===
default via 10.64.64.64 dev ppp0 metric 1000 
10.64.64.64 dev ppp0 proto kernel scope link src 10.211.163.246 

=== local table ===
local 10.211.163.246 dev ppp0 proto kernel scope host src 10.211.163.246 
broadcast 127.0.0.0 dev lo proto kernel scope link src 127.0.0.1 
local 127.0.0.0/8 dev lo proto kernel scope host src 127.0.0.1 
local 127.0.0.1 dev lo proto kernel scope host src 127.0.0.1 
broadcast 127.255.255.255 dev lo proto kernel scope link src 127.0.0.1 

=== table 1000 ===
default via 10.64.64.64 dev ppp0 

=== table default ===

=== all numeric tables ===
1000
local

=== ppp0 addr ===
16: ppp0: <POINTOPOINT,MULTICAST,NOARP,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UNKNOWN group default qlen 3
    inet 10.211.163.246 peer 10.64.64.64/32 scope global ppp0
       valid_lft forever preferred_lft forever

=== resolvectl status (full) ===
Global
         Protocols: -LLMNR -mDNS -DNSOverTLS DNSSEC=no/unsupported
  resolv.conf mode: stub

Link 2 (bond0)
    Current Scopes: none
         Protocols: -DefaultRoute -LLMNR -mDNS -DNSOverTLS DNSSEC=no/unsupported

Link 3 (dummy0)
    Current Scopes: none
         Protocols: -DefaultRoute -LLMNR -mDNS -DNSOverTLS DNSSEC=no/unsupported

Link 4 (ifb0)
    Current Scopes: none
         Protocols: -DefaultRoute -LLMNR -mDNS -DNSOverTLS DNSSEC=no/unsupported

Link 5 (ifb1)
    Current Scopes: none
         Protocols: -DefaultRoute -LLMNR -mDNS -DNSOverTLS DNSSEC=no/unsupported

Link 6 (ip_vti0)
    Current Scopes: none
         Protocols: -DefaultRoute -LLMNR -mDNS -DNSOverTLS DNSSEC=no/unsupported

Link 7 (ip6_vti0)
    Current Scopes: none
         Protocols: -DefaultRoute -LLMNR -mDNS -DNSOverTLS DNSSEC=no/unsupported

Link 8 (sit0)
    Current Scopes: none
         Protocols: -DefaultRoute -LLMNR -mDNS -DNSOverTLS DNSSEC=no/unsupported

Link 9 (ip6tnl0)
    Current Scopes: none
         Protocols: -DefaultRoute -LLMNR -mDNS -DNSOverTLS DNSSEC=no/unsupported

Link 10 (rmnet_ipa0)
    Current Scopes: none
         Protocols: -DefaultRoute -LLMNR -mDNS -DNSOverTLS DNSSEC=no/unsupported

Link 11 (usb0)
    Current Scopes: none
         Protocols: -DefaultRoute -LLMNR -mDNS -DNSOverTLS DNSSEC=no/unsupported

Link 13 (wlan0)
    Current Scopes: none
         Protocols: -DefaultRoute -LLMNR -mDNS -DNSOverTLS DNSSEC=no/unsupported

Link 14 (p2p0)
    Current Scopes: none
         Protocols: -DefaultRoute -LLMNR -mDNS -DNSOverTLS DNSSEC=no/unsupported

Link 16 (ppp0)
    Current Scopes: DNS
         Protocols: +DefaultRoute -LLMNR -mDNS -DNSOverTLS DNSSEC=no/unsupported
Current DNS Server: 8.8.8.8
       DNS Servers: 8.8.8.8 1.1.1.1

=== /etc/resolv.conf ===
# This is /run/systemd/resolve/stub-resolv.conf managed by man:systemd-resolved(8).
# Do not edit.
#
# This file might be symlinked as /etc/resolv.conf. If you're looking at
# /etc/resolv.conf and seeing this text, you have followed the symlink.
#
# This is a dynamic resolv.conf file for connecting local clients to the
# internal DNS stub resolver of systemd-resolved. This file lists all
# configured search domains.
#
# Run "resolvectl status" to see details about the uplink DNS servers
# currently in use.
#
# Third party programs should typically not access this file directly, but only
# through the symlink at /etc/resolv.conf. To manage man:resolv.conf(5) in a
# different way, replace this symlink by a static file or a different symlink.
#
# See man:systemd-resolved.service(8) for details about the supported modes of
# operation for /etc/resolv.conf.

nameserver 127.0.0.53
options edns0 trust-ad
search .

=== modem state ===
{
  "state": "CONNECTED",
  "iccid": "89852351224030048077",
  "ip_address": "10.211.163.246",
  "operator": "AT&T",
  "network_type": "lte",
  "registration": "roaming"
}
```