### PR TITLE
Scroller: snap logic in scroll panel

### DIFF
--- a/system/ui/lib/scroll_panel2.py
+++ b/system/ui/lib/scroll_panel2.py
@@ -45,9 +45,8 @@ class ScrollState(Enum):
 
 
 class GuiScrollPanel2:
-  def __init__(self, horizontal: bool = True, handle_out_of_bounds: bool = True) -> None:
+  def __init__(self, horizontal: bool = True) -> None:
     self._horizontal = horizontal
-    self._handle_out_of_bounds = handle_out_of_bounds
     self._state = ScrollState.STEADY
     self._offset: rl.Vector2 = rl.Vector2(0, 0)
     self._initial_click_event: MouseEvent | None = None
@@ -97,8 +96,9 @@ class GuiScrollPanel2:
 
     elif self._state == ScrollState.AUTO_SCROLL:
       # simple exponential return if out of bounds
+      # out of bounds is handled by snapping, so skip if set
       out_of_bounds = self.get_offset() > max_offset or self.get_offset() < min_offset
-      if out_of_bounds and self._handle_out_of_bounds:
+      if out_of_bounds and snap_target is None:
         target = max_offset if self.get_offset() > max_offset else min_offset
 
         dt = rl.get_frame_time() or 1e-6

--- a/system/ui/lib/scroll_panel2.py
+++ b/system/ui/lib/scroll_panel2.py
@@ -89,54 +89,55 @@ class GuiScrollPanel2:
     """Runs per render frame, independent of mouse events. Updates auto-scrolling state and velocity."""
     max_offset, min_offset = self._get_offset_bounds(bounds_size, content_size)
 
-    if self._state == ScrollState.STEADY:
-      # if we find ourselves out of bounds, scroll back in (from external layout dimension changes, etc.)
-      if self.get_offset() > max_offset or self.get_offset() < min_offset:
-        self._state = ScrollState.AUTO_SCROLL
+    if self._state in (ScrollState.STEADY, ScrollState.AUTO_SCROLL):
+      if self._state == ScrollState.STEADY:
+        # if we find ourselves out of bounds, scroll back in (from external layout dimension changes, etc.)
+        if self.get_offset() > max_offset or self.get_offset() < min_offset:
+          self._state = ScrollState.AUTO_SCROLL
 
-    elif self._state == ScrollState.AUTO_SCROLL:
-      # simple exponential return if out of bounds
-      # out of bounds is handled by snapping, so skip if set
-      out_of_bounds = self.get_offset() > max_offset or self.get_offset() < min_offset
-      if out_of_bounds and snap_target is None:
-        target = max_offset if self.get_offset() > max_offset else min_offset
+      elif self._state == ScrollState.AUTO_SCROLL:
+        # simple exponential return if out of bounds
+        # out of bounds is handled by snapping, so skip if set
+        out_of_bounds = self.get_offset() > max_offset or self.get_offset() < min_offset
+        if out_of_bounds and snap_target is None:
+          target = max_offset if self.get_offset() > max_offset else min_offset
 
-        dt = rl.get_frame_time() or 1e-6
-        factor = 1.0 - math.exp(-BOUNCE_RETURN_RATE * dt)
+          dt = rl.get_frame_time() or 1e-6
+          factor = 1.0 - math.exp(-BOUNCE_RETURN_RATE * dt)
 
-        dist = target - self.get_offset()
-        self.set_offset(self.get_offset() + dist * factor)  # ease toward the edge
-        self._velocity *= (1.0 - factor)  # damp any leftover fling
+          dist = target - self.get_offset()
+          self.set_offset(self.get_offset() + dist * factor)  # ease toward the edge
+          self._velocity *= (1.0 - factor)  # damp any leftover fling
 
-        # Steady once we are close enough to the target
-        if abs(dist) < 1 and abs(self._velocity) < MIN_VELOCITY:
-          self.set_offset(target)
+          # Steady once we are close enough to the target
+          if abs(dist) < 1 and abs(self._velocity) < MIN_VELOCITY:
+            self.set_offset(target)
+            self._velocity = 0.0
+            self._state = ScrollState.STEADY
+
+        elif abs(self._velocity) < MIN_VELOCITY:
           self._velocity = 0.0
           self._state = ScrollState.STEADY
 
