### PR TITLE
Scroller: restore tapping home to open settings while it's auto scrolling

### DIFF
--- a/selfdrive/ui/mici/layouts/settings/network/wifi_ui.py
+++ b/selfdrive/ui/mici/layouts/settings/network/wifi_ui.py
@@ -383,7 +383,7 @@ class WifiUIMici(NavScroller):
 
       if scroll:
         # Scroll to the new position of the network
-        self._scroller.scroll_to(self._scroller.scroll_panel.get_offset(), smooth=True, block_widget_touches=True)
+        self._scroller.scroll_to(self._scroller.scroll_panel.get_offset(), smooth=True, block_widget_interaction=True)
 
   def _update_state(self):
     super()._update_state()

--- a/selfdrive/ui/mici/layouts/settings/network/wifi_ui.py
+++ b/selfdrive/ui/mici/layouts/settings/network/wifi_ui.py
@@ -383,7 +383,7 @@ class WifiUIMici(NavScroller):
 
       if scroll:
         # Scroll to the new position of the network
-        self._scroller.scroll_to(self._scroller.scroll_panel.get_offset(), smooth=True)
+        self._scroller.scroll_to(self._scroller.scroll_panel.get_offset(), smooth=True, block_widget_touches=True)
 
   def _update_state(self):
     super()._update_state()

--- a/system/ui/mici_setup.py
+++ b/system/ui/mici_setup.py
@@ -316,7 +316,7 @@ class NetworkSetupPageBase(Scroller):
 
     def on_waiting_click():
       offset = (self._wifi_button.rect.x + self._wifi_button.rect.width / 2) - (self._rect.x + self._rect.width / 2)
-      self._scroller.scroll_to(offset, smooth=True, block_cancel=True, block_widget_touches=True)
+      self._scroller.scroll_to(offset, smooth=True, block_interrupt=True, block_widget_interaction=True)
       # trigger grow when wifi button in view
       self._pending_wifi_grow_animation = True
 
@@ -399,7 +399,7 @@ class NetworkSetupPageBase(Scroller):
     self._scroller._layout()
     end_offset = -(self._scroller.content_size - self._rect.width)
     remaining = self._scroller.scroll_panel.get_offset() - end_offset
-    self._scroller.scroll_to(remaining, smooth=True, block_cancel=True, block_widget_touches=True)
+    self._scroller.scroll_to(remaining, smooth=True, block_interrupt=True, block_widget_interaction=True)
     self._pending_continue_grow_animation = True
 
   def set_custom_software(self, custom_software: bool):

--- a/system/ui/mici_setup.py
+++ b/system/ui/mici_setup.py
@@ -316,7 +316,7 @@ class NetworkSetupPageBase(Scroller):
 
     def on_waiting_click():
       offset = (self._wifi_button.rect.x + self._wifi_button.rect.width / 2) - (self._rect.x + self._rect.width / 2)
-      self._scroller.scroll_to(offset, smooth=True, block_interaction=True)
+      self._scroller.scroll_to(offset, smooth=True, block_cancel=True, block_widget_touches=True)
       # trigger grow when wifi button in view
       self._pending_wifi_grow_animation = True
 
@@ -399,7 +399,7 @@ class NetworkSetupPageBase(Scroller):
     self._scroller._layout()
     end_offset = -(self._scroller.content_size - self._rect.width)
     remaining = self._scroller.scroll_panel.get_offset() - end_offset
-    self._scroller.scroll_to(remaining, smooth=True, block_interaction=True)
+    self._scroller.scroll_to(remaining, smooth=True, block_cancel=True, block_widget_touches=True)
     self._pending_continue_grow_animation = True
 
   def set_custom_software(self, custom_software: bool):

--- a/system/ui/widgets/scroller.py
+++ b/system/ui/widgets/scroller.py
@@ -81,7 +81,7 @@ class _Scroller(Widget):
 
     self._reset_scroll_at_show = True
 
-    self._scrolling_to: tuple[float | None, bool, bool] = (None, False, False)  # target offset, block_cancel, block_widget_touches
+    self._scrolling_to: tuple[float | None, bool, bool] = (None, False, False)  # target offset, block_interrupt, block_widget_interaction
     self._scrolling_to_filter = FirstOrderFilter(0.0, SCROLL_RC, 1 / gui_app.target_fps)
     self._zoom_filter = FirstOrderFilter(1.0, 0.2, 1 / gui_app.target_fps)
     self._zoom_out_t: float = 0.0
@@ -115,8 +115,8 @@ class _Scroller(Widget):
     self._reset_scroll_at_show = scroll
 
   def scroll_to(self, pos: float, smooth: bool = False,
-                block_cancel: bool = False, block_widget_touches: bool = False):
-    assert smooth or (not block_cancel and not block_widget_touches), "Instant scroll cannot block interaction"
+                block_interrupt: bool = False, block_widget_interaction: bool = False):
+    assert smooth or (not block_interrupt and not block_widget_interaction), "Instant scroll cannot block interaction"
 
     # already there
     if abs(pos) < 1:
