### PR TITLE
agnos: lazy-import casync so standalone CLI works without pycryptodome

### DIFF
--- a/system/hardware/tici/agnos.py
+++ b/system/hardware/tici/agnos.py
@@ -10,8 +10,6 @@ from collections.abc import Generator
 
 import requests
 
-import openpilot.system.updated.casync.casync as casync
-
 SPARSE_CHUNK_FMT = struct.Struct('H2xI4x')
 CAIBX_URL = "https://commadist.azureedge.net/agnosupdate/"
 
@@ -188,6 +186,8 @@ def extract_compressed_image(target_slot_number: int, partition: dict, cloudlog)
 
 
 def extract_casync_image(target_slot_number: int, partition: dict, cloudlog):
+  import openpilot.system.updated.casync.casync as casync
+
   path = get_partition_path(target_slot_number, partition)
   seed_path = path[:-1] + ('b' if path[-1] == 'a' else 'a')
 


### PR DESCRIPTION
## Summary

- Move the top-level `import openpilot.system.updated.casync.casync` into `extract_casync_image()`, the only function that uses it
- This allows `agnos.py --swap` and `agnos.py --verify` to run headlessly over SSH without the full openpilot virtualenv

## Problem

`agnos.py` has a standalone CLI mode (`--swap`, `--verify`, no-flag) that was added in #25130 specifically to support flashing AGNOS without casync. However, the `casync` module is imported unconditionally at the top level, and it transitively requires `pycryptodome` (`from Crypto.Hash import SHA512`). Outside of openpilot's venv, this import fails immediately:

```
ModuleNotFoundError: No module named 'Crypto'
```

This makes it impossible to run headless AGNOS updates via SSH — the primary recovery path when the updater UI is unusable (e.g. display rotation issues on the comma 4 screen).

## Fix

The `casync` module is only referenced inside `extract_casync_image()`, which is only called when `standalone=False` AND the manifest contains `casync_caibx` fields. Moving the import into that function makes it lazy — it's only loaded when actually needed, and the standalone CLI path works with just stdlib + `requests`.

## Test plan

- [x] Verified on a comma 4 (AGNOS 12.8.16 → 17.2) — `python3 agnos.py agnos.json --swap` completed successfully over SSH with this patch
- [ ] Non-standalone path (casync enabled, called from updater) is unchanged — the import still happens before any casync code runs
- [ ] `--verify` mode works without pycryptodome (no casync references in that path)