-      elif abs(self._velocity) < MIN_VELOCITY:
-        self._velocity = 0.0
-        self._state = ScrollState.STEADY
+        # Update the offset based on the current velocity
+        dt = rl.get_frame_time()
+        self.set_offset(self.get_offset() + self._velocity * dt)  # Adjust the offset based on velocity
+        # fast decay in snap mode so velocity yields to the snap pull instead of fighting it
+        auto_scroll_tc = AUTO_SCROLL_TC_SNAP if snap_target is not None else AUTO_SCROLL_TC
+        alpha = 1 - (dt / (auto_scroll_tc + dt))
+        self._velocity *= alpha
 
-      # Update the offset based on the current velocity
-      dt = rl.get_frame_time()
-      self.set_offset(self.get_offset() + self._velocity * dt)  # Adjust the offset based on velocity
-      # fast decay in snap mode so velocity yields to the snap pull instead of fighting it
-      auto_scroll_tc = AUTO_SCROLL_TC_SNAP if snap_target is not None else AUTO_SCROLL_TC
-      alpha = 1 - (dt / (auto_scroll_tc + dt))
-      self._velocity *= alpha
-
-    # Ease toward snap target when not in user control. Composes with velocity coast above:
-    # high velocity dominates initially, snap dominates as velocity decays.
-    if snap_target is not None and self.enabled and self._state not in (ScrollState.PRESSED, ScrollState.MANUAL_SCROLL):
-      snap_target = max(min_offset, min(max_offset, snap_target))
-      dist = snap_target - self.get_offset()
-      if abs(dist) < 1:  # finished snap
-        self.set_offset(snap_target)
-      else:
-        dt = rl.get_frame_time() or 1e-6
-        factor = 1.0 - math.exp(-SNAP_RATE * dt)
-        self.set_offset(self.get_offset() + dist * factor)
+      # Ease toward snap target when not in user control. Composes with velocity coast above:
+      # high velocity dominates initially, snap dominates as velocity decays.
+      if snap_target is not None and self.enabled:
+        snap_target = max(min_offset, min(max_offset, snap_target))
+        dist = snap_target - self.get_offset()
+        if abs(dist) < 1:  # finished snap
+          self.set_offset(snap_target)
+        else:
+          dt = rl.get_frame_time() or 1e-6
+          factor = 1.0 - math.exp(-SNAP_RATE * dt)
+          self.set_offset(self.get_offset() + dist * factor)
 
   def _handle_mouse_event(self, mouse_event: MouseEvent, bounds: rl.Rectangle, bounds_size: float,
                           content_size: float) -> None:

--- a/system/ui/lib/scroll_panel2.py
+++ b/system/ui/lib/scroll_panel2.py
@@ -131,8 +131,8 @@ class GuiScrollPanel2:
       snap_target = max(min_offset, min(max_offset, snap_target))
       dist = snap_target - self.get_offset()
       print('snap dist', dist, 'offset', self.get_offset(), 'target', snap_target)
-      if abs(dist) < 1:
-        self.set_offset(snap_target)  # exact set to prevent sub-pixel drift
+      if abs(dist) < 1:  # finished snap
+        self.set_offset(snap_target)
       else:
         dt = rl.get_frame_time() or 1e-6
         factor = 1.0 - math.exp(-SNAP_RATE * dt)

--- a/system/ui/lib/scroll_panel2.py
+++ b/system/ui/lib/scroll_panel2.py
@@ -131,7 +131,6 @@ class GuiScrollPanel2:
     if snap_target is not None and self.enabled and self._state not in (ScrollState.PRESSED, ScrollState.MANUAL_SCROLL):
       snap_target = max(min_offset, min(max_offset, snap_target))
       dist = snap_target - self.get_offset()
-      print('snap dist', dist, 'offset', self.get_offset(), 'target', snap_target)
       if abs(dist) < 1:  # finished snap
         self.set_offset(snap_target)
       else:

--- a/system/ui/lib/scroll_panel2.py
+++ b/system/ui/lib/scroll_panel2.py
@@ -128,7 +128,7 @@ class GuiScrollPanel2:
 
     # Ease toward snap target when not in user control. Composes with velocity coast above:
     # high velocity dominates initially, snap dominates as velocity decays.
