### PR TITLE
Use pandacan package for panda

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "panda"]
-  path = panda
-  url = ../../commaai/panda.git
 [submodule "opendbc"]
   path = opendbc_repo
   url = ../../commaai/opendbc.git

--- a/SConstruct
+++ b/SConstruct
@@ -5,6 +5,7 @@ import sysconfig
 import platform
 import shlex
 import importlib
+import importlib.util
 import numpy as np
 
 import SCons.Errors
@@ -48,6 +49,12 @@ acados_include_dirs = [
   os.path.join(acados.INCLUDE_DIR, "blasfeo", "include"),
   os.path.join(acados.INCLUDE_DIR, "hpipm", "include"),
 ]
+
+panda_spec = importlib.util.find_spec("panda")
+if panda_spec is None or not panda_spec.submodule_search_locations:
+  raise SCons.Errors.UserError("pandacan must be installed to build openpilot")
+panda_dir = panda_spec.submodule_search_locations[0]
+panda_include_dir = os.path.dirname(panda_dir)
 
 
 # ***** enforce a whitelist of system libraries *****
@@ -114,6 +121,7 @@ env = Environment(
   CPPPATH=[
     "#",
     "#msgq",
+    panda_include_dir,
     acados_include_dirs,
     [x.INCLUDE_DIR for x in pkgs],
   ],
@@ -228,8 +236,8 @@ messaging = [socketmaster, msgq, 'capnp', 'kj',]
 Export('messaging')
 
 
-# Build other submodules
-SConscript(['panda/SConscript'])
+# Build panda firmware from the installed pandacan package.
+SConscript(os.path.join(panda_dir, 'SConscript'), variant_dir='panda', duplicate=0)
 
 # Build rednose library
 SConscript(['rednose/SConscript'])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,8 +50,7 @@ dependencies = [
   "aiortc",
 
   # panda
-  "libusb1",
-  "spidev; platform_system == 'Linux'",
+  "pandacan @ git+https://github.com/premkiran2/panda.git@proper-pip-package",
 
   # logging
   "pyzmq",

--- a/uv.lock
+++ b/uv.lock
@@ -499,6 +499,15 @@ version = "1.92.7"
 source = { git = "https://github.com/commaai/dependencies.git?subdirectory=imgui&rev=release-imgui#76627bbbb9ac259c7e7e064fc5676e198c987ca9" }
 
 [[package]]
+name = "importlib-resources"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/06/b56dfa750b44e86157093bc8fca0ab81dccbf5260510de4eaf1cb69b5b99/importlib_resources-7.1.0.tar.gz", hash = "sha256:0722d4c6212489c530f2a145a34c0a7a3b4721bc96a15fada5930e2a0b760708", size = 44985, upload-time = "2026-04-12T16:36:09.232Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/db/55a262f3606bebcae07cc14095338471ad7c0bbcaa37707e6f0ee49725b7/importlib_resources-7.1.0-py3-none-any.whl", hash = "sha256:1bd7b48b4088eddb2cd16382150bb515af0bd2c70128194392725f82ad2c96a1", size = 37232, upload-time = "2026-04-12T16:36:08.219Z" },
+]
+
+[[package]]
 name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -587,6 +596,26 @@ source = { git = "https://github.com/commaai/dependencies.git?subdirectory=libjp
 name = "libusb"
 version = "1.0.29"
 source = { git = "https://github.com/commaai/dependencies.git?subdirectory=libusb&rev=release-libusb#ee3a662c45a3e66ac9ca61e7c7fb221264e18be4" }
+
+[[package]]
+name = "libusb-package"
+version = "1.0.26.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "importlib-resources" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2e/f6/83e13936b5799360eae8f0e31b5b298dd092451b91136d7cd13852777954/libusb_package-1.0.26.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c9404298485762a4e73b416e8a3208d33aa3274fb9b870c2a1cacba7e2918f19", size = 62045, upload-time = "2025-04-01T12:59:16.817Z" },
+    { url = "https://files.pythonhosted.org/packages/33/97/86ed73880b6734c9383be5f34061b541e8fe5bd0303580b1f5abe2962d58/libusb_package-1.0.26.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8126f6711318dad4cb2805ea20cd47b895a847207087d8fdb032e082dd7a2e24", size = 59502, upload-time = "2025-04-01T12:59:17.72Z" },
+    { url = "https://files.pythonhosted.org/packages/95/f7/27b67b8fe63450abf0b0b66aacf75d5d64cdf30317e214409ceb534f34b4/libusb_package-1.0.26.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:11c219366e4a2368117b9a9807261f3506b5623531f8b8ce41af5bbaec8156a0", size = 70247, upload-time = "2025-04-01T14:53:14.387Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/11/613543f9c6dab5a82eefd0c78d52d08b5d9eb93a0362151fbedf74b32541/libusb_package-1.0.26.3-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8809a50d8ab84297344c54e862027090c0d73b14abef843a8b5f783313f49457", size = 74537, upload-time = "2025-04-01T14:53:15.345Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/43/5a2331615693b56221a902869fb2094d9a0b9a764a8706c8ba16e915f77c/libusb_package-1.0.26.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a83067c3dfdbb3856badb4532eaea22e8502b52ce4245f5ab46acf93d7fbd471", size = 70652, upload-time = "2025-04-01T14:53:16.319Z" },
+    { url = "https://files.pythonhosted.org/packages/44/1a/186d4ec86421b69feb45e214edb5301fbcb9e8dc9df963678aeff1a447d5/libusb_package-1.0.26.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:b56be087ea9cde8e50fb02740a4f0cefb6f63c61ac2e7812a9244487614a3973", size = 71860, upload-time = "2025-04-01T14:53:17.87Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/3c/8cebdad822d7bfcb683a77d5fd113fbc6f72516cfb7c1c3a274fefafa8e9/libusb_package-1.0.26.3-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:ea0f6bf40e54b1671e763e40c9dbed46bf7f596a4cd98b7c827e147f176d8c97", size = 76476, upload-time = "2025-04-01T14:53:19.202Z" },
+    { url = "https://files.pythonhosted.org/packages/49/5f/30c625b6c4ecd14871644c1d16e97d7c971f82a0f87a9cfa81022f85bcfc/libusb_package-1.0.26.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:b40f77df991c6db8621de9575504886eca03a00277e521a4d64b66cbef8f6997", size = 71037, upload-time = "2025-04-01T14:53:21.359Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/e9/3aa3ff3242867b7f22ee3ce28d0e93ff88547f170ca1b8a6edc59660d974/libusb_package-1.0.26.3-cp312-cp312-win32.whl", hash = "sha256:6eee99c9fde137443869c8604d0c01b2127a9545ebc59d06a3376cf1d891e786", size = 77642, upload-time = "2025-04-01T12:58:05.471Z" },
+    { url = "https://files.pythonhosted.org/packages/15/0e/913ddb1849f828fc385438874c34541939d9b06c0e5616f48f24cddd24de/libusb_package-1.0.26.3-cp312-cp312-win_amd64.whl", hash = "sha256:5e09c0b6b3cd475841cffe78e46e91df58f0c6c02ea105ea1a4d0755a07c8006", size = 90593, upload-time = "2025-04-01T12:58:06.798Z" },
+]
 
 [[package]]
 name = "libusb1"
