### PR TITLE
ui: real startup profiling

### DIFF
--- a/system/ui/lib/application.py
+++ b/system/ui/lib/application.py
@@ -48,40 +48,21 @@ OFFSCREEN = os.getenv("OFFSCREEN") == "1"  # Disable FPS limiting for fast offli
 
 
 def get_process_elapsed_ms() -> float | None:
-  try:
-    with open("/proc/self/stat") as f:
-      stat = f.read()
-    with open("/proc/uptime") as f:
-      uptime = float(f.read().split()[0])
-
-    # Field 2, comm, can contain spaces and is wrapped in parentheses.
-    fields_after_comm = stat.rsplit(")", 1)[1].split()
-    start_ticks = int(fields_after_comm[19])
-    ticks_per_second = os.sysconf(os.sysconf_names["SC_CLK_TCK"])
-    return (uptime - (start_ticks / ticks_per_second)) * 1e3
-  except Exception:
+  if not os.path.isfile("/proc/self/stat"):
     return None
 
+  with open("/proc/self/stat") as f:
+    stat = f.read()
+  with open("/proc/uptime") as f:
+    uptime = float(f.read().split()[0])
 
-STARTUP_TIMELINE = [
-  ("process start", 0.0),
-  ("UI module loaded (interpreter + early imports)", get_process_elapsed_ms()),
-]
+  # Field 2, comm, can contain spaces and is wrapped in parentheses.
+  fields_after_comm = stat.rsplit(")", 1)[1].split()
+  start_ticks = int(fields_after_comm[19])
+  ticks_per_second = os.sysconf(os.sysconf_names["SC_CLK_TCK"])
+  return (uptime - (start_ticks / ticks_per_second)) * 1e3
 
-
-def print_startup_timeline(timeline: list[tuple[str, float | None]]):
-  print("\nStartup timeline:")
-  label_width = max(len(label) for label, _ in timeline)
-  last_ms = None
-  for label, elapsed_ms in timeline:
-    if elapsed_ms is None:
-      print(f"  {label:<{label_width}}  {'unavailable':>12}")
-      continue
-
-    delta = "" if last_ms is None else f"+{elapsed_ms - last_ms:.1f} ms"
-    print(f"  {label:<{label_width}}  {elapsed_ms:8.1f} ms  {delta:>10}")
-    last_ms = elapsed_ms
-
+MODULE_START_TIME = get_process_elapsed_ms()
 
 GL_VERSION = """
 #version 300 es
@@ -380,8 +361,11 @@ class GuiApplication:
 
     profiler = cProfile.Profile()
     start_time = time.monotonic()
-    self._startup_timeline = STARTUP_TIMELINE.copy()
-    self._startup_timeline.append(("init_window entered (entrypoint imports complete)", get_process_elapsed_ms()))
+    self._startup_timeline = [
+      ("process start", 0.0),
+      ("UI module loaded (interpreter + early imports)", MODULE_START_TIME),
+      ("init_window entered (entrypoint imports complete)", get_process_elapsed_ms()),
+    ]
     profiler.enable()
 
     def print_startup_profile():
@@ -403,7 +387,18 @@ class GuiApplication:
       else:
         print(f"{green}Profiled Python startup in {elapsed_ms:.1f} ms{reset}")
       if self._startup_timeline is not None:
-        print_startup_timeline(self._startup_timeline)
+        print("\nStartup timeline:")
+        label_width = max(len(label) for label, _ in self._startup_timeline)
+        last_ms = None
+        for label, elapsed_ms in self._startup_timeline:
+          if elapsed_ms is None:
+            print(f"  {label:<{label_width}}  {'unavailable':>12}")
+            continue
+
+          delta = "" if last_ms is None else f"+{elapsed_ms - last_ms:.1f} ms"
+          print(f"  {label:<{label_width}}  {elapsed_ms:8.1f} ms  {delta:>10}")
+          last_ms = elapsed_ms
+
 
     atexit.register(print_startup_profile)
 

--- a/system/ui/lib/application.py
+++ b/system/ui/lib/application.py
@@ -46,6 +46,43 @@ RECORD_BITRATE = os.getenv("RECORD_BITRATE", "")  # Target bitrate e.g. "2000k" 
 RECORD_SPEED = int(os.getenv("RECORD_SPEED", "1"))  # Speed multiplier
 OFFSCREEN = os.getenv("OFFSCREEN") == "1"  # Disable FPS limiting for fast offline rendering
 
+
+def get_process_elapsed_ms() -> float | None:
+  try:
+    with open("/proc/self/stat") as f:
+      stat = f.read()
+    with open("/proc/uptime") as f:
+      uptime = float(f.read().split()[0])
+
+    # Field 2, comm, can contain spaces and is wrapped in parentheses.
+    fields_after_comm = stat.rsplit(")", 1)[1].split()
+    start_ticks = int(fields_after_comm[19])
+    ticks_per_second = os.sysconf(os.sysconf_names["SC_CLK_TCK"])
+    return (uptime - (start_ticks / ticks_per_second)) * 1e3
+  except Exception:
+    return None
+
+
+STARTUP_TIMELINE = [
+  ("process start", 0.0),
+  ("UI module loaded (interpreter + early imports)", get_process_elapsed_ms()),
+]
+
+
+def print_startup_timeline(timeline: list[tuple[str, float | None]]):
+  print("\nStartup timeline:")
+  label_width = max(len(label) for label, _ in timeline)
+  last_ms = None
+  for label, elapsed_ms in timeline:
+    if elapsed_ms is None:
+      print(f"  {label:<{label_width}}  {'unavailable':>12}")
+      continue
+
+    delta = "" if last_ms is None else f"+{elapsed_ms - last_ms:.1f} ms"
+    print(f"  {label:<{label_width}}  {elapsed_ms:8.1f} ms  {delta:>10}")
+    last_ms = elapsed_ms
+
+
 GL_VERSION = """
 #version 300 es
 precision highp float;