-    if snap_target is not None and self.enabled and self._state not in (ScrollState.PRESSED, ScrollState.MANUAL_SCROLL):
+    if snap_target is not None and self._state not in (ScrollState.PRESSED, ScrollState.MANUAL_SCROLL):
       snap_target = max(min_offset, min(max_offset, snap_target))
       dist = snap_target - self.get_offset()
       if abs(dist) < 1:  # finished snap

--- a/system/ui/lib/scroll_panel2.py
+++ b/system/ui/lib/scroll_panel2.py
@@ -14,7 +14,7 @@ MIN_DRAG_PIXELS = 12
 AUTO_SCROLL_TC_SNAP = 0.025
 AUTO_SCROLL_TC = 0.18
 BOUNCE_RETURN_RATE = 10.0
-SNAP_RATE = 6.3  # exp rate of approach to snap target, 1/s
+SNAP_RATE = 6.3  # matches previous Scroller snapping. exp rate of approach to snap target, 1/s
 REJECT_DECELERATION_FACTOR = 3
 MAX_SPEED = 10000.0  # px/s
 
@@ -262,10 +262,6 @@ class GuiScrollPanel2:
   @property
   def state(self) -> ScrollState:
     return self._state
-
-  @property
-  def velocity(self) -> float:
-    return self._velocity
 
   def is_touch_valid(self) -> bool:
     # MIN_VELOCITY_FOR_CLICKING is checked in auto-scroll state

--- a/system/ui/lib/scroll_panel2.py
+++ b/system/ui/lib/scroll_panel2.py
@@ -121,6 +121,7 @@ class GuiScrollPanel2:
       # Update the offset based on the current velocity
       dt = rl.get_frame_time()
       self.set_offset(self.get_offset() + self._velocity * dt)  # Adjust the offset based on velocity
+      # fast decay in snap mode so velocity yields to the snap pull instead of fighting it
       auto_scroll_tc = AUTO_SCROLL_TC_SNAP if snap_target is not None else AUTO_SCROLL_TC
       alpha = 1 - (dt / (auto_scroll_tc + dt))
       self._velocity *= alpha

--- a/system/ui/lib/scroll_panel2.py
+++ b/system/ui/lib/scroll_panel2.py
@@ -263,6 +263,10 @@ class GuiScrollPanel2:
   def state(self) -> ScrollState:
     return self._state
 
+  @property
+  def velocity(self) -> float:
+    return self._velocity
+
   def is_touch_valid(self) -> bool:
     # MIN_VELOCITY_FOR_CLICKING is checked in auto-scroll state
     return bool(self._state != ScrollState.MANUAL_SCROLL)

--- a/system/ui/lib/scroll_panel2.py
+++ b/system/ui/lib/scroll_panel2.py
@@ -14,7 +14,7 @@ MIN_DRAG_PIXELS = 12
 AUTO_SCROLL_TC_SNAP = 0.025
 AUTO_SCROLL_TC = 0.18
 BOUNCE_RETURN_RATE = 10.0
-SNAP_RATE = 10.0  # exp rate of approach to snap target, 1/s
+SNAP_RATE = 6.3  # exp rate of approach to snap target, 1/s
 REJECT_DECELERATION_FACTOR = 3
 MAX_SPEED = 10000.0  # px/s
 
@@ -48,7 +48,6 @@ class GuiScrollPanel2:
   def __init__(self, horizontal: bool = True, handle_out_of_bounds: bool = True) -> None:
     self._horizontal = horizontal
     self._handle_out_of_bounds = handle_out_of_bounds
-    self._AUTO_SCROLL_TC = AUTO_SCROLL_TC_SNAP if not self._handle_out_of_bounds else AUTO_SCROLL_TC
     self._state = ScrollState.STEADY
     self._offset: rl.Vector2 = rl.Vector2(0, 0)
     self._initial_click_event: MouseEvent | None = None
@@ -122,7 +121,8 @@ class GuiScrollPanel2:
       # Update the offset based on the current velocity
       dt = rl.get_frame_time()
       self.set_offset(self.get_offset() + self._velocity * dt)  # Adjust the offset based on velocity
-      alpha = 1 - (dt / (self._AUTO_SCROLL_TC + dt))
+      auto_scroll_tc = AUTO_SCROLL_TC_SNAP if snap_target is not None else AUTO_SCROLL_TC
+      alpha = 1 - (dt / (auto_scroll_tc + dt))
       self._velocity *= alpha
 
     # Ease toward snap target when not in user control. Composes with velocity coast above:

