### PR TITLE
modeld: pkl tensor inputs

### DIFF
--- a/selfdrive/modeld/compile_modeld.py
+++ b/selfdrive/modeld/compile_modeld.py
@@ -259,6 +259,8 @@ if __name__ == "__main__":
                            vision_runner, policy_runner, out['metadata']['vision'], out['metadata']['policy'])
       for name, prepare_only in [('warp_enqueue', True), ('run_policy', False)]
     }
+    # zero frame for JIT warmup so runtime doesn't need a memset kernel
+    out[(cam_w,cam_h)]['dummy_frame'] = Tensor.zeros(nv12.size, dtype='uint8').contiguous().realize()
 
   with open(args.output, "wb") as f:
     pickle.dump(out, f)

--- a/selfdrive/modeld/compile_modeld.py
+++ b/selfdrive/modeld/compile_modeld.py
@@ -259,8 +259,6 @@ if __name__ == "__main__":
                            vision_runner, policy_runner, out['metadata']['vision'], out['metadata']['policy'])
       for name, prepare_only in [('warp_enqueue', True), ('run_policy', False)]
     }
-    # zero frame for JIT warmup so runtime doesn't need a memset kernel
-    out[(cam_w,cam_h)]['dummy_frame'] = Tensor.zeros(nv12.size, dtype='uint8').contiguous().realize()
 
   with open(args.output, "wb") as f:
     pickle.dump(out, f)

--- a/selfdrive/modeld/compile_modeld.py
+++ b/selfdrive/modeld/compile_modeld.py
@@ -87,29 +87,31 @@ def make_frame_prepare(nv12: NV12Frame, model_w, model_h):
   return frame_prepare_tinygrad
 
 
-def make_input_queues(vision_input_shapes, policy_input_shapes, frame_skip, device):
+def make_tensor_inputs(vision_input_shapes, policy_input_shapes, frame_skip):
   img = vision_input_shapes['img']  # (1, 12, 128, 256)
   n_frames = img[1] // 6
   img_buf_shape = (frame_skip * (n_frames - 1) + 1, 6, img[2], img[3])
-
   fb = policy_input_shapes['features_buffer']  # (1, 25, 512)
   dp = policy_input_shapes['desire_pulse']  # (1, 25, 8)
-  tc = policy_input_shapes['traffic_convention']  # (1, 2)
+  return {
+    'img_q': Tensor.zeros(img_buf_shape, dtype='uint8').contiguous().realize(),
+    'big_img_q': Tensor.zeros(img_buf_shape, dtype='uint8').contiguous().realize(),
+    'feat_q': Tensor.zeros(frame_skip * (fb[1] - 1) + 1, fb[0], fb[2]).contiguous().realize(),
+    'desire_q': Tensor.zeros(frame_skip * dp[1], dp[0], dp[2]).contiguous().realize(),
+  }
 
+
+def make_npy_inputs(policy_input_shapes):
+  dp = policy_input_shapes['desire_pulse']  # (1, 25, 8)
+  tc = policy_input_shapes['traffic_convention']  # (1, 2)
   npy = {
     'desire': np.zeros(dp[2], dtype=np.float32),
     'traffic_convention': np.zeros(tc, dtype=np.float32),
     'tfm': np.zeros((3, 3), dtype=np.float32),
     'big_tfm': np.zeros((3, 3), dtype=np.float32),
   }
-  input_queues = {
-    'img_q': Tensor.zeros(img_buf_shape, dtype='uint8', device=device).contiguous().realize(),
-    'big_img_q': Tensor.zeros(img_buf_shape, dtype='uint8', device=device).contiguous().realize(),
-    'feat_q': Tensor.zeros(frame_skip * (fb[1] - 1) + 1, fb[0], fb[2], device=device).contiguous().realize(),
-    'desire_q': Tensor.zeros(frame_skip * dp[1], dp[0], dp[2], device=device).contiguous().realize(),
-    **{k: Tensor(v, device='NPY').realize() for k, v in npy.items()},
-  }
-  return input_queues, npy
+  npy_tensors = {k: Tensor(v, device='NPY').realize() for k, v in npy.items()}
+  return npy, npy_tensors
 
 
 def shift_and_sample(buf, new_val, sample_fn):
