### PR TITLE
ui: prevent raylib sleep drifting from vblank

### DIFF
--- a/selfdrive/ui/ui.py
+++ b/selfdrive/ui/ui.py
@@ -15,7 +15,7 @@ BIG_UI = gui_app.big_ui()
 
 def main():
   cores = {5, }
-  config_realtime_process(0, 53)
+  config_realtime_process(0, 51)
 
   gui_app.init_window("UI")
   if BIG_UI:

--- a/selfdrive/ui/ui.py
+++ b/selfdrive/ui/ui.py
@@ -14,7 +14,7 @@ BIG_UI = gui_app.big_ui()
 
 def main():
   cores = {5, }
-  config_realtime_process(0, 51)
+  config_realtime_process(0, 53)
 
   gui_app.init_window("UI")
   if BIG_UI:

--- a/system/ui/lib/application.py
+++ b/system/ui/lib/application.py
@@ -316,9 +316,9 @@ class GuiApplication:
         self._ffmpeg_thread = threading.Thread(target=self._ffmpeg_writer_thread, daemon=True)
         self._ffmpeg_thread.start()
 
-      # four display runs slightly faster than 60 FPS, let it control rate
-      vblank_control = TICI and not self.big_ui()
-      rl.set_target_fps(0 if OFFSCREEN or vblank_control else fps)
+      # four display runs slightly faster than 60 FPS, let it dictate rate so we don't drift and drop frames
+      mici = HARDWARE.get_device_type() == 'mici'
+      rl.set_target_fps(0 if OFFSCREEN or mici else fps)
 
       self._target_fps = fps
       self._set_styles()

--- a/system/ui/lib/application.py
+++ b/system/ui/lib/application.py
@@ -317,8 +317,8 @@ class GuiApplication:
         self._ffmpeg_thread.start()
 
       # four display runs slightly faster than 60 FPS, let it dictate rate so we don't drift and drop frames
-      mici = HARDWARE.get_device_type() == 'mici'
-      rl.set_target_fps(0 if OFFSCREEN or mici else fps)
+      vblank_control = HARDWARE.get_device_type() == 'mici'
+      rl.set_target_fps(0 if OFFSCREEN or vblank_control else fps)
 
       self._target_fps = fps
       self._set_styles()

--- a/system/ui/lib/application.py
+++ b/system/ui/lib/application.py
@@ -316,7 +316,9 @@ class GuiApplication:
         self._ffmpeg_thread = threading.Thread(target=self._ffmpeg_writer_thread, daemon=True)
         self._ffmpeg_thread.start()
 
-      rl.set_target_fps(0)
+      # four display runs slightly faster than 60 FPS, let it control rate
+      vblank_control = TICI and not self.big_ui()
+      rl.set_target_fps(0 if OFFSCREEN or vblank_control else fps)
 
       self._target_fps = fps
       self._set_styles()

--- a/system/ui/lib/application.py
+++ b/system/ui/lib/application.py
@@ -316,8 +316,7 @@ class GuiApplication:
         self._ffmpeg_thread = threading.Thread(target=self._ffmpeg_writer_thread, daemon=True)
         self._ffmpeg_thread.start()
 
-      # OFFSCREEN disables FPS limiting for fast offline rendering (e.g. clips)
-      rl.set_target_fps(0 if OFFSCREEN else fps)
+      rl.set_target_fps(0)
 
       self._target_fps = fps
       self._set_styles()


### PR DESCRIPTION
This doesn't fully fix frame drops yet, but removes one large part.

I tried to measure the vblanks and got always saw slightly above 60Hz from the panel (like 60.05Hz), so I think what is happening is raylib is oversleeping and the ui's render loop slowly drifts out of sync with the display. Over time the render starts so late that there's not enough time for it to complete in time for the swap, we miss it and observe a frame drop. You can see this in the amount of time raylib sleeps, when it resets we see a frame drop.

Also now we can work on next frame immediately, and the sleep before the Python render loop is replaced with waiting on display after the Python render loop.

