### PR TITLE
modem.py: normalize padded ICCIDs

### DIFF
--- a/system/hardware/tici/modem.py
+++ b/system/hardware/tici/modem.py
@@ -308,7 +308,7 @@ class Modem:
     if not (imei.isdigit() and 14 <= len(imei) <= 17):  # 3GPP TS 23.003
       imei = ""
 
-    iccid = self._atv("AT+QCCID", "+QCCID:") or ""
+    iccid = (self._atv("AT+QCCID", "+QCCID:") or "").rstrip("F")
     if not iccid.isdigit():
       iccid = ""
 
@@ -387,7 +387,7 @@ class Modem:
   def _check_iccid(self, state):
     if state in (State.INITIALIZING, State.DISCONNECTING) or not self.S["iccid"]:
       return
-    iccid = self._atv("AT+QCCID", "+QCCID:")
+    iccid = (self._atv("AT+QCCID", "+QCCID:") or "").rstrip("F")
     if iccid and iccid != self.S["iccid"]:
       logging.warning(f"iccid changed: {self.S['iccid']} -> {iccid}")
       self._sim_change = True


### PR DESCRIPTION
Some eSIM profiles have ICCIDs shorter than the 20-nibble EF_ICCID storage field. Quectel AT+QCCID can expose trailing F padding nibble(s), for example a 19-digit ICCID returned as 19 digits plus F. The previous code passed that raw response to isdigit(), so the valid ICCID was rejected and reported as empty:

```
20:33:09.395 WARNING modem: iccid changed: 89852351123040005012 -> 8944476500008878576F
20:33:12.524 WARNING modem: identity read incomplete: {'imei': '865326061591809', 'iccid': '', 'mcc_mnc': '204083', 'modem_version': 'EG25GGBR07A08M2G'}, retrying
```

This normalizes the modem response by stripping trailing uppercase F padding before validating/storing the ICCID and before checking for SIM changes:

```
07:32:54.709 INFO    modem: imei=865326061591809 iccid=8944476500008878576 mcc_mnc=204083 ver=EG25GGBR07A08M2G
```

_"The number (ICCID) is typically a string of **18 to 22 digits**"_ per Saily article below.

References:
- https://onomondo.com/blog/iccid-number-explained/
- https://support.saily.com/hc/en-us/articles/24617942070556-What-us-ICCID-number-and-why-is-it-important