### PR TITLE
modeld/SConscript: fix pkl chunking

### DIFF
--- a/selfdrive/modeld/SConscript
+++ b/selfdrive/modeld/SConscript
@@ -80,12 +80,15 @@ cmd = (f'{tg_flags} {mac_brew_string} python3 {modeld_dir}/compile_modeld.py '
        f'--vision-onnx {File("models/driving_vision.onnx").abspath} '
        f'--policy-onnx {File("models/driving_policy.onnx").abspath} '
        f'--output {pkl_path} --frame-skip {frame_skip}')
-node = lenv.Command(pkl_path, tinygrad_files + compile_modeld_script + driving_onnx_deps + [Value(camera_res_args), chunker_file, tg_devices_node], cmd)
 onnx_sizes_sum = sum(os.path.getsize(f) for f in driving_onnx_deps)
 chunk_targets = get_chunk_paths(pkl_path, estimate_pickle_max_size(onnx_sizes_sum)*2) # TODO make weight dedupe work on QCOM
 def do_chunk(target, source, env, pkl=pkl_path, chunks=chunk_targets):
   chunk_file(pkl, chunks)
-lenv.Command(chunk_targets, node, do_chunk)
+lenv.Command(
+  chunk_targets,
+  tinygrad_files + compile_modeld_script + driving_onnx_deps + [Value(camera_res_args), chunker_file, tg_devices_node],
+  [cmd, do_chunk],
+)
 
 # get model metadata
 fn = File(f"models/dmonitoring_model").abspath
@@ -108,17 +111,12 @@ def tg_compile(flags, model_name):
   pkl = fn + "_tinygrad.pkl"
   onnx_path = fn + ".onnx"
   chunk_targets = get_chunk_paths(pkl, estimate_pickle_max_size(os.path.getsize(onnx_path)))
-  compile_node = lenv.Command(
-    pkl,
-    [onnx_path] + tinygrad_files + [chunker_file, tg_devices_node],
-    f'{pythonpath_string} {flags} python3 {Dir("#tinygrad_repo").abspath}/examples/openpilot/compile3.py {fn}.onnx {pkl}',
-  )
   def do_chunk(target, source, env):
     chunk_file(pkl, chunk_targets)
   return lenv.Command(
     chunk_targets,
-    compile_node,
-    do_chunk,
+    [onnx_path] + tinygrad_files + [chunker_file, tg_devices_node],
+    [f'{pythonpath_string} {flags} python3 {Dir("#tinygrad_repo").abspath}/examples/openpilot/compile3.py {fn}.onnx {pkl}', do_chunk],
   )
 
 tg_compile(tg_flags, 'dmonitoring_model')


### PR DESCRIPTION
because we defined the un-chunked pkl as a target, and because chunking removes that file, scons would always trigger a rebuild because the un-chunked pkl would always be missing