### PR TITLE
ui: bump priority above plannerd and radard

### DIFF
--- a/selfdrive/ui/ui.py
+++ b/selfdrive/ui/ui.py
@@ -15,7 +15,8 @@ BIG_UI = gui_app.big_ui()
 
 def main():
   cores = {5, }
-  config_realtime_process(0, 51)
+  # above plannerd and radard
+  config_realtime_process(0, 53)
 
   gui_app.init_window("UI")
   if BIG_UI:

--- a/selfdrive/ui/ui.py
+++ b/selfdrive/ui/ui.py
@@ -4,7 +4,7 @@ import time
 
 from cereal import messaging
 from openpilot.system.hardware import TICI
-from openpilot.common.realtime import config_realtime_process, set_core_affinity
+from openpilot.common.realtime import Priority, config_realtime_process, set_core_affinity
 from openpilot.system.ui.lib.application import gui_app
 from openpilot.selfdrive.ui.layouts.main import MainLayout
 from openpilot.selfdrive.ui.mici.layouts.main import MiciMainLayout
@@ -16,7 +16,7 @@ BIG_UI = gui_app.big_ui()
 def main():
   cores = {5, }
   # above plannerd and radard
-  config_realtime_process(0, 53)
+  config_realtime_process(0, Priority.CTRL_HIGH)
 
   gui_app.init_window("UI")
   if BIG_UI:


### PR DESCRIPTION
From https://github.com/commaai/openpilot/pull/37980

plannerd and radard timings becoming less consistent when bumped below ui makes sense, but no clue why they recover. Then modeld becomes noisy and then drops to a new floor?! This may be the random noise I've been trying to unsuccessfully figure out for the past few days. Regardless, this is a huge improvement for ui frame drops

@adeebshihadeh if you have time and want to see if it can be made consistent, just run openpilot with CAN replay onroad, make sure you patch ui_state.py so it thinks it's engaged.

<img width="1614" height="1199" alt="image" src="https://github.com/user-attachments/assets/30a6297e-9c9f-4f03-aaee-a09cad6c123e" />

---

Weird, I swapped ui back to 51 and plannerd and radard got noisy, so doesn't look like ui above them inherently destroys timings:

<img width="1616" height="1199" alt="image" src="https://github.com/user-attachments/assets/16d33825-b2dc-4afc-a07b-27bce6c75f2c" />