--- a/system/ui/lib/scroll_panel2.py
+++ b/system/ui/lib/scroll_panel2.py
@@ -14,6 +14,7 @@ MIN_DRAG_PIXELS = 12
 AUTO_SCROLL_TC_SNAP = 0.025
 AUTO_SCROLL_TC = 0.18
 BOUNCE_RETURN_RATE = 10.0
+SNAP_RATE = 10.0  # exp rate of approach to snap target, 1/s
 REJECT_DECELERATION_FACTOR = 3
 MAX_SPEED = 10000.0  # px/s
 
@@ -63,7 +64,7 @@ class GuiScrollPanel2:
   def enabled(self) -> bool:
     return self._enabled() if callable(self._enabled) else self._enabled
 
-  def update(self, bounds: rl.Rectangle, content_size: float) -> float:
+  def update(self, bounds: rl.Rectangle, content_size: float, snap_target: float | None = None) -> float:
     if DEBUG:
       print('Old state:', self._state)
 
@@ -73,7 +74,7 @@ class GuiScrollPanel2:
       self._handle_mouse_event(mouse_event, bounds, bounds_size, content_size)
       self._previous_mouse_event = mouse_event
 
-    self._update_state(bounds_size, content_size)
+    self._update_state(bounds_size, content_size, snap_target)
 
     if DEBUG:
       print('Velocity:', self._velocity)
@@ -86,7 +87,7 @@ class GuiScrollPanel2:
     """Returns (max_offset, min_offset) for the given bounds and content size."""
     return 0.0, min(0.0, bounds_size - content_size)
 
-  def _update_state(self, bounds_size: float, content_size: float) -> None:
+  def _update_state(self, bounds_size: float, content_size: float, snap_target: float | None) -> None:
     """Runs per render frame, independent of mouse events. Updates auto-scrolling state and velocity."""
     max_offset, min_offset = self._get_offset_bounds(bounds_size, content_size)
 
@@ -123,6 +124,19 @@ class GuiScrollPanel2:
       self.set_offset(self.get_offset() + self._velocity * dt)  # Adjust the offset based on velocity
       alpha = 1 - (dt / (self._AUTO_SCROLL_TC + dt))
       self._velocity *= alpha
+
+    # Ease toward snap target when not in user control. Composes with velocity coast above:
+    # high velocity dominates initially, snap dominates as velocity decays.
+    if snap_target is not None and self.enabled and self._state not in (ScrollState.PRESSED, ScrollState.MANUAL_SCROLL):
+      snap_target = max(min_offset, min(max_offset, snap_target))
+      dist = snap_target - self.get_offset()
+      print('snap dist', dist, 'offset', self.get_offset(), 'target', snap_target)
+      if abs(dist) < 1:
+        self.set_offset(snap_target)  # exact set to prevent sub-pixel drift
+      else:
+        dt = rl.get_frame_time() or 1e-6
+        factor = 1.0 - math.exp(-SNAP_RATE * dt)
+        self.set_offset(self.get_offset() + dist * factor)
 
   def _handle_mouse_event(self, mouse_event: MouseEvent, bounds: rl.Rectangle, bounds_size: float,
                           content_size: float) -> None:

--- a/system/ui/lib/scroll_panel2.py
+++ b/system/ui/lib/scroll_panel2.py
@@ -89,55 +89,54 @@ class GuiScrollPanel2:
     """Runs per render frame, independent of mouse events. Updates auto-scrolling state and velocity."""
     max_offset, min_offset = self._get_offset_bounds(bounds_size, content_size)
 
-    if self._state in (ScrollState.STEADY, ScrollState.AUTO_SCROLL):
-      if self._state == ScrollState.STEADY:
-        # if we find ourselves out of bounds, scroll back in (from external layout dimension changes, etc.)
-        if self.get_offset() > max_offset or self.get_offset() < min_offset:
-          self._state = ScrollState.AUTO_SCROLL
+    if self._state == ScrollState.STEADY:
+      # if we find ourselves out of bounds, scroll back in (from external layout dimension changes, etc.)
+      if self.get_offset() > max_offset or self.get_offset() < min_offset:
+        self._state = ScrollState.AUTO_SCROLL
 