@@ -241,6 +278,7 @@ class GuiApplication:
     self._profile_render_frames = PROFILE_RENDER
     self._render_profiler = None
     self._render_profile_start_time = None
+    self._startup_timeline: list[tuple[str, float | None]] | None = None
 
   @property
   def frame(self):
@@ -342,23 +380,36 @@ class GuiApplication:
 
     profiler = cProfile.Profile()
     start_time = time.monotonic()
+    self._startup_timeline = STARTUP_TIMELINE.copy()
+    self._startup_timeline.append(("init_window entered (entrypoint imports complete)", get_process_elapsed_ms()))
     profiler.enable()
+
+    def print_startup_profile():
+      profiler.disable()
+      elapsed_ms = (time.monotonic() - start_time) * 1e3
+      process_elapsed_ms = get_process_elapsed_ms()
+      if self._startup_timeline is not None:
+        self._startup_timeline.append(("process exit", process_elapsed_ms))
+
+      stats_stream = io.StringIO()
+      pstats.Stats(profiler, stream=stats_stream).sort_stats("cumtime").print_stats(25)
+      print("\n=== Startup profile ===")
+      print(stats_stream.getvalue().rstrip())
+
+      green = "\033[92m"
+      reset = "\033[0m"
+      if process_elapsed_ms is not None:
+        print(f"{green}Process elapsed in {process_elapsed_ms:.1f} ms (profiled Python: {elapsed_ms:.1f} ms){reset}")
+      else:
+        print(f"{green}Profiled Python startup in {elapsed_ms:.1f} ms{reset}")
+      if self._startup_timeline is not None:
+        print_startup_timeline(self._startup_timeline)
+
+    atexit.register(print_startup_profile)
 
     # do the init
     yield
-
-    profiler.disable()
-    elapsed_ms = (time.monotonic() - start_time) * 1e3
-
-    stats_stream = io.StringIO()
-    pstats.Stats(profiler, stream=stats_stream).sort_stats("cumtime").print_stats(25)
-    print("\n=== Startup profile ===")
-    print(stats_stream.getvalue().rstrip())
-
-    green = "\033[92m"
-    reset = "\033[0m"
-    print(f"{green}UI window ready in {elapsed_ms:.1f} ms{reset}")
-    sys.exit(0)
+    self._startup_timeline.append(("init_window complete (window ready)", get_process_elapsed_ms()))
 
   def _ffmpeg_writer_thread(self):
     """Background thread that writes frames to ffmpeg."""
@@ -651,6 +702,10 @@ class GuiApplication:
           self._draw_grid()
 
         rl.end_drawing()