@@ -126,7 +126,7 @@ class _Scroller(Widget):
     scroll_offset = self.scroll_panel.get_offset() - pos
     if smooth:
       self._scrolling_to_filter.x = self.scroll_panel.get_offset()
-      self._scrolling_to = scroll_offset, block_cancel, block_widget_touches
+      self._scrolling_to = scroll_offset, block_interrupt, block_widget_interaction
     else:
       self.scroll_panel.set_offset(scroll_offset)
 

--- a/system/ui/widgets/scroller.py
+++ b/system/ui/widgets/scroller.py
@@ -114,8 +114,7 @@ class _Scroller(Widget):
   def set_reset_scroll_at_show(self, scroll: bool):
     self._reset_scroll_at_show = scroll
 
-  def scroll_to(self, pos: float, smooth: bool = False,
-                block_interrupt: bool = False, block_widget_interaction: bool = False):
+  def scroll_to(self, pos: float, smooth: bool = False, block_interrupt: bool = False, block_widget_interaction: bool = False):
     assert smooth or (not block_interrupt and not block_widget_interaction), "Instant scroll cannot block interaction"
 
     # already there

--- a/system/ui/widgets/scroller.py
+++ b/system/ui/widgets/scroller.py
@@ -81,7 +81,7 @@ class _Scroller(Widget):
 
     self._reset_scroll_at_show = True
 
-    self._scrolling_to: tuple[float | None, bool] = (None, False)  # target offset, block_interaction
+    self._scrolling_to: tuple[float | None, bool, bool] = (None, False, False)  # target offset, block_cancel, block_widget_touches
     self._scrolling_to_filter = FirstOrderFilter(0.0, SCROLL_RC, 1 / gui_app.target_fps)
     self._zoom_filter = FirstOrderFilter(1.0, 0.2, 1 / gui_app.target_fps)
     self._zoom_out_t: float = 0.0
@@ -114,8 +114,9 @@ class _Scroller(Widget):
   def set_reset_scroll_at_show(self, scroll: bool):
     self._reset_scroll_at_show = scroll
 
-  def scroll_to(self, pos: float, smooth: bool = False, block_interaction: bool = False):
-    assert not block_interaction or smooth, "Instant scroll cannot block user interaction"
+  def scroll_to(self, pos: float, smooth: bool = False,
+                block_cancel: bool = False, block_widget_touches: bool = False):
+    assert smooth or (not block_cancel and not block_widget_touches), "Instant scroll cannot block interaction"
 
     # already there
     if abs(pos) < 1:
@@ -125,7 +126,7 @@ class _Scroller(Widget):
     scroll_offset = self.scroll_panel.get_offset() - pos
     if smooth:
       self._scrolling_to_filter.x = self.scroll_panel.get_offset()
-      self._scrolling_to = scroll_offset, block_interaction
+      self._scrolling_to = scroll_offset, block_cancel, block_widget_touches
     else:
       self.scroll_panel.set_offset(scroll_offset)
 
@@ -146,7 +147,7 @@ class _Scroller(Widget):
 
     # preserve original touch valid callback
     original_touch_valid_callback = item._touch_valid_callback
-    item.set_touch_valid_callback(lambda: self.scroll_panel.is_touch_valid() and self.enabled and self._scrolling_to[0] is None
+    item.set_touch_valid_callback(lambda: self.scroll_panel.is_touch_valid() and self.enabled and not self._scrolling_to[2]
                                           and not self.moving_items and (original_touch_valid_callback() if
                                                                          original_touch_valid_callback else True))
 
@@ -173,7 +174,7 @@ class _Scroller(Widget):
     # Cancel auto-scroll if user starts manually scrolling (unless block_interaction)
     if (self.scroll_panel.state in (ScrollState.PRESSED, ScrollState.MANUAL_SCROLL) and
         self._scrolling_to[0] is not None and not self._scrolling_to[1]):
-      self._scrolling_to = None, False
+      self._scrolling_to = None, False, False
 
     if self._scrolling_to[0] is not None and len(self._pending_lift) == 0:
       self._scrolling_to_filter.update(self._scrolling_to[0])
@@ -181,7 +182,7 @@ class _Scroller(Widget):
 
       if abs(self._scrolling_to_filter.x - self._scrolling_to[0]) < 1:  # finished scroll
         self.scroll_panel.set_offset(self._scrolling_to[0])
-        self._scrolling_to = None, False
+        self._scrolling_to = None, False, False
 
   def _get_scroll(self, visible_items: list[Widget], content_size: float) -> float:
     scroll_enabled = self._scroll_enabled() if callable(self._scroll_enabled) else self._scroll_enabled
@@ -380,7 +381,7 @@ class _Scroller(Widget):
     self._move_lift.clear()
     self._pending_lift.clear()
     self._pending_move.clear()
-    self._scrolling_to = None, False
+    self._scrolling_to = None, False, False
     self._scrolling_to_filter.x = 0.0
 
   def hide_event(self):


### PR DESCRIPTION
You used to be able to tap onroad -> scrolls home -> tap home while it's still moving to quickly open settings. We removed this because WifiUi required us to block interactions, but it feels way clunkier now without this, even though it's what mobile UIs do. Add two bools to allow this.