-      elif self._state == ScrollState.AUTO_SCROLL:
-        # simple exponential return if out of bounds
-        # out of bounds is handled by snapping, so skip if set
-        out_of_bounds = self.get_offset() > max_offset or self.get_offset() < min_offset
-        if out_of_bounds and snap_target is None:
-          target = max_offset if self.get_offset() > max_offset else min_offset
+    elif self._state == ScrollState.AUTO_SCROLL:
+      # simple exponential return if out of bounds
+      # out of bounds is handled by snapping, so skip if set
+      out_of_bounds = self.get_offset() > max_offset or self.get_offset() < min_offset
+      if out_of_bounds and snap_target is None:
+        target = max_offset if self.get_offset() > max_offset else min_offset
 
-          dt = rl.get_frame_time() or 1e-6
-          factor = 1.0 - math.exp(-BOUNCE_RETURN_RATE * dt)
+        dt = rl.get_frame_time() or 1e-6
+        factor = 1.0 - math.exp(-BOUNCE_RETURN_RATE * dt)
 
-          dist = target - self.get_offset()
-          self.set_offset(self.get_offset() + dist * factor)  # ease toward the edge
-          self._velocity *= (1.0 - factor)  # damp any leftover fling
+        dist = target - self.get_offset()
+        self.set_offset(self.get_offset() + dist * factor)  # ease toward the edge
+        self._velocity *= (1.0 - factor)  # damp any leftover fling
 
-          # Steady once we are close enough to the target
-          if abs(dist) < 1 and abs(self._velocity) < MIN_VELOCITY:
-            self.set_offset(target)
-            self._velocity = 0.0
-            self._state = ScrollState.STEADY
-
-        elif abs(self._velocity) < MIN_VELOCITY:
+        # Steady once we are close enough to the target
+        if abs(dist) < 1 and abs(self._velocity) < MIN_VELOCITY:
+          self.set_offset(target)
           self._velocity = 0.0
           self._state = ScrollState.STEADY
 
-        # Update the offset based on the current velocity
-        dt = rl.get_frame_time()
-        self.set_offset(self.get_offset() + self._velocity * dt)  # Adjust the offset based on velocity
-        # fast decay in snap mode so velocity yields to the snap pull instead of fighting it
-        auto_scroll_tc = AUTO_SCROLL_TC_SNAP if snap_target is not None else AUTO_SCROLL_TC
-        alpha = 1 - (dt / (auto_scroll_tc + dt))
-        self._velocity *= alpha
+      elif abs(self._velocity) < MIN_VELOCITY:
+        self._velocity = 0.0
+        self._state = ScrollState.STEADY
 
-      # Ease toward snap target when not in user control. Composes with velocity coast above:
-      # high velocity dominates initially, snap dominates as velocity decays.
-      if snap_target is not None and self.enabled:
-        snap_target = max(min_offset, min(max_offset, snap_target))
-        dist = snap_target - self.get_offset()
-        if abs(dist) < 1:  # finished snap
-          self.set_offset(snap_target)
-        else:
-          dt = rl.get_frame_time() or 1e-6
-          factor = 1.0 - math.exp(-SNAP_RATE * dt)
-          self.set_offset(self.get_offset() + dist * factor)
+      # Update the offset based on the current velocity
+      dt = rl.get_frame_time()
+      self.set_offset(self.get_offset() + self._velocity * dt)  # Adjust the offset based on velocity
+      # fast decay in snap mode so velocity yields to the snap pull instead of fighting it
+      auto_scroll_tc = AUTO_SCROLL_TC_SNAP if snap_target is not None else AUTO_SCROLL_TC
+      alpha = 1 - (dt / (auto_scroll_tc + dt))
+      self._velocity *= alpha
+
+    # Ease toward snap target when not in user control. Composes with velocity coast above:
+    # high velocity dominates initially, snap dominates as velocity decays.
+    if snap_target is not None and self.enabled and self._state not in (ScrollState.PRESSED, ScrollState.MANUAL_SCROLL):
+      snap_target = max(min_offset, min(max_offset, snap_target))
+      dist = snap_target - self.get_offset()
+      if abs(dist) < 1:  # finished snap
+        self.set_offset(snap_target)
+      else:
+        dt = rl.get_frame_time() or 1e-6
+        factor = 1.0 - math.exp(-SNAP_RATE * dt)
+        self.set_offset(self.get_offset() + dist * factor)
 
   def _handle_mouse_event(self, mouse_event: MouseEvent, bounds: rl.Rectangle, bounds_size: float,
                           content_size: float) -> None:

--- a/system/ui/widgets/scroller.py
+++ b/system/ui/widgets/scroller.py
@@ -193,7 +193,12 @@ class _Scroller(Widget):
     if self._snap_items and visible_items and self._scrolling_to[0] is None:
       # TODO: this doesn't handle two small buttons at the edges well
       center_pos = self._rect.x + self._rect.width / 2
-      closest_delta_pos = min((((item.rect.x + item.rect.width / 2) - center_pos) for item in visible_items), key=abs)
+      closest_delta_pos = float('inf')
+      for item in visible_items:
+        delta_pos = (item.rect.x + item.rect.width / 2) - center_pos
+        if abs(delta_pos) < abs(closest_delta_pos):
+          closest_delta_pos = delta_pos
+
       snap_target = self.scroll_panel.get_offset() - closest_delta_pos
 
     offset = self.scroll_panel.update(self._rect, content_size, snap_target=snap_target)

--- a/system/ui/widgets/scroller.py
+++ b/system/ui/widgets/scroller.py
@@ -194,7 +194,7 @@ class _Scroller(Widget):
     if self._snap_items and visible_items and self._scrolling_to[0] is None:
       # TODO: this doesn't handle two small buttons at the edges well
       # Project where items will end up given current scroll velocity, so flicks land on the next item
-      center_pos = self._rect.x + self._rect.width / 2 - self.scroll_panel.velocity * SNAP_LOOKAHEAD
+      center_pos = self._rect.x + self._rect.width / 2# - self.scroll_panel.velocity * SNAP_LOOKAHEAD
       closest_delta_pos = min((((item.rect.x + item.rect.width / 2) - center_pos) for item in visible_items), key=abs)
       print('closest_delta_pos', closest_delta_pos)
       snap_target = self.scroll_panel.get_offset() - closest_delta_pos

--- a/system/ui/widgets/scroller.py
+++ b/system/ui/widgets/scroller.py
@@ -193,12 +193,7 @@ class _Scroller(Widget):
     if self._snap_items and visible_items and self._scrolling_to[0] is None:
       # TODO: this doesn't handle two small buttons at the edges well
       center_pos = self._rect.x + self._rect.width / 2
-      closest_delta_pos = float('inf')
-      for item in visible_items:
-        delta_pos = (item.rect.x + item.rect.width / 2) - center_pos
-        if abs(delta_pos) < abs(closest_delta_pos):
-          closest_delta_pos = delta_pos
-
+      closest_delta_pos = min((((item.rect.x + item.rect.width / 2) - center_pos) for item in visible_items), key=abs)
       snap_target = self.scroll_panel.get_offset() - closest_delta_pos
 
     offset = self.scroll_panel.update(self._rect, content_size, snap_target=snap_target)

--- a/system/ui/widgets/scroller.py
+++ b/system/ui/widgets/scroller.py
@@ -187,7 +187,8 @@ class _Scroller(Widget):
     scroll_enabled = self._scroll_enabled() if callable(self._scroll_enabled) else self._scroll_enabled
     self.scroll_panel.set_enabled(scroll_enabled and self.enabled and not self._scrolling_to[1])
 
-    # Snap closest item to center: target offset that would put it on the viewport center
+    # Snap closest item to center: target offset that would put it on the viewport center.
+    # Skipped while scroll_to() is animating; they target different offsets and would fight.
     snap_target: float | None = None
     if self._snap_items and visible_items and self._scrolling_to[0] is None:
       # TODO: this doesn't handle two small buttons at the edges well

--- a/system/ui/widgets/scroller.py
+++ b/system/ui/widgets/scroller.py
@@ -93,9 +93,6 @@ class _Scroller(Widget):
 
     self._item_pos_filter = BounceFilter(0.0, 0.05, 1 / gui_app.target_fps)
 
-    # when not pressed, snap to closest item to be center
-    self._scroll_snap_filter = FirstOrderFilter(0.0, 0.05, 1 / gui_app.target_fps)
-
     self.scroll_panel = GuiScrollPanel2(self._horizontal, handle_out_of_bounds=not self._snap_items)
     self._scroll_enabled: bool | Callable[[], bool] = True
 
