### PR TITLE
hardware: tolerate missing modem state in setup

### DIFF
--- a/system/hardware/tici/hardware.py
+++ b/system/hardware/tici/hardware.py
@@ -69,9 +69,11 @@ class Tici(HardwareBase):
     return Amplifier()
 
   def get_modem_state(self) -> dict:
-    """Read modem.py state file. Raises if modem.py hasn't published state yet."""
-    with open(MODEM_STATE_PATH) as f:
-      return json.load(f)
+    try:
+      with open(MODEM_STATE_PATH) as f:
+        return json.load(f)
+    except (FileNotFoundError, json.JSONDecodeError):
+      return {}
 
   def get_os_version(self):
     with open("/VERSION") as f:

--- a/system/hardware/tici/hardware.py
+++ b/system/hardware/tici/hardware.py
@@ -114,7 +114,6 @@ class Tici(HardwareBase):
       f.write(f"{value}\n")
 
   def get_network_type(self):
-    ms = self.get_modem_state()
     try:
       primary_connection = self.nm.Get(NM, 'PrimaryConnection', dbus_interface=DBUS_PROPS, timeout=TIMEOUT)
       primary_connection = self.bus.get_object(NM, primary_connection)
@@ -126,6 +125,7 @@ class Tici(HardwareBase):
     except Exception:
       pass
 
+    ms = self.get_modem_state()
     if ms.get('connected'):
       nt = ms.get('network_type', '')
       if nt == 'nr':


### PR DESCRIPTION
Fixes #38034.

`get_network_type()` raises when `/dev/shm/modem` doesn't exist (modem.py only runs under openpilot manager, not during setup), causing setup's "waiting for internet" check to never advance after wifi connects.

move modem state fetch after wifi check, don’t fetch if primary connection is wifi

also return an empty dict instead as all callers already use `.get()`.

future release will move modem.py to a system service.