```
[rl_EndDrawing] total=  9.5ms | endTex=0.03 rotation= 0.00 batch= 0.21 swap= 8.22 waittime= 1.08 poll= 0.00                                                              
[rl_Swap] total= 4.89ms | eglSwap= 2.74 gbmLock=0.00 getFB=0.00 flip=0.09 waitVBlank= 2.05 release=0.00                                                                  
[rl_EndDrawing] total=  6.2ms | endTex=0.03 rotation= 0.00 batch= 0.19 swap= 4.94 waittime= 1.08 poll= 0.00                                                              
[rl_Swap] total= 5.31ms | eglSwap= 4.21 gbmLock=0.00 getFB=0.00 flip=0.09 waitVBlank= 1.00 release=0.00                                                                  
[rl_EndDrawing] total=  6.7ms | endTex=0.03 rotation= 0.00 batch= 0.20 swap= 5.36 waittime= 1.07 poll= 0.00                                                              
[rl_Swap] total= 5.63ms | eglSwap= 2.71 gbmLock=0.00 getFB=0.00 flip=0.09 waitVBlank= 2.83 release=0.00                                                                  
[rl_EndDrawing] total=  7.0ms | endTex=0.03 rotation= 0.00 batch= 0.17 swap= 5.68 waittime= 1.08 poll= 0.00                                                              
[rl_Swap] total= 5.72ms | eglSwap= 2.68 gbmLock=0.00 getFB=0.00 flip=0.09 waitVBlank= 2.94 release=0.00                                                                  
[rl_EndDrawing] total=  7.1ms | endTex=0.03 rotation= 0.00 batch= 0.19 swap= 5.77 waittime= 1.09 poll= 0.00                                                              
[rl_Swap] total=18.37ms | eglSwap= 2.53 gbmLock=0.00 getFB=0.00 flip=0.09 waitVBlank=15.75 release=0.00                                                                  
>>> [rl_EndDrawing] total= 18.6ms | endTex=0.03 rotation= 0.00 batch= 0.19 swap=18.42 waittime= 0.00 poll= 0.00  # SEE FRAME DROP HERE!                                                              
[rl_Swap] total= 6.24ms | eglSwap= 2.69 gbmLock=0.00 getFB=0.00 flip=0.10 waitVBlank= 3.45 release=0.00                                                                  
[rl_EndDrawing] total=  6.6ms | endTex=0.03 rotation= 0.00 batch= 0.17 swap= 6.29 waittime= 0.09 poll= 0.00                                                              
[rl_Swap] total= 6.63ms | eglSwap= 4.08 gbmLock=0.00 getFB=0.00 flip=0.10 waitVBlank= 2.45 release=0.00                                                                  
[rl_EndDrawing] total=  7.0ms | endTex=0.03 rotation= 0.00 batch= 0.18 swap= 6.69 waittime= 0.09 poll= 0.00                                                              
[rl_Swap] total= 9.15ms | eglSwap= 2.58 gbmLock=0.00 getFB=0.00 flip=0.12 waitVBlank= 6.45 release=0.00                                                                  
[rl_EndDrawing] total=  9.5ms | endTex=0.03 rotation= 0.00 batch= 0.20 swap= 9.20 waittime= 0.10 poll= 0.00                                     
[rl_Swap] total= 6.84ms | eglSwap= 2.86 gbmLock=0.00 getFB=0.00 flip=0.11 waitVBlank= 3.86 release=0.00
[rl_EndDrawing] total=  7.2ms | endTex=0.03 rotation= 0.00 batch= 0.18 swap= 6.88 waittime= 0.12 poll= 0.00
```

Before/after:

<img width="1617" height="1200" alt="image" src="https://github.com/user-attachments/assets/e103ffb5-fa18-4fca-99e8-2bad4a94f0d8" />

Without modeld there were still frame drops on the CPU side, so speeding up ui and other procs on this core *will* help to a degree. Killing radard and locationd stops frame drops every few seconds, then killing selfdrived stops frame drops every 10s (still frame drops every 60s??).

<details><summary>Killed a bunch of CPU procs, super consistent</summary>

<img width="1411" height="1045" alt="image" src="https://github.com/user-attachments/assets/e255fa02-e13c-40de-9b51-4e30b5467c23" />

CPU frame drops:

<img width="1407" height="1033" alt="image" src="https://github.com/user-attachments/assets/5c172d60-ca26-4a2f-ae0d-53da90d7306b" />

</details>
