### PR TITLE
build_release: check file sizes in CI

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -56,13 +56,13 @@ jobs:
       timeout-minutes: 1
       working-directory: ${{ env.STRIPPED_DIR }}
       run: release/check-dirty.sh
+    - name: Check file sizes
+      timeout-minutes: 1
+      run: release/check-file-sizes.sh
     - name: Check submodules
       if: github.repository == 'commaai/openpilot'
       timeout-minutes: 3
       run: release/check-submodules.sh
-    - name: Check file sizes
-      timeout-minutes: 1
-      run: release/check-file-sizes.sh
 
   build_mac:
     name: build macOS

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -60,6 +60,9 @@ jobs:
       if: github.repository == 'commaai/openpilot'
       timeout-minutes: 3
       run: release/check-submodules.sh
+    - name: Check file sizes
+      timeout-minutes: 1
+      run: release/check-file-sizes.sh
 
   build_mac:
     name: build macOS

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -58,6 +58,7 @@ jobs:
       run: release/check-dirty.sh
     - name: Check file sizes
       timeout-minutes: 1
+      working-directory: ${{ env.STRIPPED_DIR }}
       run: release/check-file-sizes.sh
     - name: Check submodules
       if: github.repository == 'commaai/openpilot'

--- a/release/check-file-sizes.sh
+++ b/release/check-file-sizes.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -e
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
+cd $DIR/..
+
+# ensure files are within GitHub's limit
+BIG_FILES="$(find . -type f -not -path './.git/*' -size +95M)"
+if [ ! -z "$BIG_FILES" ]; then
+  printf '\n\n\n'
+  echo "Found files exceeding GitHub's 100MB limit:"
+  echo "$BIG_FILES"
+  exit 1
+fi


### PR DESCRIPTION
build_release.sh, which pushes and throws the GitHub error, is only run in Jenkins after we push the blank `__nightly` branch. build_stripped.sh is run in GH CI, but doesn't build. To surface the issue after build time, before Jenkins we need this additional step in the build release test