### PR TITLE
modeld: always build big model for release

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -190,7 +190,7 @@ else:
 np_version = SCons.Script.Value(np.__version__)
 Export('envCython', 'np_version')
 
-Export('env', 'arch', 'acados')
+Export('env', 'arch', 'acados', 'release')
 
 # Setup cache dir
 cache_dir = '/data/scons_cache' if arch == "larch64" else '/tmp/scons_cache'

--- a/selfdrive/modeld/SConscript
+++ b/selfdrive/modeld/SConscript
@@ -15,7 +15,7 @@ CAMERA_CONFIGS = [
   (_os_fisheye.width, _os_fisheye.height),        # mici: 1344x760
 ]
 
-Import('env', 'arch')
+Import('env', 'arch', 'release')
 chunker_file = File("#common/file_chunker.py")
 lenv = env.Clone()
 
@@ -53,7 +53,7 @@ tg_devices = { # which device to put jit inputs to at runtime
   },
 }
 
-USBGPU = usbgpu_present() # or release # TODO always build big model on release
+USBGPU = usbgpu_present() or release
 if USBGPU:
   tg_devices['selfdrive.modeld.modeld']['usbgpu'] = {'WARP_DEV': tg_backend, 'QUEUE_DEV': 'AMD'}
   usbgpu_tg_flags = f'DEBUG=2 DEV=USB+AMD:LLVM WARP_DEV={tg_backend} FLOAT16=1 JIT_BATCH_SIZE=0 GMMU=0'


### PR DESCRIPTION
- [ ] if usbgpu plugged into ci build devices, they'll default to running test_onroad.py and model_replay.py with usbgpu, need so way to make them run both with and without usbgpu?