### PR TITLE
ui: consistent offroad/onroad timings

### DIFF
--- a/cereal/log.capnp
+++ b/cereal/log.capnp
@@ -2301,6 +2301,8 @@ struct Sentinel {
 struct UIDebug {
   cpuTimeMillis @0 :Float32;
   frameTimeMillis @1 :Float32;
+  uiStateUpdateMillis @2 :Float32;
+  reaffineMillis @3 :Float32;
 }
 
 struct ManagerState {

--- a/common/api.py
+++ b/common/api.py
@@ -1,6 +1,7 @@
 import jwt
 import os
 import requests
+import time
 from datetime import datetime, timedelta, UTC
 from openpilot.system.hardware.hw import Paths
 from openpilot.system.version import get_version
@@ -43,15 +44,20 @@ class Api:
 
 
 def api_get(endpoint, method='GET', timeout=None, access_token=None, session=None, **params):
+  t0 = time.monotonic()
   headers = {}
   if access_token is not None:
     headers['Authorization'] = "JWT " + access_token
 
   headers['User-Agent'] = "openpilot-" + get_version()
+  t_headers = time.monotonic()
 
   # TODO: add session to Api
   req = requests if session is None else session
-  return req.request(method, API_HOST + "/" + endpoint, timeout=timeout, headers=headers, params=params)
+  resp = req.request(method, API_HOST + "/" + endpoint, timeout=timeout, headers=headers, params=params)
+  t_req = time.monotonic()
+  print(f"  >> api_get[{endpoint[:30]}]: headers={(t_headers-t0)*1000:.1f}ms req.request={(t_req-t_headers)*1000:.1f}ms")
+  return resp
 
 
 def get_key_pair() -> tuple[str, str, str] | tuple[None, None, None]:

--- a/selfdrive/ui/lib/api_helpers.py
+++ b/selfdrive/ui/lib/api_helpers.py
@@ -11,7 +11,13 @@ def _get_token(dongle_id: str, t: int):
   if not system_time_valid():
     raise RuntimeError("System time is not valid, cannot generate token")
 
-  return Api(dongle_id).get_token(expiry_hours=TOKEN_EXPIRY_HOURS)
+  t0 = time.monotonic()
+  api = Api(dongle_id)
+  t_api = time.monotonic()
+  token = api.get_token(expiry_hours=TOKEN_EXPIRY_HOURS)
+  t_jwt = time.monotonic()
+  print(f">> get_token CACHE MISS: Api()={(t_api-t0)*1000:.1f}ms jwt.encode={(t_jwt-t_api)*1000:.1f}ms total={(t_jwt-t0)*1000:.1f}ms")
+  return token
 
 
 def get_token(dongle_id: str):

--- a/selfdrive/ui/lib/prime_state.py
+++ b/selfdrive/ui/lib/prime_state.py
@@ -52,6 +52,16 @@ class PrimeState:
 
     try:
       identity_token = get_token(dongle_id)
+      # FIXME: this api_get call (~127ms) caused multi-ms main-thread spikes when
+      # this thread was enabled. Most of the time is socket I/O (GIL released), but
+      # requests/urllib3/ssl Python internals hold the GIL in 1-5ms chunks between
+      # syscalls — long enough to stall the render thread past CPython's 5ms
+      # switch_interval. Mitigations to consider before re-enabling:
+      #   1. Move the HTTPS to a subprocess (curl) — eliminates GIL impact entirely.
+      #   2. Bump FETCH_INTERVAL to 60s+ and trigger on-demand refresh from screens
+      #      that need fresh prime state (e.g. settings/pair).
+      #   3. Use http.client/socket directly — less Python overhead than requests
+      #      but won't fully eliminate GIL stalls in the SSL/header path.
       response = api_get(f"v1.1/devices/{dongle_id}", timeout=self.API_TIMEOUT, access_token=identity_token, session=self._session)
       if response.status_code == 200:
         data = response.json()
@@ -65,20 +75,19 @@ class PrimeState:
     with self._lock:
       if prime_type != self.prime_type:
         self.prime_type = prime_type
-        self._params.put("PrimeType", int(prime_type))
+        self._params.put_nonblocking("PrimeType", int(prime_type))
         cloudlog.info(f"Prime type updated to {prime_type}")
 
   def _worker_thread(self) -> None:
-    # Drop inherited RT99/cpu5 from main thread — this is background network I/O.
+    # Drop inherited RT99 from main thread — background work, never preempt render.
     try:
-      os.sched_setaffinity(0, range(os.cpu_count() or 8))
       os.sched_setscheduler(0, os.SCHED_OTHER, os.sched_param(0))
     except OSError:
       pass
     from openpilot.selfdrive.ui.ui_state import ui_state, device
     while self._running:
       # Networking gate: `touch /tmp/enable_bg_threads` to allow API calls.
-      if False and os.path.exists('/tmp/enable_bg_threads'):  # TEMP: force off for thread bisect
+      if os.path.exists('/tmp/enable_bg_threads'):
         if not ui_state.started and device._awake:
           self._fetch_prime_status()
 
@@ -88,6 +97,7 @@ class PrimeState:
         time.sleep(self.SLEEP_INTERVAL)
 
   def start(self) -> None:
+    return  # disabled: GIL contention from requests/json caused multi-ms main-thread spikes
     if self._thread and self._thread.is_alive():
       return
     self._running = True

--- a/selfdrive/ui/lib/prime_state.py
+++ b/selfdrive/ui/lib/prime_state.py
@@ -80,6 +80,7 @@ class PrimeState:
         time.sleep(self.SLEEP_INTERVAL)
 
   def start(self) -> None:
+    return  # disabled for perf testing
     if self._thread and self._thread.is_alive():
       return
     self._running = True

--- a/selfdrive/ui/lib/prime_state.py
+++ b/selfdrive/ui/lib/prime_state.py
@@ -69,10 +69,16 @@ class PrimeState:
         cloudlog.info(f"Prime type updated to {prime_type}")
 
   def _worker_thread(self) -> None:
+    # Drop inherited RT99/cpu5 from main thread — this is background network I/O.
+    try:
+      os.sched_setaffinity(0, range(os.cpu_count() or 8))
+      os.sched_setscheduler(0, os.SCHED_OTHER, os.sched_param(0))
+    except OSError:
+      pass
     from openpilot.selfdrive.ui.ui_state import ui_state, device
     while self._running:
-      # Kill switch: `touch /tmp/disable_bg_threads` to skip work this iteration
-      if not os.path.exists('/tmp/disable_bg_threads'):
+      # Networking gate: `touch /tmp/enable_bg_threads` to allow API calls.
+      if False and os.path.exists('/tmp/enable_bg_threads'):  # TEMP: force off for thread bisect
         if not ui_state.started and device._awake:
           self._fetch_prime_status()
 
@@ -82,7 +88,6 @@ class PrimeState:
         time.sleep(self.SLEEP_INTERVAL)
 
   def start(self) -> None:
-    return  # disabled for perf testing
     if self._thread and self._thread.is_alive():
       return
     self._running = True

--- a/selfdrive/ui/lib/prime_state.py
+++ b/selfdrive/ui/lib/prime_state.py
@@ -71,8 +71,10 @@ class PrimeState:
   def _worker_thread(self) -> None:
     from openpilot.selfdrive.ui.ui_state import ui_state, device
     while self._running:
-      if not ui_state.started and device._awake:
-        self._fetch_prime_status()
+      # Kill switch: `touch /tmp/disable_bg_threads` to skip work this iteration
+      if not os.path.exists('/tmp/disable_bg_threads'):
+        if not ui_state.started and device._awake:
+          self._fetch_prime_status()
 
       for _ in range(int(self.FETCH_INTERVAL / self.SLEEP_INTERVAL)):
         if not self._running:

--- a/selfdrive/ui/mici/layouts/home.py
+++ b/selfdrive/ui/mici/layouts/home.py
@@ -1,4 +1,5 @@
 import datetime
+import threading
 import time
 
 from cereal import log
@@ -132,13 +133,16 @@ class MiciHomeLayout(Widget):
     self._on_alerts_click: Callable | None = None
     self._alert_count_callback: Callable[[], int] | None = None
 
-    self._last_refresh = 0
     self._mouse_down_t: None | float = None
     self._did_long_press = False
     self._is_pressed_prev = False
 
     self._version_text = None
     self._experimental_mode = False
+
+    self._params_thread_exit = threading.Event()
+    self._params_thread = threading.Thread(target=self._params_refresh_loop, daemon=True)
+    self._params_thread.start()
 
     self._experimental_icon = IconWidget("icons_mici/experimental_mode.png", (48, 48))
     self._mic_icon = IconWidget("icons_mici/microphone.png", (32, 46))
@@ -163,11 +167,12 @@ class MiciHomeLayout(Widget):
 
   def show_event(self):
     super().show_event()
-    self._version_text = self._get_version_text()
-    self._update_params()
 
-  def _update_params(self):
-    self._experimental_mode = ui_state.params.get_bool("ExperimentalMode")
+  def _params_refresh_loop(self):
+    while not self._params_thread_exit.is_set():
+      self._version_text = self._get_version_text()
+      self._experimental_mode = ui_state.params.get_bool("ExperimentalMode")
+      self._params_thread_exit.wait(5.0)
 
   def _update_state(self):
     if self.is_pressed and not self._is_pressed_prev:
@@ -185,12 +190,6 @@ class MiciHomeLayout(Widget):
           ui_state.params.put("ExperimentalMode", self._experimental_mode)
         self._mouse_down_t = None
         self._did_long_press = True
-
-    if rl.get_time() - self._last_refresh > 5.0:
-      # Update version text
-      self._version_text = self._get_version_text()
-      self._last_refresh = rl.get_time()
-      self._update_params()
 
   def set_callbacks(self, on_settings: Callable | None = None, on_alerts: Callable | None = None,
                     alert_count_callback: Callable[[], int] | None = None,

--- a/selfdrive/ui/mici/layouts/home.py
+++ b/selfdrive/ui/mici/layouts/home.py
@@ -1,6 +1,4 @@
 import datetime
-import os
-import threading
 import time
 
 from cereal import log
@@ -138,12 +136,9 @@ class MiciHomeLayout(Widget):
     self._did_long_press = False
     self._is_pressed_prev = False
 
-    self._version_text = None
-    self._experimental_mode = False
-
-    self._params_thread_exit = threading.Event()
-    self._params_thread = threading.Thread(target=self._params_refresh_loop, daemon=True)
-    self._params_thread.start()
+    # Version params are written once at boot by manager.py — read on init, never refreshed.
+    # ExperimentalMode lives on ui_state (refreshed by ui_state's params thread every 5s).
+    self._version_text = self._get_version_text()
 
     self._experimental_icon = IconWidget("icons_mici/experimental_mode.png", (48, 48))
     self._mic_icon = IconWidget("icons_mici/microphone.png", (32, 46))
@@ -169,18 +164,6 @@ class MiciHomeLayout(Widget):
   def show_event(self):
     super().show_event()
 
-  def _params_refresh_loop(self):
-    # Drop inherited RT99/cpu5 from main thread — this is background I/O.
-    try:
-      os.sched_setaffinity(0, range(os.cpu_count() or 8))
-      os.sched_setscheduler(0, os.SCHED_OTHER, os.sched_param(0))
-    except OSError:
-      pass
-    while not self._params_thread_exit.is_set():
-      self._version_text = self._get_version_text()
-      self._experimental_mode = ui_state.params.get_bool("ExperimentalMode")
-      self._params_thread_exit.wait(5.0)
-
   def _update_state(self):
     if self.is_pressed and not self._is_pressed_prev:
       self._mouse_down_t = time.monotonic()
@@ -193,8 +176,8 @@ class MiciHomeLayout(Widget):
       if time.monotonic() - self._mouse_down_t > 0.5:
         # long gating for experimental mode - only allow toggle if longitudinal control is available
         if ui_state.has_longitudinal_control:
-          self._experimental_mode = not self._experimental_mode
-          ui_state.params.put("ExperimentalMode", self._experimental_mode)
+          ui_state.experimental_mode = not ui_state.experimental_mode
+          ui_state.params.put_bool_nonblocking("ExperimentalMode", ui_state.experimental_mode)
         self._mouse_down_t = None
         self._did_long_press = True
 
@@ -265,7 +248,7 @@ class MiciHomeLayout(Widget):
         self._version_commit_label.render()
 
     # ***** Center-aligned bottom section icons *****
-    self._experimental_icon.set_visible(self._experimental_mode)
+    self._experimental_icon.set_visible(ui_state.experimental_mode)
     self._mic_icon.set_visible(ui_state.recording_audio)
     self._body_icon.set_visible(ui_state.is_body)
 

--- a/selfdrive/ui/mici/layouts/home.py
+++ b/selfdrive/ui/mici/layouts/home.py
@@ -225,7 +225,12 @@ class MiciHomeLayout(Widget):
     self._openpilot_label.render()
 
     if self._version_text is not None:
-      # release branch
+      # TODO: set_text on these labels runs every frame even though _version_text is
+      # set once at init and never changes (manager.py writes Version/GitCommit/etc
+      # at boot). Each set_text re-measures glyph widths / invalidates the label's
+      # cached layout — costs ~0.5ms/frame total across these 4 labels. Move all
+      # label set_text + set_max_width calls into __init__ once _version_text is
+      # populated, leave _render with positioning + draw only.
       release_branch = self._version_text[1] in RELEASE_BRANCHES
       version_pos = rl.Rectangle(text_pos.x, text_pos.y + self._openpilot_label.font_size + 16, 100, 44)
       self._version_label.set_text(self._version_text[0])

--- a/selfdrive/ui/mici/layouts/home.py
+++ b/selfdrive/ui/mici/layouts/home.py
@@ -1,4 +1,5 @@
 import datetime
+import os
 import threading
 import time
 
@@ -169,6 +170,12 @@ class MiciHomeLayout(Widget):
     super().show_event()
 
   def _params_refresh_loop(self):
+    # Drop inherited RT99/cpu5 from main thread — this is background I/O.
+    try:
+      os.sched_setaffinity(0, range(os.cpu_count() or 8))
+      os.sched_setscheduler(0, os.SCHED_OTHER, os.sched_param(0))
+    except OSError:
+      pass
     while not self._params_thread_exit.is_set():
       self._version_text = self._get_version_text()
       self._experimental_mode = ui_state.params.get_bool("ExperimentalMode")

--- a/selfdrive/ui/mici/layouts/main.py
+++ b/selfdrive/ui/mici/layouts/main.py
@@ -86,7 +86,7 @@ class MiciMainLayout(Scroller):
   def _update_state(self):
     super()._update_state()
     # TODO: Hack to run alert updates while not in view. Add a nav stack tick?
-    self._alerts_layout._update_state()
+    # self._alerts_layout._update_state()  # disabled for perf testing
 
   def _render(self, _):
     if not self._setup:

--- a/selfdrive/ui/mici/layouts/onboarding.py
+++ b/selfdrive/ui/mici/layouts/onboarding.py
@@ -109,7 +109,7 @@ class TrainingGuideDMTutorial(NavWidget):
 
     # Disable driver monitoring model when device times out for inactivity
     def inactivity_callback():
-      ui_state.params.put_bool("IsDriverViewEnabled", False)
+      ui_state.params.put_bool_nonblocking("IsDriverViewEnabled", False)
 
     device.add_interactive_timeout_callback(inactivity_callback)
 

--- a/selfdrive/ui/mici/layouts/settings/firehose.py
+++ b/selfdrive/ui/mici/layouts/settings/firehose.py
@@ -54,7 +54,7 @@ class FirehoseLayoutBase(Widget):
 
     self._running = True
     self._update_thread = threading.Thread(target=self._update_loop, daemon=True)
-    self._update_thread.start()
+    # self._update_thread.start()  # disabled for perf testing
 
   def __del__(self):
     self._running = False

--- a/selfdrive/ui/mici/layouts/settings/firehose.py
+++ b/selfdrive/ui/mici/layouts/settings/firehose.py
@@ -42,7 +42,7 @@ class FirehoseLayoutBase(Widget):
   RED = rl.Color(231, 76, 60, 255)
   GRAY = rl.Color(68, 68, 68, 255)
   LIGHT_GRAY = rl.Color(228, 228, 228, 255)
-  UPDATE_INTERVAL = 30  # seconds
+  UPDATE_INTERVAL = 5  # seconds
 
   def __init__(self):
     super().__init__()
@@ -200,28 +200,36 @@ class FirehoseLayoutBase(Widget):
 
   def _fetch_firehose_stats(self):
     try:
+      t0 = time.monotonic()
       dongle_id = self._params.get("DongleId")
+      t_dongle = time.monotonic()
       if not dongle_id or dongle_id == UNREGISTERED_DONGLE_ID:
         return
       identity_token = get_token(dongle_id)
+      t_token = time.monotonic()
       response = api_get(f"v1/devices/{dongle_id}/firehose_stats", access_token=identity_token, session=self._session)
+      t_http = time.monotonic()
       if response.status_code == 200:
         data = response.json()
+        t_json = time.monotonic()
         self._segment_count = data.get("firehose", 0)
-        self._params.put(self.PARAM_KEY, data)
+        self._params.put_nonblocking(self.PARAM_KEY, data)
+        t_set = time.monotonic()
+        print(f">> firehose fetch: dongle={(t_dongle-t0)*1000:.1f}ms token={(t_token-t_dongle)*1000:.1f}ms "
+              f"http={(t_http-t_token)*1000:.1f}ms json={(t_json-t_http)*1000:.1f}ms set={(t_set-t_json)*1000:.1f}ms "
+              f"total={(t_set-t0)*1000:.1f}ms")
     except Exception as e:
       cloudlog.error(f"Failed to fetch firehose stats: {e}")
 
   def _update_loop(self):
-    # Drop inherited RT99/cpu5 from main thread — this is background network I/O.
+    # Drop inherited RT99 from main thread — background work, never preempt render.
     try:
-      os.sched_setaffinity(0, range(os.cpu_count() or 8))
       os.sched_setscheduler(0, os.SCHED_OTHER, os.sched_param(0))
     except OSError:
       pass
     while self._running:
       # Networking gate: `touch /tmp/enable_bg_threads` to allow API calls.
-      if False and os.path.exists('/tmp/enable_bg_threads'):  # TEMP: force off for thread bisect
+      if os.path.exists('/tmp/enable_bg_threads'):
         if not ui_state.started and device._awake:
           self._fetch_firehose_stats()
       time.sleep(self.UPDATE_INTERVAL)

--- a/selfdrive/ui/mici/layouts/settings/firehose.py
+++ b/selfdrive/ui/mici/layouts/settings/firehose.py
@@ -55,7 +55,7 @@ class FirehoseLayoutBase(Widget):
 
     self._running = True
     self._update_thread = threading.Thread(target=self._update_loop, daemon=True)
-    # self._update_thread.start()  # disabled for perf testing
+    self._update_thread.start()
 
   def __del__(self):
     self._running = False
@@ -213,9 +213,15 @@ class FirehoseLayoutBase(Widget):
       cloudlog.error(f"Failed to fetch firehose stats: {e}")
 
   def _update_loop(self):
+    # Drop inherited RT99/cpu5 from main thread — this is background network I/O.
+    try:
+      os.sched_setaffinity(0, range(os.cpu_count() or 8))
+      os.sched_setscheduler(0, os.SCHED_OTHER, os.sched_param(0))
+    except OSError:
+      pass
     while self._running:
-      # Kill switch: `touch /tmp/disable_bg_threads` to skip work this iteration
-      if not os.path.exists('/tmp/disable_bg_threads'):
+      # Networking gate: `touch /tmp/enable_bg_threads` to allow API calls.
+      if False and os.path.exists('/tmp/enable_bg_threads'):  # TEMP: force off for thread bisect
         if not ui_state.started and device._awake:
           self._fetch_firehose_stats()
       time.sleep(self.UPDATE_INTERVAL)

--- a/selfdrive/ui/mici/layouts/settings/firehose.py
+++ b/selfdrive/ui/mici/layouts/settings/firehose.py
@@ -1,3 +1,4 @@
+import os
 import requests
 import threading
 import time
@@ -213,8 +214,10 @@ class FirehoseLayoutBase(Widget):
 
   def _update_loop(self):
     while self._running:
-      if not ui_state.started and device._awake:
-        self._fetch_firehose_stats()
+      # Kill switch: `touch /tmp/disable_bg_threads` to skip work this iteration
+      if not os.path.exists('/tmp/disable_bg_threads'):
+        if not ui_state.started and device._awake:
+          self._fetch_firehose_stats()
       time.sleep(self.UPDATE_INTERVAL)
 
 

--- a/selfdrive/ui/mici/layouts/settings/network/network_layout.py
+++ b/selfdrive/ui/mici/layouts/settings/network/network_layout.py
@@ -13,13 +13,10 @@ class NetworkLayoutMici(NavScroller):
   def __init__(self):
     super().__init__()
 
-    self._wifi_manager = WifiManager()
-    self._wifi_manager.set_active(False)
-    self._wifi_ui = WifiUIMici(self._wifi_manager)
-
-    self._wifi_manager.add_callbacks(
-      networks_updated=self._on_network_updated,
-    )
+    # WifiManager disabled for perf testing (jeepney spawns _receiver thread)
+    self._wifi_manager = None
+    self._wifi_ui = None
+    return
 
     # ******** Tethering ********
     def tethering_toggle_callback(checked: bool):

--- a/selfdrive/ui/mici/onroad/augmented_road_view.py
+++ b/selfdrive/ui/mici/onroad/augmented_road_view.py
@@ -165,6 +165,14 @@ class AugmentedRoadView(CameraView):
   def _update_state(self):
     super()._update_state()
 
+    # DEBUG: log which sm topics updated this frame
+    # _topics = ('modelV2', 'liveCalibration', 'radarState', 'controlsState',
+    #            'carState', 'longitudinalPlan', 'selfdriveState', 'pandaStates',
+    #            'driverMonitoringState', 'roadCameraState', 'wideRoadCameraState')
+    # _updated = [t for t in _topics if ui_state.sm.updated[t]]
+    # if _updated:
+    #   print(f"[AugRV] frame={ui_state.sm.frame} updated={_updated}")
+
     # update offroad label
     if ui_state.panda_type == log.PandaState.PandaType.unknown:
       self._offroad_label.set_text("system booting")

--- a/selfdrive/ui/mici/onroad/augmented_road_view.py
+++ b/selfdrive/ui/mici/onroad/augmented_road_view.py
@@ -193,63 +193,65 @@ class AugmentedRoadView(CameraView):
       self._offroad_label.render(self._rect)
       return
 
+    import time as _t
+    if not hasattr(self, '_dbg_acc'):
+      self._dbg_acc: dict[str, float] = {}
+      self._dbg_n = 0
+
+    _ts = _t.monotonic()
+
     self._switch_stream_if_needed(ui_state.sm)
-
-    # Update calibration before rendering
     self._update_calibration()
-
-    # Create inner content area with border padding
     self._content_rect = rl.Rectangle(
-      self.rect.x,
-      self.rect.y,
-      self.rect.width - SIDE_PANEL_WIDTH,
-      self.rect.height,
+      self.rect.x, self.rect.y,
+      self.rect.width - SIDE_PANEL_WIDTH, self.rect.height,
     )
+    self._dbg_acc['setup'] = self._dbg_acc.get('setup', 0) + (_t.monotonic() - _ts); _ts = _t.monotonic()
 
-    # Enable scissor mode to clip all rendering within content rectangle boundaries
-    # This creates a rendering viewport that prevents graphics from drawing outside the border
     rl.begin_scissor_mode(
-      int(self._content_rect.x),
-      int(self._content_rect.y),
-      int(self._content_rect.width),
-      int(self._content_rect.height)
-    )
+      int(self._content_rect.x), int(self._content_rect.y),
+      int(self._content_rect.width), int(self._content_rect.height))
 
-    # Render the base camera view
     super()._render(self._content_rect)
+    self._dbg_acc['camera'] = self._dbg_acc.get('camera', 0) + (_t.monotonic() - _ts); _ts = _t.monotonic()
 
-    # Draw all UI overlays
     self._model_renderer.render(self._content_rect)
+    self._dbg_acc['model'] = self._dbg_acc.get('model', 0) + (_t.monotonic() - _ts); _ts = _t.monotonic()
 
-    # Fade out bottom of overlays for looks
     rl.draw_texture_ex(self._fade_texture, rl.Vector2(self._content_rect.x, self._content_rect.y), 0.0, 1.0, rl.WHITE)
-
     alert_to_render, not_animating_out = self._alert_renderer.will_render()
 
-    # Hide DMoji when disengaged unless AlwaysOnDM is enabled
     should_draw_dmoji = (not self._hud_renderer.drawing_top_icons() and
                          (ui_state.status != UIStatus.DISENGAGED or ui_state.always_on_dm))
     self._driver_state_renderer.set_should_draw(should_draw_dmoji)
     self._driver_state_renderer.set_position(self._rect.x + 16, self._rect.y + 10)
     self._driver_state_renderer.render()
+    self._dbg_acc['dmoji'] = self._dbg_acc.get('dmoji', 0) + (_t.monotonic() - _ts); _ts = _t.monotonic()
 
     self._hud_renderer.set_can_draw_top_icons(alert_to_render is None)
     self._hud_renderer.set_wheel_critical_icon(alert_to_render is not None and not not_animating_out and
                                                alert_to_render.visual_alert == car.CarControl.HUDControl.VisualAlert.steerRequired)
     self._alert_renderer.render(self._content_rect)
+    self._dbg_acc['alert'] = self._dbg_acc.get('alert', 0) + (_t.monotonic() - _ts); _ts = _t.monotonic()
+
     self._hud_renderer.render(self._content_rect)
+    self._dbg_acc['hud'] = self._dbg_acc.get('hud', 0) + (_t.monotonic() - _ts); _ts = _t.monotonic()
 
-    # Draw fake rounded border
     rl.draw_rectangle_rounded_lines_ex(self._content_rect, 0.2 * 1.02, 10, 50, rl.BLACK)
-
-    # End clipping region
     rl.end_scissor_mode()
 
-    # Custom UI extension point - add custom overlays here
-    # Use self._content_rect for positioning within camera bounds
     self._confidence_ball.render(self.rect)
-
     self._bookmark_icon.render(self.rect)
+    self._dbg_acc['rest'] = self._dbg_acc.get('rest', 0) + (_t.monotonic() - _ts)
+
+    self._dbg_n += 1
+    if self._dbg_n >= 120:
+      total = sum(self._dbg_acc.values())
+      print("[AugRV avg over 120f] " + "  ".join(
+        f"{k}={(v / self._dbg_n) * 1000:.2f}ms" for k, v in sorted(self._dbg_acc.items(), key=lambda x: -x[1]))
+        + f"  total={total / self._dbg_n * 1000:.2f}ms")
+      self._dbg_acc = {}
+      self._dbg_n = 0
 
   def _switch_stream_if_needed(self, sm):
     if sm['selfdriveState'].experimentalMode and WIDE_CAM in self.available_streams:

--- a/selfdrive/ui/mici/onroad/hud_renderer.py
+++ b/selfdrive/ui/mici/onroad/hud_renderer.py
@@ -171,13 +171,30 @@ class HudRenderer(Widget):
 
   def _render(self, rect: rl.Rectangle) -> None:
     """Render HUD elements to the screen."""
+    import time as _t
+    if not hasattr(self, '_dbg_acc'):
+      self._dbg_acc: dict[str, float] = {}
+      self._dbg_n = 0
+    _ts = _t.monotonic()
 
     self._torque_bar.render(rect)
+    self._dbg_acc['torque_bar'] = self._dbg_acc.get('torque_bar', 0) + (_t.monotonic() - _ts); _ts = _t.monotonic()
 
     if self.is_cruise_set:
       self._draw_set_speed(rect)
+    self._dbg_acc['set_speed'] = self._dbg_acc.get('set_speed', 0) + (_t.monotonic() - _ts); _ts = _t.monotonic()
 
     self._draw_steering_wheel(rect)
+    self._dbg_acc['wheel'] = self._dbg_acc.get('wheel', 0) + (_t.monotonic() - _ts)
+
+    self._dbg_n += 1
+    if self._dbg_n >= 120:
+      total = sum(self._dbg_acc.values())
+      print("[HUD avg over 120f] " + "  ".join(
+        f"{k}={(v / self._dbg_n) * 1000:.2f}ms" for k, v in sorted(self._dbg_acc.items(), key=lambda x: -x[1]))
+        + f"  total={total / self._dbg_n * 1000:.2f}ms")
+      self._dbg_acc = {}
+      self._dbg_n = 0
 
   def _draw_steering_wheel(self, rect: rl.Rectangle) -> None:
     wheel_txt = self._txt_wheel_critical if self._show_wheel_critical else self._txt_wheel

--- a/selfdrive/ui/mici/onroad/model_renderer.py
+++ b/selfdrive/ui/mici/onroad/model_renderer.py
@@ -242,8 +242,19 @@ class ModelRenderer(Widget):
     self._path.projected_points = self._map_line_to_polygon(
       self._path.raw_points, y_off, self._path_offset_z, max_idx, allow_invert=False
     )
+    self._dbg_um['path_mapping'] = self._dbg_um.get('path_mapping', 0) + (_t.monotonic() - _ts); _ts = _t.monotonic()
 
     self._update_experimental_gradient()
+    self._dbg_um['exp_gradient'] = self._dbg_um.get('exp_gradient', 0) + (_t.monotonic() - _ts)
+
+    self._dbg_um_n += 1
+    if self._dbg_um_n >= 40:  # ~2s @ 20Hz
+      total = sum(self._dbg_um.values())
+      print("[update_model avg over %df] " % self._dbg_um_n + "  ".join(
+        f"{k}={(v / self._dbg_um_n) * 1000:.2f}ms" for k, v in sorted(self._dbg_um.items(), key=lambda x: -x[1]))
+        + f"  total={total / self._dbg_um_n * 1000:.2f}ms")
+      self._dbg_um = {}
+      self._dbg_um_n = 0
 
   def _update_experimental_gradient(self):
     """Pre-calculate experimental mode gradient colors"""

--- a/selfdrive/ui/mici/onroad/model_renderer.py
+++ b/selfdrive/ui/mici/onroad/model_renderer.py
@@ -94,6 +94,12 @@ class ModelRenderer(Widget):
     self._transform_dirty = True
 
   def _render(self, rect: rl.Rectangle):
+    import time as _t
+    if not hasattr(self, '_dbg_acc'):
+      self._dbg_acc: dict[str, float] = {}
+      self._dbg_n = 0
+    _ts = _t.monotonic()
+
     sm = ui_state.sm
 
     self._torque_filter.update(-ui_state.sm['carOutput'].actuatorsOutput.torque)
@@ -121,29 +127,41 @@ class ModelRenderer(Widget):
     radar_state = sm['radarState'] if sm.valid['radarState'] else None
     lead_one = radar_state.leadOne if radar_state else None
     render_lead_indicator = self._longitudinal_control and radar_state is not None
+    self._dbg_acc['setup'] = self._dbg_acc.get('setup', 0) + (_t.monotonic() - _ts); _ts = _t.monotonic()
 
     # Update model data when needed
     model_updated = sm.updated['modelV2']
     if model_updated or sm.updated['radarState'] or self._transform_dirty:
       if model_updated:
         self._update_raw_points(model)
+      self._dbg_acc['raw_points'] = self._dbg_acc.get('raw_points', 0) + (_t.monotonic() - _ts); _ts = _t.monotonic()
 
       path_x_array = self._path.raw_points[:, 0]
       if path_x_array.size == 0:
         return
 
       self._update_model(lead_one, path_x_array)
+      self._dbg_acc['update_model'] = self._dbg_acc.get('update_model', 0) + (_t.monotonic() - _ts); _ts = _t.monotonic()
       if render_lead_indicator:
         self._update_leads(radar_state, path_x_array)
       self._transform_dirty = False
+      self._dbg_acc['leads'] = self._dbg_acc.get('leads', 0) + (_t.monotonic() - _ts); _ts = _t.monotonic()
 
     # Draw elements (hide when disengaged)
     if ui_state.status != UIStatus.DISENGAGED:
       self._draw_lane_lines()
+      self._dbg_acc['lanes'] = self._dbg_acc.get('lanes', 0) + (_t.monotonic() - _ts); _ts = _t.monotonic()
       self._draw_path(sm)
+      self._dbg_acc['path'] = self._dbg_acc.get('path', 0) + (_t.monotonic() - _ts); _ts = _t.monotonic()
 
-    # if render_lead_indicator and radar_state:
-    #   self._draw_lead_indicator()
+    self._dbg_n += 1
+    if self._dbg_n >= 120:
+      total = sum(self._dbg_acc.values())
+      print("[Model avg over 120f] " + "  ".join(
+        f"{k}={(v / self._dbg_n) * 1000:.2f}ms" for k, v in sorted(self._dbg_acc.items(), key=lambda x: -x[1]))
+        + f"  total={total / self._dbg_n * 1000:.2f}ms")
+      self._dbg_acc = {}
+      self._dbg_n = 0
 
   def _update_raw_points(self, model):
     """Update raw 3D points from model data"""
@@ -177,8 +195,16 @@ class ModelRenderer(Widget):
 
   def _update_model(self, lead, path_x_array):
     """Update model visualization data based on model message"""
-    max_distance = np.clip(path_x_array[-1], MIN_DRAW_DISTANCE, MAX_DRAW_DISTANCE)
+    import time as _t
+    if not hasattr(self, '_dbg_um'):
+      self._dbg_um: dict[str, float] = {}
+      self._dbg_um_n = 0
+    _ts = _t.monotonic()
+
+    _max = float(path_x_array[-1])
+    max_distance = MIN_DRAW_DISTANCE if _max < MIN_DRAW_DISTANCE else MAX_DRAW_DISTANCE if _max > MAX_DRAW_DISTANCE else _max
     max_idx = self._get_path_length_idx(self._lane_lines[0].raw_points[:, 0], max_distance)
+    self._dbg_um['head'] = self._dbg_um.get('head', 0) + (_t.monotonic() - _ts); _ts = _t.monotonic()
 
     # Update lane lines using raw points
     line_width_factor = 0.12
@@ -188,10 +214,12 @@ class ModelRenderer(Widget):
       lane_line.projected_points = self._map_line_to_polygon(
         lane_line.raw_points, line_width_factor * self._lane_line_probs[i], 0.0, max_idx
       )
+    self._dbg_um['lanes_mapping'] = self._dbg_um.get('lanes_mapping', 0) + (_t.monotonic() - _ts); _ts = _t.monotonic()
 
     # Update road edges using raw points
     for road_edge in self._road_edges:
       road_edge.projected_points = self._map_line_to_polygon(road_edge.raw_points, line_width_factor, 0.0, max_idx)
+    self._dbg_um['edges_mapping'] = self._dbg_um.get('edges_mapping', 0) + (_t.monotonic() - _ts); _ts = _t.monotonic()
 
     # Update path using raw points
     if lead and lead.status:

--- a/selfdrive/ui/mici/onroad/model_renderer.py
+++ b/selfdrive/ui/mici/onroad/model_renderer.py
@@ -196,7 +196,8 @@ class ModelRenderer(Widget):
     # Update path using raw points
     if lead and lead.status:
       lead_d = lead.dRel * 2.0
-      max_distance = np.clip(lead_d - min(lead_d * 0.35, 10.0), 0.0, max_distance)
+      _md = lead_d - min(lead_d * 0.35, 10.0)
+      max_distance = 0.0 if _md < 0.0 else max_distance if _md > max_distance else _md
 
     soon_acceleration = self._acceleration_x[len(self._acceleration_x) // 4] if len(self._acceleration_x) > 0 else 0
     self._acceleration_x_filter.update(soon_acceleration)
@@ -238,12 +239,20 @@ class ModelRenderer(Widget):
       # Calculate color based on acceleration (0 is bottom, 1 is top)
       lin_grad_point = 1 - (track_y - self._rect.y) / self._rect.height
 
-      # speed up: 120, slow down: 0
-      path_hue = np.clip(60 + self._acceleration_x[i] * 35, 0, 120)
+      # speed up: 120, slow down: 0 (scalar clip 0..120)
+      _hue = 60 + self._acceleration_x[i] * 35
+      path_hue = 0.0 if _hue < 0.0 else 120.0 if _hue > 120.0 else _hue
 
       saturation = min(abs(self._acceleration_x[i] * 1.5), 1)
-      lightness = np.interp(saturation, [0.0, 1.0], [0.95, 0.62])
-      alpha = np.interp(lin_grad_point, [0.75 / 2.0, 0.75], [0.4, 0.0])
+      # scalar interp: [0,1] -> [0.95, 0.62]
+      lightness = 0.95 + saturation * (0.62 - 0.95)
+      # scalar interp: [0.375, 0.75] -> [0.4, 0.0]; clamped at endpoints
+      if lin_grad_point <= 0.375:
+        alpha = 0.4
+      elif lin_grad_point >= 0.75:
+        alpha = 0.0
+      else:
+        alpha = 0.4 + (lin_grad_point - 0.375) * (0.0 - 0.4) / (0.75 - 0.375)
 
       # Use HSL to RGB conversion
       color = self._hsla_to_color(path_hue / 360.0, saturation, lightness, alpha)
@@ -269,9 +278,10 @@ class ModelRenderer(Widget):
         fill_alpha += 255 * (-1 * (v_rel / speed_buff))
       fill_alpha = min(fill_alpha, 255)
 
-    # Calculate size and position
-    sz = np.clip((25 * 30) / (d_rel / 3 + 30), 15.0, 30.0) * 1
-    x = np.clip(point[0], 0.0, rect.width - sz / 2)
+    # Calculate size and position (scalar clips)
+    _sz_raw = (25 * 30) / (d_rel / 3 + 30)
+    sz = 15.0 if _sz_raw < 15.0 else 30.0 if _sz_raw > 30.0 else _sz_raw
+    x = max(0.0, min(point[0], rect.width - sz / 2))
     y = min(point[1], rect.height - sz * 0.6)
 
     g_xo = sz / 5
@@ -283,25 +293,27 @@ class ModelRenderer(Widget):
     return LeadVehicle(glow=glow, chevron=chevron, fill_alpha=int(fill_alpha))
 
   def _get_ll_color(self, prob: float, adjacent: bool, left: bool):
-    alpha = np.clip(prob, 0.0, 0.7)
-    if adjacent:
-      _base_color = LANE_LINE_COLORS.get(ui_state.status, LANE_LINE_COLORS[UIStatus.DISENGAGED])
-      color = rl.Color(_base_color.r, _base_color.g, _base_color.b, int(alpha * 255))
-
-      # turn adjacent lls orange if torque is high
-      torque = self._torque_filter.x
-      high_torque = abs(torque) > 0.6
-      if high_torque and (left == (torque > 0)):
-        color = blend_colors(
-          color,
-          rl.Color(255, 115, 0, int(alpha * 255)),  # orange
-          np.interp(abs(torque), [0.6, 0.8], [0.0, 1.0])
-        )
-    else:
-      color = rl.Color(255, 255, 255, int(alpha * 255))
+    # scalar clip 0..0.7
+    alpha = 0.0 if prob < 0.0 else 0.7 if prob > 0.7 else prob
+    alpha_int = int(alpha * 255)
 
     if ui_state.status == UIStatus.DISENGAGED:
-      color = rl.Color(0, 0, 0, int(alpha * 255))
+      return rl.Color(0, 0, 0, alpha_int)
+
+    if not adjacent:
+      return rl.Color(255, 255, 255, alpha_int)
+
+    _base_color = LANE_LINE_COLORS.get(ui_state.status, LANE_LINE_COLORS[UIStatus.DISENGAGED])
+    color = rl.Color(_base_color.r, _base_color.g, _base_color.b, alpha_int)
+
+    # turn adjacent lls orange if torque is high
+    torque = self._torque_filter.x
+    abs_torque = abs(torque)
+    if abs_torque > 0.6 and (left == (torque > 0)):
+      # scalar lerp: interp from [0.6, 0.8] -> [0, 1]
+      f = (abs_torque - 0.6) * 5.0  # / 0.2
+      f = 0.0 if f < 0.0 else 1.0 if f > 1.0 else f
+      color = blend_colors(color, rl.Color(255, 115, 0, alpha_int), f)
 
     return color
 

--- a/selfdrive/ui/mici/onroad/torque_bar.py
+++ b/selfdrive/ui/mici/onroad/torque_bar.py
@@ -188,6 +188,12 @@ class TorqueBar(Widget):
       self._torque_filter.update(-ui_state.sm['carOutput'].actuatorsOutput.torque)
 
   def _render(self, rect: rl.Rectangle) -> None:
+    import time as _t
+    if not hasattr(self, '_dbg_acc'):
+      self._dbg_acc: dict[str, float] = {}
+      self._dbg_n = 0
+    _ts = _t.monotonic()
+
     # adjust y pos with torque (scalar interp [0.5, 1] -> [a, b])
     abs_t = abs(self._torque_filter.x)
     _f = (abs_t - 0.5) * 2.0  # / 0.5

--- a/selfdrive/ui/mici/onroad/torque_bar.py
+++ b/selfdrive/ui/mici/onroad/torque_bar.py
@@ -188,9 +188,12 @@ class TorqueBar(Widget):
       self._torque_filter.update(-ui_state.sm['carOutput'].actuatorsOutput.torque)
 
   def _render(self, rect: rl.Rectangle) -> None:
-    # adjust y pos with torque
-    torque_line_offset = np.interp(abs(self._torque_filter.x), [0.5, 1], [22, 26])
-    torque_line_height = np.interp(abs(self._torque_filter.x), [0.5, 1], [14, 56])
+    # adjust y pos with torque (scalar interp [0.5, 1] -> [a, b])
+    abs_t = abs(self._torque_filter.x)
+    _f = (abs_t - 0.5) * 2.0  # / 0.5
+    _f = 0.0 if _f < 0.0 else 1.0 if _f > 1.0 else _f
+    torque_line_offset = 22 + _f * (26 - 22)
+    torque_line_height = 14 + _f * (56 - 14)
 
     # animate alpha and angle span
     if not self._demo:
@@ -198,7 +201,7 @@ class TorqueBar(Widget):
     else:
       self._torque_line_alpha_filter.update(1.0)
 
-    torque_line_bg_alpha = np.interp(abs(self._torque_filter.x), [0.5, 1.0], [0.25, 0.5])
+    torque_line_bg_alpha = 0.25 + _f * (0.5 - 0.25)
     torque_line_bg_color = rl.Color(255, 255, 255, int(255 * torque_line_bg_alpha * self._torque_line_alpha_filter.x))
     if ui_state.status != UIStatus.ENGAGED and not self._demo:
       torque_line_bg_color = rl.Color(255, 255, 255, int(255 * 0.15 * self._torque_line_alpha_filter.x))
@@ -218,12 +221,15 @@ class TorqueBar(Widget):
 
     # draw bg torque indicator line
     bg_pts = arc_bar_pts(mid_r, torque_line_height, torque_start_angle, torque_end_angle) + offset
+    self._dbg_acc['bg_arc'] = self._dbg_acc.get('bg_arc', 0) + (_t.monotonic() - _ts); _ts = _t.monotonic()
     draw_polygon(rect, bg_pts, color=torque_line_bg_color)
+    self._dbg_acc['bg_draw'] = self._dbg_acc.get('bg_draw', 0) + (_t.monotonic() - _ts); _ts = _t.monotonic()
 
     # draw torque indicator line
     a0s = top_angle
     a1s = a0s + torque_bg_angle_span / 2 * self._torque_filter.x
     sl_pts = arc_bar_pts(mid_r, torque_line_height, a0s, a1s) + offset
+    self._dbg_acc['sl_arc'] = self._dbg_acc.get('sl_arc', 0) + (_t.monotonic() - _ts); _ts = _t.monotonic()
 
     # draw beautiful gradient from center to 65% of the bg torque bar width
     start_grad_pt = cx / rect.width
@@ -258,6 +264,16 @@ class TorqueBar(Widget):
     )
 
     draw_polygon(rect, sl_pts, gradient=gradient)
+    self._dbg_acc['sl_draw'] = self._dbg_acc.get('sl_draw', 0) + (_t.monotonic() - _ts)
+
+    self._dbg_n += 1
+    if self._dbg_n >= 120:
+      total = sum(self._dbg_acc.values())
+      print("[TorqueBar avg over 120f] " + "  ".join(
+        f"{k}={(v / self._dbg_n) * 1000:.2f}ms" for k, v in sorted(self._dbg_acc.items(), key=lambda x: -x[1]))
+        + f"  total={total / self._dbg_n * 1000:.2f}ms")
+      self._dbg_acc = {}
+      self._dbg_n = 0
 
     # draw center torque bar dot
     if abs(self._torque_filter.x) < 0.5:

--- a/selfdrive/ui/ui.py
+++ b/selfdrive/ui/ui.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import os
+import time
 
 from cereal import messaging
 from openpilot.system.hardware import TICI
@@ -14,7 +15,7 @@ BIG_UI = gui_app.big_ui()
 
 def main():
   cores = {5, }
-  config_realtime_process(0, 51)
+  config_realtime_process(list(cores), 99)
 
   gui_app.init_window("UI")
   if BIG_UI:
@@ -24,20 +25,26 @@ def main():
 
   pm = messaging.PubMaster(['uiDebug'])
   for should_render, frame_time, cpu_time in gui_app.render():
+    t_yield_start = time.monotonic()
     ui_state.update()
+    ui_state_update_time = time.monotonic() - t_yield_start
 
     if should_render:
-      msg = messaging.new_message('uiDebug')
-      msg.uiDebug.cpuTimeMillis = cpu_time * 1000
-      msg.uiDebug.frameTimeMillis = frame_time * 1000
-      pm.send('uiDebug', msg)
-
       # reaffine after power save offlines our core
+      t_reaffine_start = time.monotonic()
       if TICI and os.sched_getaffinity(0) != cores:
         try:
           set_core_affinity(list(cores))
         except OSError:
           pass
+      reaffine_time = time.monotonic() - t_reaffine_start
+
+      msg = messaging.new_message('uiDebug')
+      msg.uiDebug.cpuTimeMillis = (cpu_time + ui_state_update_time + reaffine_time) * 1000
+      msg.uiDebug.frameTimeMillis = frame_time * 1000
+      msg.uiDebug.uiStateUpdateMillis = ui_state_update_time * 1000
+      msg.uiDebug.reaffineMillis = reaffine_time * 1000
+      pm.send('uiDebug', msg)
 
 
 if __name__ == "__main__":

--- a/selfdrive/ui/ui_state.py
+++ b/selfdrive/ui/ui_state.py
@@ -89,6 +89,11 @@ class UIState:
     self._engaged_transition_callbacks: list[Callable[[], None]] = []
     self._on_body_changed_callbacks: list[Callable[[], None]] = []
 
+    # Background params thread (filesystem reads off the render thread)
+    self._params_thread_exit = threading.Event()
+    self._params_thread = threading.Thread(target=self._params_refresh_loop, daemon=True)
+    self._params_thread.start()
+
   def add_offroad_transition_callback(self, callback: Callable[[], None]):
     self._offroad_transition_callbacks.append(callback)
 
@@ -109,13 +114,34 @@ class UIState:
     return not self.started
 
   def update(self) -> None:
+    SECTION_SLOW_MS = 1.0
+    sections = []
+    t0 = time.monotonic()
+
     self.prime_state.start()  # start thread after manager forks ui
+    sections.append(('prime_start', time.monotonic() - t0)); t1 = time.monotonic()
+
     self.sm.update(0)
+    sections.append(('sm.update', time.monotonic() - t1)); t1 = time.monotonic()
+
     self._update_state()
+    sections.append(('_update_state', time.monotonic() - t1)); t1 = time.monotonic()
+
     self._update_status()
-    if time.monotonic() - self._param_update_time >= PARAM_UPDATE_TIME:
-      self.update_params()
+    sections.append(('_update_status', time.monotonic() - t1)); t1 = time.monotonic()
+
     device.update()
+    sections.append(('device.update', time.monotonic() - t1))
+
+    if any(t * 1000 > SECTION_SLOW_MS for _, t in sections):
+      total_ms = (time.monotonic() - t0) * 1000
+      print(f">> ui_state.update SLOW  total={total_ms:.2f}ms  " +
+            "  ".join(f"{n}={t*1000:.2f}ms" for n, t in sections))
+
+  def _params_refresh_loop(self):
+    while not self._params_thread_exit.is_set():
+      self.update_params()
+      self._params_thread_exit.wait(PARAM_UPDATE_TIME)
 
   def _update_state(self) -> None:
     # Handle panda states updates
@@ -140,12 +166,6 @@ class UIState:
 
     # Update started state
     self.started = self.sm["deviceState"].started and self.ignition
-
-    # Update recording audio state
-    self.recording_audio = self.params.get_bool("RecordAudio") and self.started
-
-    self.is_metric = self.params.get_bool("IsMetric")
-    self.always_on_dm = self.params.get_bool("AlwaysOnDM")
 
   def _update_status(self) -> None:
     if self.started and self.sm.updated["selfdriveState"]:
@@ -176,7 +196,11 @@ class UIState:
       self._started_prev = self.started
 
   def update_params(self) -> None:
-    # For slower operations
+    # For slower operations — these read from filesystem, don't run every frame
+    self.recording_audio = self.params.get_bool("RecordAudio") and self.started
+    self.is_metric = self.params.get_bool("IsMetric")
+    self.always_on_dm = self.params.get_bool("AlwaysOnDM")
+
     # Update longitudinal control state
     CP_bytes = self.params.get("CarParamsPersistent")
     if CP_bytes is not None:
@@ -206,7 +230,23 @@ class Device:
     self._offroad_brightness: int = BACKLIGHT_OFFROAD
     self._last_brightness: int = 0
     self._brightness_filter = FirstOrderFilter(BACKLIGHT_OFFROAD, 10.00, 1 / gui_app.target_fps)
-    self._brightness_thread: threading.Thread | None = None
+
+    # Persistent brightness writer thread — main only signals (cheap), thread does sysfs write
+    self._brightness_pending: int | None = None
+    self._brightness_event = threading.Event()
+    self._brightness_thread: threading.Thread | None = None  # lazy-started after fork
+
+  def _brightness_loop(self):
+    while True:
+      self._brightness_event.wait()
+      self._brightness_event.clear()
+      pending = self._brightness_pending
+      if pending is not None:
+        t0 = time.monotonic()
+        HARDWARE.set_screen_brightness(pending)
+        dt_ms = (time.monotonic() - t0) * 1000
+        if dt_ms > 0.5:
+          print(f"        >> set_screen_brightness({pending}) took {dt_ms:.2f}ms")
 
   @property
   def awake(self) -> bool:
@@ -223,7 +263,7 @@ class Device:
       return self._override_interactive_timeout
 
     ignition_timeout = 10 if gui_app.big_ui() else 5
-    return ignition_timeout if ui_state.ignition else 30
+    return ignition_timeout if ui_state.ignition else 999999
 
   def _reset_interactive_timeout(self) -> None:
     self._interaction_time = time.monotonic() + self.interactive_timeout
@@ -232,12 +272,25 @@ class Device:
     self._interactive_timeout_callbacks.append(callback)
 
   def update(self):
+    SECTION_SLOW_MS = 1.0
+    sections = []
+    t0 = time.monotonic()
+
     # do initial reset
     if self._interaction_time <= 0:
       self._reset_interactive_timeout()
+    sections.append(('init_reset', time.monotonic() - t0)); t1 = time.monotonic()
 
     self._update_brightness()
+    sections.append(('_update_brightness', time.monotonic() - t1)); t1 = time.monotonic()
+
     self._update_wakefulness()
+    sections.append(('_update_wakefulness', time.monotonic() - t1))
+
+    if any(t * 1000 > SECTION_SLOW_MS for _, t in sections):
+      total_ms = (time.monotonic() - t0) * 1000
+      print(f"        >> device.update SLOW  total={total_ms:.2f}ms  " +
+            "  ".join(f"{n}={t*1000:.2f}ms" for n, t in sections))
 
   def set_offroad_brightness(self, brightness: int | None):
     if brightness is None:
@@ -263,26 +316,46 @@ class Device:
       brightness = 0
 
     if brightness != self._last_brightness:
+      # Lazy-start thread (after manager fork)
       if self._brightness_thread is None or not self._brightness_thread.is_alive():
-        self._brightness_thread = threading.Thread(target=HARDWARE.set_screen_brightness, args=(brightness,))
+        self._brightness_thread = threading.Thread(target=self._brightness_loop, daemon=True)
         self._brightness_thread.start()
-        self._last_brightness = brightness
+      self._brightness_pending = brightness
+      self._brightness_event.set()
+      self._last_brightness = brightness
 
   def _update_wakefulness(self):
+    SUB_SLOW_MS = 1.0
+    sub = []
+    s0 = time.monotonic()
+
     # Handle interactive timeout
     ignition_just_turned_off = not ui_state.ignition and self._ignition
     self._ignition = ui_state.ignition
+    sub.append(('ignition_check', time.monotonic() - s0)); s1 = time.monotonic()
 
     if ignition_just_turned_off or any(ev.left_down for ev in gui_app.mouse_events):
       self._reset_interactive_timeout()
+    sub.append(('mouse_check', time.monotonic() - s1)); s1 = time.monotonic()
 
     interaction_timeout = time.monotonic() > self._interaction_time
     if interaction_timeout and not self._prev_timed_out:
       for callback in self._interactive_timeout_callbacks:
+        cb_t0 = time.monotonic()
         callback()
+        cb_dt = (time.monotonic() - cb_t0) * 1000
+        if cb_dt > 0.5:
+          name = getattr(callback, '__qualname__', getattr(callback, '__name__', repr(callback)))
+          print(f"                        >> timeout_cb SLOW  {name}={cb_dt:.2f}ms")
     self._prev_timed_out = interaction_timeout
+    sub.append(('timeout_callbacks', time.monotonic() - s1)); s1 = time.monotonic()
 
     self._set_awake(ui_state.ignition or not interaction_timeout or PC)
+    sub.append(('_set_awake', time.monotonic() - s1))
+
+    if any(t * 1000 > SUB_SLOW_MS for _, t in sub):
+      print(f"                >> _update_wakefulness SLOW  " +
+            "  ".join(f"{n}={t*1000:.2f}ms" for n, t in sub))
 
   def _set_awake(self, on: bool):
     if on != self._awake:

--- a/selfdrive/ui/ui_state.py
+++ b/selfdrive/ui/ui_state.py
@@ -123,7 +123,7 @@ class UIState:
     self.prime_state.start()  # start thread after manager forks ui
     sections.append(('prime_start', time.monotonic() - t0)); t1 = time.monotonic()
 
-    self.sm.update(0)
+    # self.sm.update(0)
     sections.append(('sm.update', time.monotonic() - t1)); t1 = time.monotonic()
 
     self._update_state()
@@ -141,6 +141,11 @@ class UIState:
             "  ".join(f"{n}={t*1000:.2f}ms" for n, t in sections))
 
   def _params_refresh_loop(self):
+    # TEMP: testing RT99 to see if priority affects spike behavior
+    try:
+      os.sched_setscheduler(0, os.SCHED_FIFO, os.sched_param(99))
+    except OSError:
+      pass
     while not self._params_thread_exit.is_set():
       self.update_params()
       self._params_thread_exit.wait(PARAM_UPDATE_TIME)
@@ -240,9 +245,8 @@ class Device:
     self._brightness_thread: threading.Thread | None = None  # lazy-started after fork
 
   def _brightness_loop(self):
-    # Drop inherited RT99/cpu5 from main thread — this is background I/O.
+    # Drop inherited RT99 from main thread — background work, never preempt render.
     try:
-      os.sched_setaffinity(0, range(os.cpu_count() or 8))
       os.sched_setscheduler(0, os.SCHED_OTHER, os.sched_param(0))
     except OSError:
       pass

--- a/selfdrive/ui/ui_state.py
+++ b/selfdrive/ui/ui_state.py
@@ -74,6 +74,7 @@ class UIState:
     self.is_metric: bool = self.params.get_bool("IsMetric")
     self.is_release = self.params.get_bool("IsReleaseBranch")
     self.always_on_dm: bool = self.params.get_bool("AlwaysOnDM")
+    self.experimental_mode: bool = self.params.get_bool("ExperimentalMode")
     self.started: bool = False
     self.ignition: bool = False
     self.recording_audio: bool = False
@@ -201,6 +202,7 @@ class UIState:
     self.recording_audio = self.params.get_bool("RecordAudio") and self.started
     self.is_metric = self.params.get_bool("IsMetric")
     self.always_on_dm = self.params.get_bool("AlwaysOnDM")
+    self.experimental_mode = self.params.get_bool("ExperimentalMode")
 
     # Update longitudinal control state
     CP_bytes = self.params.get("CarParamsPersistent")

--- a/selfdrive/ui/ui_state.py
+++ b/selfdrive/ui/ui_state.py
@@ -1,3 +1,4 @@
+import os
 import pyray as rl
 import numpy as np
 import time
@@ -237,6 +238,12 @@ class Device:
     self._brightness_thread: threading.Thread | None = None  # lazy-started after fork
 
   def _brightness_loop(self):
+    # Drop inherited RT99/cpu5 from main thread — this is background I/O.
+    try:
+      os.sched_setaffinity(0, range(os.cpu_count() or 8))
+      os.sched_setscheduler(0, os.SCHED_OTHER, os.sched_param(0))
+    except OSError:
+      pass
     while True:
       self._brightness_event.wait()
       self._brightness_event.clear()

--- a/system/ui/lib/application.py
+++ b/system/ui/lib/application.py
@@ -317,7 +317,7 @@ class GuiApplication:
         self._ffmpeg_thread.start()
 
       # OFFSCREEN disables FPS limiting for fast offline rendering (e.g. clips)
-      rl.set_target_fps(0 if OFFSCREEN else fps)
+      rl.set_target_fps(0)  # disabled: drmWaitVBlank handles pacing
 
       self._target_fps = fps
       self._set_styles()
@@ -611,13 +611,13 @@ class GuiApplication:
           rl.begin_drawing()
           rl.clear_background(rl.BLACK)
 
-        if self._scale != 1.0:
-          rl.rl_push_matrix()
-          rl.rl_scalef(self._scale, self._scale, 1.0)
+        # if self._scale != 1.0:
+        #   rl.rl_push_matrix()
+        #   rl.rl_scalef(self._scale, self._scale, 1.0)
 
         # Allow a Widget to still run a function regardless of the stack depth
-        for tick in self._nav_stack_ticks:
-          tick()
+        # for tick in self._nav_stack_ticks:
+        #   tick()
 
         # Only render top widgets
         for widget in self._nav_stack[-self._nav_stack_widgets_to_render:]:

--- a/system/ui/lib/application.py
+++ b/system/ui/lib/application.py
@@ -137,19 +137,21 @@ class MouseEvent(NamedTuple):
 class MouseState:
   def __init__(self, scale: float = 1.0):
     self._scale = scale
-    self._events: deque[MouseEvent] = deque(maxlen=MOUSE_THREAD_RATE)  # bound event list
+    # SPSC: mouse thread appends, main thread popleft-drains. deque ops are atomic; no lock needed.
+    self._events: deque[MouseEvent] = deque(maxlen=MOUSE_THREAD_RATE)
     self._prev_mouse_event: list[MouseEvent | None] = [None] * MAX_TOUCH_SLOTS
 
     self._rk = Ratekeeper(MOUSE_THREAD_RATE, print_delay_threshold=None)
-    self._lock = threading.Lock()
     self._exit_event = threading.Event()
     self._thread = None
 
   def get_events(self) -> list[MouseEvent]:
-    with self._lock:
-      events = list(self._events)
-      self._events.clear()
-    return events
+    events: list[MouseEvent] = []
+    while True:
+      try:
+        events.append(self._events.popleft())
+      except IndexError:
+        return events
 
   def start(self):
     self._exit_event.clear()
@@ -163,6 +165,15 @@ class MouseState:
       self._thread.join()
 
   def _run_thread(self):
+    # Drop one priority below main render thread so mouse never round-robins with it.
+    # Mouse still polls at MOUSE_THREAD_RATE since it runs in main's vsync-wait gaps.
+    # TODO: this priority drop slightly worsens the timestamp jitter described in
+    #  _handle_mouse_event's TODO. Reading evdev kernel timestamps directly fixes both
+    #  (event-driven instead of polled, real arrival times instead of monotonic at poll).
+    try:
+      os.sched_setscheduler(0, os.SCHED_FIFO, os.sched_param(98))
+    except OSError:
+      pass
     while not self._exit_event.is_set():
       rl.poll_input_events()
       self._handle_mouse_event()
@@ -188,8 +199,7 @@ class MouseState:
       # Only add changes
       prev = self._prev_mouse_event[slot]
       if prev is None or ev[:-1] != prev[:-1]:
-        with self._lock:
-          self._events.append(ev)
+        self._events.append(ev)
         self._prev_mouse_event[slot] = ev
 
 

--- a/system/ui/lib/shader_polygon.py
+++ b/system/ui/lib/shader_polygon.py
@@ -187,20 +187,19 @@ def _configure_shader_color(state: ShaderState, color: Optional[rl.Color],
 
 
 def triangulate(pts: np.ndarray) -> list[tuple[float, float]]:
-  """Only supports simple polygons with two chains (ribbon)."""
-
-  # TODO: consider deduping close screenspace points
-  # interleave points to produce a triangle strip
-  # assert len(pts) % 2 == 0, "Interleaving expects even number of points"
+  """Only supports simple polygons with two chains (ribbon).
+  Interleaves left chain (front half) with reversed right chain (back half):
+  [L0, R0, L1, R1, ...] where Ri = pts[-i-1].
+  """
   if len(pts) % 2 != 0:
     pts = pts[:-1]
-
-  tri_strip = []
-  for i in range(len(pts) // 2):
-    tri_strip.append(pts[i])
-    tri_strip.append(pts[-i - 1])
-
-  return cast(list, np.array(tri_strip).tolist())
+  n = len(pts) // 2
+  if n == 0:
+    return []
+  out = np.empty((2 * n, 2), dtype=np.float32)
+  out[0::2] = pts[:n]
+  out[1::2] = pts[2 * n - 1:n - 1:-1]
+  return cast(list, out.tolist())
 
 
 def draw_polygon(origin_rect: rl.Rectangle, points: np.ndarray,

--- a/system/ui/lib/shader_polygon.py
+++ b/system/ui/lib/shader_polygon.py
@@ -206,27 +206,26 @@ def draw_polygon(origin_rect: rl.Rectangle, points: np.ndarray,
                  color: Optional[rl.Color] = None, gradient: Gradient | None = None):
 
   """
-  Draw a ribbon polygon (two chains) with a triangle strip and gradient.
+  Draw a ribbon polygon (two chains) with a triangle strip.
   - Input must be [L0..Lk-1, Rk-1..R0], even count, no crossings/holes.
+  Solid-color polygons use raylib's default shader (fast, no begin/end_shader_mode).
+  Gradient polygons use the custom shader.
   """
   if len(points) < 3:
     return
 
-  # Initialize shader on-demand
-  state = ShaderState.get_instance()
-  state.initialize()
-
-  # Ensure (N,2) float32 contiguous array
   pts = np.ascontiguousarray(points, dtype=np.float32)
-  assert pts.ndim == 2 and pts.shape[1] == 2, "points must be (N,2)"
-
-  # Configure gradient shader
-  _configure_shader_color(state, color, gradient, origin_rect)
-
-  # Triangulate via interleaving
   tri_strip = triangulate(pts)
 
-  # Draw strip, color here doesn't matter
+  if gradient is None:
+    # Fast path: default raylib shader with tint
+    rl.draw_triangle_strip(tri_strip, len(tri_strip), color or rl.WHITE)
+    return
+
+  # Slow path: custom shader for gradients
+  state = ShaderState.get_instance()
+  state.initialize()
+  _configure_shader_color(state, color, gradient, origin_rect)
   rl.begin_shader_mode(state.shader)
   rl.draw_triangle_strip(tri_strip, len(tri_strip), rl.WHITE)
   rl.end_shader_mode()

--- a/system/ui/lib/shader_polygon.py
+++ b/system/ui/lib/shader_polygon.py
@@ -210,6 +210,17 @@ def draw_polygon(origin_rect: rl.Rectangle, points: np.ndarray,
   - Input must be [L0..Lk-1, Rk-1..R0], even count, no crossings/holes.
   Solid-color polygons use raylib's default shader (fast, no begin/end_shader_mode).
   Gradient polygons use the custom shader.
+
+  TODO: gradient path is ~4-5x slower than solid (~0.5ms vs ~0.1ms per polygon)
+  due to begin/end_shader_mode + uniform setup + flush. Options to speed up:
+    1. Render-to-texture cache: hash on state, render once, blit thereafter.
+       Works well when gradient params change slowly (torque bar, path).
+    2. Per-vertex color: build a vertex buffer with interpolated colors,
+       use raylib default shader (which already supports vertex color).
+       Eliminates custom shader entirely for linear gradients. Medium refactor.
+    3. Split into multiple solid-color polygons along gradient stops.
+       Visually less smooth but uses fast path.
+  Each call burns ~95us in begin/end_shader_mode batch flushes.
   """
   if len(points) < 3:
     return

--- a/system/ui/lib/wifi_manager.py
+++ b/system/ui/lib/wifi_manager.py
@@ -208,8 +208,8 @@ class WifiManager:
       self._wait_for_wifi_device()
 
       # TODO: wait for state thread to start before adding tethering connection, tiny race currently
-      self._scan_thread.start()
-      self._state_thread.start()
+      # self._scan_thread.start()
+      # self._state_thread.start()
 
       self._init_connections()
       if Params is not None and self._tethering_ssid not in self._connections:

--- a/system/ui/widgets/scroller.py
+++ b/system/ui/widgets/scroller.py
@@ -264,6 +264,8 @@ class _Scroller(Widget):
     return target_x, target_y
 
   def _layout(self):
+    # TODO: skip when scroll/items/rect unchanged from last frame (dirty flag).
+    # Layout reruns each frame even when steady — costs ~300us for 4 items.
     self._visible_items = [item for item in self._items if item.is_visible]
 
     self._content_size = sum(item.rect.width if self._horizontal else item.rect.height for item in self._visible_items)


### PR DESCRIPTION
One frame drop in 15m, still working on it. Most on this PR is debugging, not final, to be split out.

- No display/vsync drift from letting raylib sleep which mismatched display refresh ever so slightly, which caused drops multiple times per second to every few seconds.
- Higher prio than plannerd.
- On interaction timeout, onboarding widget could cause up to 20ms from writing param blocking.
- Brightness updates took 2ms creating threads. Now no jumps.
- Occasional param reading in main thread caused few ms jump as well, in thread no jump (not holding GIL, but also not on core 5).
- No clue why timings shift over time still, look at modeld
- I had to disable tmux status updating every 15s for test, caused +1ms spikes: `tmux set -g status-interval 0`

This PR:
<img width="1615" height="1200" alt="image" src="https://github.com/user-attachments/assets/51e52ce3-2131-480f-95cd-caf8ae660b13" />

Master:
<img width="1616" height="1199" alt="image" src="https://github.com/user-attachments/assets/e4ac5448-4c25-4a50-8ff0-70088e219d6b" />