### PR TITLE
ui: nonblocking Params writes

### DIFF
--- a/selfdrive/ui/layouts/settings/common.py
+++ b/selfdrive/ui/layouts/settings/common.py
@@ -2,4 +2,4 @@ from openpilot.selfdrive.ui.ui_state import ui_state
 
 
 def restart_needed_callback(_=None):
-  ui_state.params.put_bool("OnroadCycleRequested", True)
+  ui_state.params.put_bool_nonblocking("OnroadCycleRequested", True)

--- a/selfdrive/ui/mici/layouts/onboarding.py
+++ b/selfdrive/ui/mici/layouts/onboarding.py
@@ -109,7 +109,7 @@ class TrainingGuideDMTutorial(NavWidget):
 
     # Disable driver monitoring model when device times out for inactivity
     def inactivity_callback():
-      ui_state.params.put_bool("IsDriverViewEnabled", False)
+      ui_state.params.put_bool_nonblocking("IsDriverViewEnabled", False)
 
     device.add_interactive_timeout_callback(inactivity_callback)
 

--- a/selfdrive/ui/mici/onroad/driver_camera_dialog.py
+++ b/selfdrive/ui/mici/onroad/driver_camera_dialog.py
@@ -41,7 +41,7 @@ class BaseDriverCameraDialog(Widget):
 
   def show_event(self):
     super().show_event()
-    ui_state.params.put_bool("IsDriverViewEnabled", True)
+    ui_state.params.put_bool_nonblocking("IsDriverViewEnabled", True)
     self._publish_alert_sound(None)
     device.set_override_interactive_timeout(300)
     ui_state.params.remove("DriverTooDistracted")
@@ -49,7 +49,7 @@ class BaseDriverCameraDialog(Widget):
 
   def hide_event(self):
     super().hide_event()
-    ui_state.params.put_bool("IsDriverViewEnabled", False)
+    ui_state.params.put_bool_nonblocking("IsDriverViewEnabled", False)
     device.set_override_interactive_timeout(None)
 
   def _handle_mouse_release(self, _):

--- a/selfdrive/ui/onroad/exp_button.py
+++ b/selfdrive/ui/onroad/exp_button.py
@@ -36,7 +36,7 @@ class ExpButton(Widget):
     super()._handle_mouse_release(_)
     if self._is_toggle_allowed():
       new_mode = not self._experimental_mode
-      self._params.put_bool("ExperimentalMode", new_mode)
+      self._params.put_bool_nonblocking("ExperimentalMode", new_mode)
 
       # Hold new state temporarily
       self._held_mode = new_mode


### PR DESCRIPTION
Some main-thread `params.put*` calls that block on disk fsync, causing visible UI frame spikes when triggered (10-20ms).

There's more when flipping a toggle but we currently rely on the file being up to date to update the toggles, will fixup at some point