@@ -172,7 +174,9 @@ def compile_modeld(nv12: NV12Frame, model_w, model_h, prepare_only, frame_skip,
   SEED = 42
 
   def random_inputs_run_fn(fn, seed, test_val=None, test_buffers=None, expect_match=True):
-    input_queues, npy = make_input_queues(vision_input_shapes, policy_input_shapes, frame_skip, Device.DEFAULT)
+    tensor_inputs = make_tensor_inputs(vision_input_shapes, policy_input_shapes, frame_skip)
+    npy, npy_tensors = make_npy_inputs(policy_input_shapes)
+    input_queues = {**tensor_inputs, **npy_tensors}
     np.random.seed(seed)
     Tensor.manual_seed(seed)
 
@@ -239,6 +243,13 @@ if __name__ == "__main__":
   policy_runner = OnnxRunner(args.policy_onnx)
   out['metadata']['vision'] = make_metadata_dict(args.vision_onnx)
   out['metadata']['policy'] = make_metadata_dict(args.policy_onnx)
+
+  # pre-allocate device tensor inputs so runtime doesn't need a compiler to zero-init them
+  out['tensor_inputs'] = make_tensor_inputs(
+    out['metadata']['vision']['input_shapes'],
+    out['metadata']['policy']['input_shapes'],
+    args.frame_skip,
+  )
 
   for cam_w, cam_h in args.camera_resolutions:
     nv12 = NV12Frame(cam_w, cam_h, *get_nv12_info(cam_w, cam_h))

--- a/selfdrive/modeld/modeld.py
+++ b/selfdrive/modeld/modeld.py
@@ -94,9 +94,9 @@ class ModelState:
     self.frame_buf_params = {k: get_nv12_info(cam_w, cam_h) for k in ('img', 'big_img')}
     self.run_policy = jits[(cam_w,cam_h)]['run_policy']
     self.warp_enqueue = jits[(cam_w,cam_h)]['warp_enqueue']
-    # warmup JIT with a zero frame copied from host (no device memset kernel)
-    dummy_frame = Tensor(np.zeros(self.frame_buf_params['img'][3], dtype=np.uint8), device='NPY').to(self.DEV).realize()
-    self.warp_enqueue(**self.input_queues, frame=dummy_frame, big_frame=dummy_frame)
+    # warmup JIT with zero frames copied from host (no device memset kernel)
+    def _zero_frame(key): return Tensor(np.zeros(self.frame_buf_params[key][3], dtype=np.uint8), device='NPY').to(self.DEV).realize()
+    self.warp_enqueue(**self.input_queues, frame=_zero_frame('img'), big_frame=_zero_frame('big_img'))
 
   def slice_outputs(self, model_outputs: np.ndarray, output_slices: dict[str, slice]) -> dict[str, np.ndarray]:
     parsed_model_outputs = {k: model_outputs[np.newaxis, v] for k,v in output_slices.items()}

--- a/selfdrive/modeld/modeld.py
+++ b/selfdrive/modeld/modeld.py
@@ -94,10 +94,8 @@ class ModelState:
     self.frame_buf_params = {k: get_nv12_info(cam_w, cam_h) for k in ('img', 'big_img')}
     self.run_policy = jits[(cam_w,cam_h)]['run_policy']
     self.warp_enqueue = jits[(cam_w,cam_h)]['warp_enqueue']
-    self.warp_enqueue(
-      **self.input_queues,
-      frame=Tensor.zeros(self.frame_buf_params['img'][3], dtype='uint8', device=self.DEV).contiguous().realize(),
-      big_frame=Tensor.zeros(self.frame_buf_params['big_img'][3], dtype='uint8', device=self.DEV).contiguous().realize())
+    dummy_frame = jits[(cam_w,cam_h)]['dummy_frame']
+    self.warp_enqueue(**self.input_queues, frame=dummy_frame, big_frame=dummy_frame)
 
   def slice_outputs(self, model_outputs: np.ndarray, output_slices: dict[str, slice]) -> dict[str, np.ndarray]:
     parsed_model_outputs = {k: model_outputs[np.newaxis, v] for k,v in output_slices.items()}

--- a/selfdrive/modeld/modeld.py
+++ b/selfdrive/modeld/modeld.py
@@ -20,7 +20,7 @@ from openpilot.common.transformations.model import get_warp_matrix
 from openpilot.selfdrive.controls.lib.desire_helper import DesireHelper
 from openpilot.selfdrive.controls.lib.drive_helpers import get_accel_from_plan, smooth_value, get_curvature_from_plan
 from openpilot.selfdrive.modeld.parse_model_outputs import Parser
-from openpilot.selfdrive.modeld.compile_modeld import make_input_queues
+from openpilot.selfdrive.modeld.compile_modeld import make_npy_inputs
 from openpilot.selfdrive.modeld.fill_model_msg import fill_model_msg, fill_pose_msg, PublishState
 from openpilot.common.file_chunker import read_file_chunked
 from openpilot.selfdrive.modeld.constants import ModelConstants, Plan
@@ -86,7 +86,8 @@ class ModelState:
     self.prev_desire = np.zeros(ModelConstants.DESIRE_LEN, dtype=np.float32)
 
     self.frame_skip = ModelConstants.MODEL_RUN_FREQ // ModelConstants.MODEL_CONTEXT_FREQ
-    self.input_queues, self.npy = make_input_queues(self.vision_input_shapes, self.policy_input_shapes, self.frame_skip, device=self.DEV)
+    self.npy, npy_tensors = make_npy_inputs(self.policy_input_shapes)
+    self.input_queues = {**jits['tensor_inputs'], **npy_tensors}
     self.full_frames : dict[str, Tensor] = {}
     self._blob_cache : dict[int, Tensor] = {}
     self.parser = Parser()

--- a/selfdrive/modeld/modeld.py
+++ b/selfdrive/modeld/modeld.py
@@ -94,8 +94,10 @@ class ModelState:
     self.frame_buf_params = {k: get_nv12_info(cam_w, cam_h) for k in ('img', 'big_img')}
     self.run_policy = jits[(cam_w,cam_h)]['run_policy']
     self.warp_enqueue = jits[(cam_w,cam_h)]['warp_enqueue']
-    dummy_frame = jits[(cam_w,cam_h)]['dummy_frame']
-    self.warp_enqueue(**self.input_queues, frame=dummy_frame, big_frame=dummy_frame)
+    self.warp_enqueue(
+      **self.input_queues,
+      frame=Tensor.zeros(self.frame_buf_params['img'][3], dtype='uint8', device=self.DEV).contiguous().realize(),
+      big_frame=Tensor.zeros(self.frame_buf_params['big_img'][3], dtype='uint8', device=self.DEV).contiguous().realize())
 
   def slice_outputs(self, model_outputs: np.ndarray, output_slices: dict[str, slice]) -> dict[str, np.ndarray]:
     parsed_model_outputs = {k: model_outputs[np.newaxis, v] for k,v in output_slices.items()}

--- a/selfdrive/modeld/modeld.py
+++ b/selfdrive/modeld/modeld.py
@@ -94,10 +94,9 @@ class ModelState:
     self.frame_buf_params = {k: get_nv12_info(cam_w, cam_h) for k in ('img', 'big_img')}
     self.run_policy = jits[(cam_w,cam_h)]['run_policy']
     self.warp_enqueue = jits[(cam_w,cam_h)]['warp_enqueue']
-    self.warp_enqueue(
-      **self.input_queues,
-      frame=Tensor.zeros(self.frame_buf_params['img'][3], dtype='uint8', device=self.DEV).contiguous().realize(),
-      big_frame=Tensor.zeros(self.frame_buf_params['big_img'][3], dtype='uint8', device=self.DEV).contiguous().realize())
+    # warmup JIT with a zero frame copied from host (no device memset kernel)
+    dummy_frame = Tensor(np.zeros(self.frame_buf_params['img'][3], dtype=np.uint8), device='NPY').to(self.DEV).realize()
+    self.warp_enqueue(**self.input_queues, frame=dummy_frame, big_frame=dummy_frame)
 
   def slice_outputs(self, model_outputs: np.ndarray, output_slices: dict[str, slice]) -> dict[str, np.ndarray]:
     parsed_model_outputs = {k: model_outputs[np.newaxis, v] for k,v in output_slices.items()}


### PR DESCRIPTION
`ModelState` init ~3s -> ~2s on qcom
adds about ~1MB to pkl size

also allows not having to set compiler on AMD, nor keeping track of which device to put the queues to