@@ -747,6 +776,17 @@ wheels = [
 ]
 
 [[package]]
+name = "opendbc"
+version = "0.3.1"
+source = { git = "https://github.com/commaai/opendbc.git?rev=master#a5276670833fb5c2feeac6b81baaac2814eff173" }
+dependencies = [
+    { name = "numpy" },
+    { name = "pycapnp" },
+    { name = "pycryptodome" },
+    { name = "tqdm" },
+]
+
+[[package]]
 name = "openpilot"
 version = "0.1.0"
 source = { editable = "." }
@@ -772,10 +812,10 @@ dependencies = [
     { name = "json11" },
     { name = "libjpeg" },
     { name = "libusb" },
-    { name = "libusb1" },
     { name = "libyuv" },
     { name = "ncurses" },
     { name = "numpy" },
+    { name = "pandacan" },
     { name = "pillow" },
     { name = "psutil" },
     { name = "pycapnp" },
@@ -791,7 +831,6 @@ dependencies = [
     { name = "setproctitle" },
     { name = "setuptools" },
     { name = "sounddevice" },
-    { name = "spidev", marker = "sys_platform == 'linux'" },
     { name = "sympy" },
     { name = "tqdm" },
     { name = "websocket-client" },
@@ -857,13 +896,13 @@ requires-dist = [
     { name = "json11", git = "https://github.com/commaai/dependencies.git?subdirectory=json11&rev=release-json11" },
     { name = "libjpeg", git = "https://github.com/commaai/dependencies.git?subdirectory=libjpeg&rev=release-libjpeg" },
     { name = "libusb", git = "https://github.com/commaai/dependencies.git?subdirectory=libusb&rev=release-libusb" },
-    { name = "libusb1" },
     { name = "libyuv", git = "https://github.com/commaai/dependencies.git?subdirectory=libyuv&rev=release-libyuv" },
     { name = "matplotlib", marker = "extra == 'dev'" },
     { name = "metadrive-simulator", marker = "platform_machine != 'aarch64' and extra == 'tools'", git = "https://github.com/commaai/metadrive.git?rev=minimal" },
     { name = "ncurses", git = "https://github.com/commaai/dependencies.git?subdirectory=ncurses&rev=release-ncurses" },
     { name = "numpy", specifier = ">=2.0" },
     { name = "opencv-python-headless", marker = "extra == 'dev'" },
+    { name = "pandacan", git = "https://github.com/premkiran2/panda.git?rev=proper-pip-package" },
     { name = "pillow" },
     { name = "pre-commit-hooks", marker = "extra == 'testing'" },
     { name = "psutil" },
@@ -886,7 +925,6 @@ requires-dist = [
     { name = "setproctitle" },
     { name = "setuptools" },
     { name = "sounddevice" },
-    { name = "spidev", marker = "sys_platform == 'linux'" },
     { name = "sympy" },
     { name = "tqdm" },
     { name = "ty", marker = "extra == 'testing'" },
@@ -946,6 +984,17 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/0d/be/c4d1ded04c22b357277cf6e6a44c1ab4abb285a700bd1991460460e05b99/panda3d_simplepbr-0.13.1.tar.gz", hash = "sha256:c83766d7c8f47499f365a07fe1dff078fc8b3054c2689bdc8dceabddfe7f1a35", size = 6216055, upload-time = "2025-03-30T16:57:41.087Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/11/5d/3744c6550dddf933785a37cdd4a9921fe13284e6d115b5a2637fe390f158/panda3d_simplepbr-0.13.1-py3-none-any.whl", hash = "sha256:cda41cb57cff035b851646956cfbdcc408bee42511dabd4f2d7bd4fbf48c57a9", size = 2457097, upload-time = "2025-03-30T16:57:39.729Z" },
+]
+
+[[package]]
+name = "pandacan"
+version = "0.0.11"
+source = { git = "https://github.com/premkiran2/panda.git?rev=proper-pip-package#126dc64377bca8084ce4a11560504fd1a08f74bf" }
+dependencies = [
+    { name = "libusb-package" },
+    { name = "libusb1" },
+    { name = "opendbc" },
+    { name = "spidev", marker = "sys_platform == 'linux'" },
 ]
 
 [[package]]


### PR DESCRIPTION
Validation PR for removing panda as an openpilot submodule and consuming it as a normal Python dependency.

This PR:
- removes the panda submodule entry from `.gitmodules`
- removes the panda gitlink
- replaces direct panda transport deps with `pandacan` from `premkiran2/panda@proper-pip-package`
- updates `SConstruct` to locate the installed `panda` package and run its packaged `SConscript` with a local `variant_dir`

Depends on panda package PR: https://github.com/commaai/panda/pull/2403

Local validation:
- `python3 -m py_compile SConstruct`
- parsed `pyproject.toml` dependencies
- `git diff --cached --check` before commit

Full CI on this PR is the intended validation that openpilot can build without the panda submodule.