### PR TITLE
Use pandacan as panda dependency

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "panda"]
-  path = panda
-  url = ../../commaai/panda.git
 [submodule "opendbc"]
   path = opendbc_repo
   url = ../../commaai/opendbc.git

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,8 +50,7 @@ dependencies = [
   "aiortc",
 
   # panda
-  "libusb1",
-  "spidev; platform_system == 'Linux'",
+  "pandacan @ git+https://github.com/premkiran2/panda.git@codex/pip-package-fw",
 
   # logging
   "pyzmq",


### PR DESCRIPTION
Validation PR for packaging panda as a normal Python dependency.

This removes the panda submodule and depends on the pandacan package branch that bundles firmware artifacts and panda runtime transport dependencies.

Depends on premkiran2/panda@codex/pip-package-fw until pandacan 0.0.11 is published.