### PR TITLE
Cabana: Fixed internal typos and method casing

### DIFF
--- a/tools/cabana/binaryview.cc
+++ b/tools/cabana/binaryview.cc
@@ -40,14 +40,14 @@ BinaryView::BinaryView(QWidget *parent) : QTableView(parent) {
   addShortcuts();
   setWhatsThis(R"(
     <b>Binary View</b><br/>
-    <!-- TODO: add descprition here -->
+    <!-- TODO: add description here -->
     <span style="color:gray">Shortcuts</span><br />
     Delete Signal:
       <span style="background-color:lightGray;color:gray">&nbsp;x&nbsp;</span>,
       <span style="background-color:lightGray;color:gray">&nbsp;Backspace&nbsp;</span>,
       <span style="background-color:lightGray;color:gray">&nbsp;Delete&nbsp;</span><br />
     Change endianness: <span style="background-color:lightGray;color:gray">&nbsp;e&nbsp; </span><br />
-    Change singedness: <span style="background-color:lightGray;color:gray">&nbsp;s&nbsp;</span><br />
+    Change signedness: <span style="background-color:lightGray;color:gray">&nbsp;s&nbsp;</span><br />
     Open chart:
       <span style="background-color:lightGray;color:gray">&nbsp;c&nbsp;</span>,
       <span style="background-color:lightGray;color:gray">&nbsp;p&nbsp;</span>,

--- a/tools/cabana/messageswidget.cc
+++ b/tools/cabana/messageswidget.cc
@@ -64,7 +64,7 @@ MessagesWidget::MessagesWidget(QWidget *parent) : menu(new QMenu(this)), QWidget
 
   setWhatsThis(tr(R"(
     <b>Message View</b><br/>
-    <!-- TODO: add descprition here -->
+    <!-- TODO: add description here -->
     <span style="color:gray">Byte color</span><br />
     <span style="color:gray;">■ </span> constant changing<br />
     <span style="color:blue;">■ </span> increasing<br />
@@ -146,7 +146,7 @@ void MessagesWidget::menuAboutToShow() {
   action->setCheckable(true);
   action->setChecked(settings.multiple_lines_hex);
 
-  action = menu->addAction(tr("Show inactive Messages"), model, &MessageListModel::showInactivemessages);
+  action = menu->addAction(tr("Show inactive messages"), model, &MessageListModel::showInactiveMessages);
   action->setCheckable(true);
   action->setChecked(model->show_inactive_messages);
 }
@@ -216,7 +216,7 @@ void MessageListModel::setFilterStrings(const QMap<int, QString> &filters) {
   filterAndSort();
 }
 
-void MessageListModel::showInactivemessages(bool show) {
+void MessageListModel::showInactiveMessages(bool show) {
   show_inactive_messages = show;
   filterAndSort();
 }

--- a/tools/cabana/messageswidget.h
+++ b/tools/cabana/messageswidget.h
@@ -36,7 +36,7 @@ public:
   int rowCount(const QModelIndex &parent = QModelIndex()) const override { return items_.size(); }
   void sort(int column, Qt::SortOrder order = Qt::AscendingOrder) override;
   void setFilterStrings(const QMap<int, QString> &filters);
-  void showInactivemessages(bool show);
+  void showInactiveMessages(bool show);
   void msgsReceived(const std::set<MessageId> *new_msgs, bool has_new_ids);
   bool filterAndSort();
   void dbcModified();

--- a/tools/cabana/signalview.cc
+++ b/tools/cabana/signalview.cc
@@ -495,7 +495,7 @@ SignalView::SignalView(ChartsWidget *charts, QWidget *parent) : charts(charts), 
 
   setWhatsThis(tr(R"(
     <b>Signal view</b><br />
-    <!-- TODO: add descprition here -->
+    <!-- TODO: add description here -->
   )"));
 }
 

--- a/tools/cabana/videowidget.cc
+++ b/tools/cabana/videowidget.cc
@@ -51,7 +51,7 @@ VideoWidget::VideoWidget(QWidget *parent) : QFrame(parent) {
   updatePlayBtnState();
   setWhatsThis(tr(R"(
     <b>Video</b><br />
-    <!-- TODO: add descprition here -->
+    <!-- TODO: add description here -->
     <span style="color:gray">Timeline color</span>
     <table>
     <tr><td><span style="color:%1;">■ </span>Disengaged </td>


### PR DESCRIPTION
**Description**

Small Cabana cleanup to improve readability and consistency:

- rename the typo’d slot `showInactivemessages` to `showInactiveMessages`
- fix a few help-text typos in Cabana widgets (`descprition` -> `description`, `singedness` -> `signedness`)
- update the inactive messages menu label to use normal casing

No functional behavior will change.

**Verification**

- Ran a search to confirm there are no stale references to the old slot name.
- Reviewed the diff to make sure the change is limited to Cabana UI text and naming.