### PR TITLE
op.sh: fix arg quoting so special chars survive eval

### DIFF
--- a/tools/op.sh
+++ b/tools/op.sh
@@ -42,7 +42,7 @@ function retry() {
 }
 
 function op_run_command() {
-  CMD="$@"
+  CMD="$*"
 
   echo -e "${BOLD}Running command →${NC} $CMD │"
   for ((i=0; i<$((19 + ${#CMD})); i++)); do
@@ -51,7 +51,7 @@ function op_run_command() {
   echo -e "┘\n"
 
   if [[ -z "$DRY" ]]; then
-    eval "$CMD"
+    "$@"
   fi
 }
 
@@ -304,33 +304,33 @@ function op_build() {
     op_run_command system/manager/build.py
   else
     # scons is fine on PC
-    op_run_command scons $@
+    op_run_command scons "$@"
   fi
 }
 
 function op_juggle() {
   op_before_cmd
-  op_run_command tools/plotjuggler/juggle.py $@
+  op_run_command tools/plotjuggler/juggle.py "$@"
 }
 
 function op_lint() {
   op_before_cmd
-  op_run_command scripts/lint/lint.sh $@
+  op_run_command scripts/lint/lint.sh "$@"
 }
 
 function op_test() {
   op_before_cmd
-  op_run_command pytest $@
+  op_run_command pytest "$@"
 }
 
 function op_replay() {
   op_before_cmd
-  op_run_command tools/replay/replay $@
+  op_run_command tools/replay/replay "$@"
 }
 
 function op_cabana() {
   op_before_cmd
-  op_run_command tools/cabana/cabana $@
+  op_run_command tools/cabana/cabana "$@"
 }
 
 function op_sim() {
@@ -341,7 +341,7 @@ function op_sim() {
 
 function op_clip() {
   op_before_cmd
-  op_run_command tools/clip/run.py $@
+  op_run_command tools/clip/run.py "$@"
 }
 
 function op_switch() {
@@ -483,4 +483,4 @@ function _op() {
   esac
 }
 
-_op $@
+_op "$@"


### PR DESCRIPTION
shell-relevant characters like `$` break with current parse logic, this makes it more robust.

#### before
```
comma@comma-5e84b88:/data/openpilot$ tools/op.sh esim --download 'LPA:1$rsp.truphone.com$QRF-SPEEDTEST' TEST
Checking system → [✔]
Running command → system/hardware/esim.py --download LPA:1$rsp.truphone.com$QRF-SPEEDTEST TEST │
───────────────────────────────────────────────────────────────────────────────────────────────┘

Traceback (most recent call last):
  File "/data/openpilot/system/hardware/esim.py", line 26, in <module>
    lpa.download_profile(args.download[0], args.download[1])
  File "/data/pythonpath/openpilot/system/hardware/tici/lpa.py", line 749, in download_profile
    iccid = download_profile(self._client, qr)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/pythonpath/openpilot/system/hardware/tici/lpa.py", line 641, in download_profile
    smdp, matching_id = parse_lpa_activation_code(activation_code)
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/pythonpath/openpilot/system/hardware/tici/lpa.py", line 617, in parse_lpa_activation_code
    raise ValueError("Invalid activation code format")
ValueError: Invalid activation code format
```

#### after
```
comma@comma-5e84b88:/data/openpilot$ tools/op.sh esim --download 'LPA:1$rsp.truphone.com$QRF-SPEEDTEST' TEST
Checking system → [✔]
Running command → system/hardware/esim.py --download LPA:1$rsp.truphone.com$QRF-SPEEDTEST TEST │
───────────────────────────────────────────────────────────────────────────────────────────────┘

Traceback (most recent call last):
  File "/data/openpilot/system/hardware/esim.py", line 26, in <module>
    lpa.download_profile(args.download[0], args.download[1])
  File "/data/pythonpath/openpilot/system/hardware/tici/lpa.py", line 749, in download_profile
    iccid = download_profile(self._client, qr)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/pythonpath/openpilot/system/hardware/tici/lpa.py", line 675, in download_profile
    load_bpp(client, _b64_field(bpp, "boundProfilePackage"))
  File "/data/pythonpath/openpilot/system/hardware/tici/lpa.py", line 592, in load_bpp
    raise RuntimeError(msg)
RuntimeError: Profile installation failed. The QR code may have already been used.
```