### PR TITLE
modeld/SConscript: depend on tg HEAD + git status

### DIFF
--- a/selfdrive/modeld/SConscript
+++ b/selfdrive/modeld/SConscript
@@ -1,4 +1,4 @@
-import glob
+import hashlib
 import json
 import os
 import sys, subprocess
@@ -19,9 +19,10 @@ Import('env', 'arch')
 chunker_file = File("#common/file_chunker.py")
 lenv = env.Clone()
 
-tinygrad_root = env.Dir("#").abspath
-tinygrad_files = ["#"+x for x in glob.glob(env.Dir("#tinygrad_repo").relpath + "/**", recursive=True, root_dir=tinygrad_root)
-                  if 'pycache' not in x and os.path.isfile(os.path.join(tinygrad_root, x))]
+tinygrad_root = env.Dir("#tinygrad_repo").abspath
+tinygrad_head = subprocess.check_output(['git', '-C', tinygrad_root, 'rev-parse', 'HEAD'], text=True).strip()
+tinygrad_status = subprocess.check_output(['git', '-C', tinygrad_root, 'status', '--porcelain'], text=True)
+tinygrad_files = [Value(f"tinygrad@{tinygrad_head}-{hashlib.sha256(tinygrad_status.encode()).hexdigest()}")]
 
 def estimate_pickle_max_size(onnx_size):
   return 1.2 * onnx_size  + 10 * 1024 * 1024  # 20% + 10MB is plenty


### PR DESCRIPTION
this makes the output of `scons --tree` readable by not depending on all tg files
useful to know what gets built, what it depends on and what will be ran:
`scons -c selfdrive/modeld/ && scons -n --no-cache selfdrive/modeld/ --tree=all,status,linedraw 2>/dev/null`
```
[  B      ]    ├─┬selfdrive/modeld/models/driving_tinygrad.pkl.chunkmanifest
[E     C  ]    │ ├─tinygrad@eecd4706fffe3ad8bdd7350e8db52d86d7214be2-f6129298473b164e65cb2745bf8accc96a0439c3ce77eb54432e75d4270a90ed
[E     C  ]    │ ├─selfdrive/modeld/compile_modeld.py
[E     C  ]    │ ├─selfdrive/modeld/get_model_metadata.py
[E     C  ]    │ ├─system/camerad/cameras/nv12_info.py
[E     C  ]    │ ├─system/hardware/hw.py
[E     C  ]    │ ├─selfdrive/modeld/models/driving_vision.onnx
[E     C  ]    │ ├─selfdrive/modeld/models/driving_policy.onnx
[E     C  ]    │ ├─['/home/batman/Dev/openpilot/selfdrive/modeld/models/driving_tinygrad.pkl.chunkmanifest', '/home/batman/Dev/openpilot/selfdrive/modeld/models/driving_tinygrad.pkl.chunk01of02', '/home/batman/Dev/openpilot/selfdrive/modeld/models/driving_tinygrad.pkl.chunk02of02']
[E     C  ]    │ └─common/file_chunker.py
```

- [ ] manually hash all the files and use that instead? do we care about git dep at build time?