@@ -189,35 +186,18 @@ class _Scroller(Widget):
   def _get_scroll(self, visible_items: list[Widget], content_size: float) -> float:
     scroll_enabled = self._scroll_enabled() if callable(self._scroll_enabled) else self._scroll_enabled
     self.scroll_panel.set_enabled(scroll_enabled and self.enabled and not self._scrolling_to[1])
-    self.scroll_panel.update(self._rect, content_size)
-    if not self._snap_items:
-      return self.scroll_panel.get_offset()
 
-    # Snap closest item to center
-    center_pos = self._rect.x + self._rect.width / 2
-    closest_delta_pos = float('inf')
-    scroll_snap_idx: int | None = None
-    for idx, item in enumerate(visible_items):
-      delta_pos = (item.rect.x + item.rect.width / 2) - center_pos
-      if abs(delta_pos) < abs(closest_delta_pos):
-        closest_delta_pos = delta_pos
-        scroll_snap_idx = idx
+    # Snap closest item to center: target offset that would put it on the viewport center
+    snap_target: float | None = None
+    if self._snap_items and visible_items and self._scrolling_to[0] is None:
+      # TODO: this doesn't handle two small buttons at the edges well
+      center_pos = self._rect.x + self._rect.width / 2
+      closest_delta_pos = min((((item.rect.x + item.rect.width / 2) - center_pos) for item in visible_items), key=abs)
+      snap_target = self.scroll_panel.get_offset() - closest_delta_pos
 
-    if scroll_snap_idx is not None:
-      snap_item = visible_items[scroll_snap_idx]
-      if self.is_pressed:
-        # no snapping until released
-        self._scroll_snap_filter.x = 0
-      else:
-        # TODO: this doesn't handle two small buttons at the edges well
-        snap_delta_pos = (center_pos - (snap_item.rect.x + snap_item.rect.width / 2)) / 10
-        snap_delta_pos = min(snap_delta_pos, -self.scroll_panel.get_offset() / 10)
-        snap_delta_pos = max(snap_delta_pos, (self._rect.width - self.scroll_panel.get_offset() - content_size) / 10)
-        self._scroll_snap_filter.update(snap_delta_pos)
-
-      self.scroll_panel.set_offset(self.scroll_panel.get_offset() + self._scroll_snap_filter.x)
-
-    return self.scroll_panel.get_offset()
+    offset = self.scroll_panel.update(self._rect, content_size, snap_target=snap_target)
+    print('final offset', offset)
+    return offset
 
   @property
   def moving_items(self) -> bool:

--- a/system/ui/widgets/scroller.py
+++ b/system/ui/widgets/scroller.py
@@ -197,8 +197,6 @@ class _Scroller(Widget):
       snap_target = self.scroll_panel.get_offset() - closest_delta_pos
 
     offset = self.scroll_panel.update(self._rect, content_size, snap_target=snap_target)
-    print('final offset', offset)
-    print()
     return offset
 
   @property

--- a/system/ui/widgets/scroller.py
+++ b/system/ui/widgets/scroller.py
@@ -187,8 +187,7 @@ class _Scroller(Widget):
     scroll_enabled = self._scroll_enabled() if callable(self._scroll_enabled) else self._scroll_enabled
     self.scroll_panel.set_enabled(scroll_enabled and self.enabled and not self._scrolling_to[1])
 
-    # Snap closest item to center: target offset that would put it on the viewport center.
-    # Skipped while scroll_to() is animating; they target different offsets and would fight.
+    # Snap closest item to center. Skipped while scroll_to() is animating
     snap_target: float | None = None
     if self._snap_items and visible_items and self._scrolling_to[0] is None:
       # TODO: this doesn't handle two small buttons at the edges well
@@ -196,8 +195,7 @@ class _Scroller(Widget):
       closest_delta_pos = min((((item.rect.x + item.rect.width / 2) - center_pos) for item in visible_items), key=abs)
       snap_target = self.scroll_panel.get_offset() - closest_delta_pos
 
-    offset = self.scroll_panel.update(self._rect, content_size, snap_target=snap_target)
-    return offset
+    return self.scroll_panel.update(self._rect, content_size, snap_target=snap_target)
 
   @property
   def moving_items(self) -> bool:

--- a/system/ui/widgets/scroller.py
+++ b/system/ui/widgets/scroller.py
@@ -179,7 +179,7 @@ class _Scroller(Widget):
       self._scrolling_to_filter.update(self._scrolling_to[0])
       self.scroll_panel.set_offset(self._scrolling_to_filter.x)
 
-      if abs(self._scrolling_to_filter.x - self._scrolling_to[0]) < 1:
+      if abs(self._scrolling_to_filter.x - self._scrolling_to[0]) < 1:  # finished scroll
         self.scroll_panel.set_offset(self._scrolling_to[0])
         self._scrolling_to = None, False
 

--- a/system/ui/widgets/scroller.py
+++ b/system/ui/widgets/scroller.py
@@ -18,8 +18,6 @@ MOVE_LIFT = 20
 MOVE_OVERLAY_ALPHA = 0.65
 SCROLL_RC = 0.15
 
-SNAP_LOOKAHEAD = 0.1  # s, use scroll velocity to pick the snap item we'll coast to
-
 EDGE_SHADOW_WIDTH = 20
 
 MIN_ZOOM_ANIMATION_TIME = 0.075  # seconds
@@ -193,10 +191,8 @@ class _Scroller(Widget):
     snap_target: float | None = None
     if self._snap_items and visible_items and self._scrolling_to[0] is None:
       # TODO: this doesn't handle two small buttons at the edges well
-      # Project where items will end up given current scroll velocity, so flicks land on the next item
-      center_pos = self._rect.x + self._rect.width / 2# - self.scroll_panel.velocity * SNAP_LOOKAHEAD
+      center_pos = self._rect.x + self._rect.width / 2
       closest_delta_pos = min((((item.rect.x + item.rect.width / 2) - center_pos) for item in visible_items), key=abs)
-      print('closest_delta_pos', closest_delta_pos)
       snap_target = self.scroll_panel.get_offset() - closest_delta_pos
 
     offset = self.scroll_panel.update(self._rect, content_size, snap_target=snap_target)

--- a/system/ui/widgets/scroller.py
+++ b/system/ui/widgets/scroller.py
@@ -93,7 +93,7 @@ class _Scroller(Widget):
 
     self._item_pos_filter = BounceFilter(0.0, 0.05, 1 / gui_app.target_fps)
 
-    self.scroll_panel = GuiScrollPanel2(self._horizontal, handle_out_of_bounds=not self._snap_items)
+    self.scroll_panel = GuiScrollPanel2(self._horizontal)
     self._scroll_enabled: bool | Callable[[], bool] = True
 
     self._show_scroll_indicator = scroll_indicator and self._horizontal

--- a/system/ui/widgets/scroller.py
+++ b/system/ui/widgets/scroller.py
@@ -18,6 +18,8 @@ MOVE_LIFT = 20
 MOVE_OVERLAY_ALPHA = 0.65
 SCROLL_RC = 0.15
 
+SNAP_LOOKAHEAD = 0.1  # s, use scroll velocity to pick the snap item we'll coast to
+
 EDGE_SHADOW_WIDTH = 20
 
 MIN_ZOOM_ANIMATION_TIME = 0.075  # seconds
@@ -191,12 +193,15 @@ class _Scroller(Widget):
     snap_target: float | None = None
     if self._snap_items and visible_items and self._scrolling_to[0] is None:
       # TODO: this doesn't handle two small buttons at the edges well
-      center_pos = self._rect.x + self._rect.width / 2
+      # Project where items will end up given current scroll velocity, so flicks land on the next item
+      center_pos = self._rect.x + self._rect.width / 2 - self.scroll_panel.velocity * SNAP_LOOKAHEAD
       closest_delta_pos = min((((item.rect.x + item.rect.width / 2) - center_pos) for item in visible_items), key=abs)
+      print('closest_delta_pos', closest_delta_pos)
       snap_target = self.scroll_panel.get_offset() - closest_delta_pos
 
     offset = self.scroll_panel.update(self._rect, content_size, snap_target=snap_target)
     print('final offset', offset)
+    print()
     return offset
 
   @property


### PR DESCRIPTION
Fixes the offset ending up at 535.99997, etc, causing both onroad and home view to be rendered (from the culling in Scroller thinking it's in view). Especially laggy when you open settings and are rendering 3 widgets at once

Also fixes the few pixels of overshoot on finishing snapping