+
+        if self._startup_timeline is not None:
+          self._startup_timeline.append(("draw first frame", get_process_elapsed_ms()))
+          sys.exit(0)
 
         if RECORD:
           image = rl.load_image_from_texture(self._render_texture.texture)


### PR DESCRIPTION

```bash
comma@comma-13322bf1:/data/openpilot/system/ui$ PROFILE_STARTUP=1 ./setup.py
gbm_create_device(156): Info: backend name is: msm_drm
No WiFi device found
No WiFi device found

=== Startup profile ===
         56592 function calls (55294 primitive calls) in 1.853 seconds

   Ordered by: cumulative time
   List reduced from 942 to 25 due to restriction <25>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        5    0.000    0.000    2.956    0.591 /usr/lib/python3.12/threading.py:1115(join)
    32/26    0.000    0.000    2.952    0.114 /usr/lib/python3.12/threading.py:1153(_wait_for_tstate_lock)
       27    0.002    0.000    1.489    0.055 /usr/local/venv/lib/python3.12/site-packages/jeepney/io/threading.py:55(receive)
        2    0.001    0.001    1.281    0.640 /usr/local/venv/lib/python3.12/site-packages/jeepney/io/threading.py:165(close)
       10    0.000    0.000    1.280    0.128 /usr/lib/python3.12/threading.py:637(wait)
        2    0.000    0.000    1.278    0.639 /usr/local/venv/lib/python3.12/site-packages/jeepney/io/threading.py:207(_receiver)
        1    0.000    0.000    1.276    1.276 /data/pythonpath/openpilot/system/ui/lib/wifi_manager.py:934(stop)
        7    0.000    0.000    1.193    0.170 /usr/local/venv/lib/python3.12/site-packages/jeepney/io/blocking.py:149(receive)
        1    0.000    0.000    1.188    1.188 /data/pythonpath/openpilot/system/ui/lib/wifi_manager.py:328(_monitor_state)
        1    0.000    0.000    1.188    1.188 /usr/local/venv/lib/python3.12/site-packages/jeepney/io/blocking.py:158(recv_messages)
        1    0.000    0.000    0.906    0.906 /usr/lib/python3.12/urllib/request.py:138(urlopen)
      2/1    0.000    0.000    0.906    0.906 /usr/lib/python3.12/urllib/request.py:496(open)
      2/1    0.000    0.000    0.906    0.906 /usr/lib/python3.12/urllib/request.py:624(http_response)
      5/3    0.000    0.000    0.892    0.297 /usr/lib/python3.12/urllib/request.py:485(_call_chain)
        2    0.000    0.000    0.883    0.442 /usr/lib/python3.12/urllib/request.py:525(_open)
        2    0.000    0.000    0.883    0.441 /usr/lib/python3.12/urllib/request.py:1391(https_open)
        2    0.000    0.000    0.881    0.441 /usr/lib/python3.12/urllib/request.py:1303(do_open)
        2    0.000    0.000    0.881    0.440 /usr/lib/python3.12/http/client.py:1404(getresponse)
        1    0.000    0.000    0.879    0.879 /usr/lib/python3.12/urllib/request.py:540(error)
        2    0.000    0.000    0.876    0.438 /usr/lib/python3.12/http/client.py:329(begin)
        1    0.000    0.000    0.870    0.870 /usr/lib/python3.12/urllib/request.py:687(http_error_302)
        2    0.000    0.000    0.869    0.434 /usr/lib/python3.12/http/client.py:296(_read_status)
       29    0.000    0.000    0.865    0.030 {method 'readline' of '_io.BufferedReader' objects}
        5    0.000    0.000    0.865    0.173 /usr/lib/python3.12/socket.py:693(readinto)
  618/294    0.004    0.000    0.687    0.002 /usr/local/venv/lib/python3.12/site-packages/pyray/__init__.py:47(wrapped_func)
Process elapsed in 2940.0 ms (profiled Python: 1851.9 ms)

Startup timeline:
  process start                                           0.0 ms
  UI module loaded (interpreter + early imports)        840.0 ms   +840.0 ms
  init_window entered (entrypoint imports complete)    1090.0 ms   +250.0 ms
  init_window complete (window ready)                  1670.0 ms   +580.0 ms
  draw first frame                                     1960.0 ms   +290.0 ms
  process exit                                         2940.0 ms   +980.0 ms
```