### PR TITLE
tools/lib: add auto_camera_source for multi-source camera file resolution

### DIFF
--- a/tools/lib/file_sources.py
+++ b/tools/lib/file_sources.py
@@ -18,8 +18,18 @@ def comma_api_source(sr: SegmentRange, seg_idxs: list[int], fns: FileNames) -> d
   # comma api will have already checked if the file exists
   if fns == FileName.RLOG:
     return {seg: route.log_paths()[seg] for seg in seg_idxs if route.log_paths()[seg] is not None}
-  else:
+  elif fns == FileName.QLOG:
     return {seg: route.qlog_paths()[seg] for seg in seg_idxs if route.qlog_paths()[seg] is not None}
+  elif fns == FileName.FCAMERA:
+    return {seg: route.camera_paths()[seg] for seg in seg_idxs if route.camera_paths()[seg] is not None}
+  elif fns == FileName.DCAMERA:
+    return {seg: route.dcamera_paths()[seg] for seg in seg_idxs if route.dcamera_paths()[seg] is not None}
+  elif fns == FileName.ECAMERA:
+    return {seg: route.ecamera_paths()[seg] for seg in seg_idxs if route.ecamera_paths()[seg] is not None}
+  elif fns == FileName.QCAMERA:
+    return {seg: route.qcamera_paths()[seg] for seg in seg_idxs if route.qcamera_paths()[seg] is not None}
+  else:
+    raise ValueError(f"Unknown file type: {fns}")
 
 
 def internal_source(sr: SegmentRange, seg_idxs: list[int], fns: FileNames, endpoint_url: str = DATA_ENDPOINT) -> dict[int, str]:

--- a/tools/lib/logreader.py
+++ b/tools/lib/logreader.py
@@ -18,7 +18,7 @@ from urllib.parse import parse_qs, urlparse
 from cereal import log as capnp_log
 from openpilot.common.swaglog import cloudlog
 from openpilot.tools.lib.filereader import FileReader
-from openpilot.tools.lib.file_sources import comma_api_source, internal_source, openpilotci_source, comma_car_segments_source, Source
+from openpilot.tools.lib.file_sources import comma_api_source, internal_source, openpilotci_source, comma_car_segments_source, Source, FileNames
 from openpilot.tools.lib.route import SegmentRange, FileName
 from openpilot.tools.lib.log_time_series import msgs_to_time_series
 
@@ -146,7 +146,27 @@ def direct_source(file_or_url: str) -> list[str]:
   return [file_or_url]
 
 
-# TODO this should apply to camera files as well
+def auto_camera_source(identifier: str, sources: list[Source], camera_type: FileNames = FileName.FCAMERA) -> list[str]:
+  sr = SegmentRange(identifier)
+  needed_seg_idxs = sr.seg_idxs
+
+  valid_files: dict[int, str] = {}
+  exceptions = {}
+  for source in sources:
+    try:
+      files = source(sr, needed_seg_idxs, camera_type)
+      valid_files |= files
+      needed_seg_idxs = [idx for idx in needed_seg_idxs if idx not in valid_files]
+      if len(needed_seg_idxs) == 0:
+        return list(valid_files.values())
+    except Exception as e:
+      exceptions[source.__name__] = e
+
+  missing = len(needed_seg_idxs)
+  raise LogsUnavailable(f"{missing}/{len(sr.seg_idxs)} camera files were not found for {sr.route_name}, " +
+                        f"camera_type={camera_type}\n\n" +
+                        "Exceptions for sources:\n  - " + "\n  - ".join([f"{k}: {repr(v)}" for k, v in exceptions.items()]))
+
 def auto_source(identifier: str, sources: list[Source], default_mode: ReadMode) -> list[str]:
   exceptions = {}
 

--- a/tools/lib/tests/test_logreader.py
+++ b/tools/lib/tests/test_logreader.py
@@ -10,9 +10,9 @@ import requests
 from openpilot.common.parameterized import parameterized
 
 from cereal import log as capnp_log
-from openpilot.tools.lib.logreader import LogsUnavailable, LogIterable, LogReader, parse_indirect, ReadMode
+from openpilot.tools.lib.logreader import LogsUnavailable, LogIterable, LogReader, parse_indirect, ReadMode, auto_camera_source
 from openpilot.tools.lib.file_sources import comma_api_source, InternalUnavailableException
-from openpilot.tools.lib.route import SegmentRange
+from openpilot.tools.lib.route import SegmentRange, FileName
 from openpilot.tools.lib.url_file import URLFileException
 
 NUM_SEGS = 17  # number of segments in the test route
@@ -261,3 +261,130 @@ class TestLogReader:
       msgs = list(LogReader(qlog.name, only_union_types=True))
       assert len(msgs) == num_msgs
       [m.which() for m in msgs]
+
+
+TEST_ROUTE_CAM = "344c5c15b34f2d8a/2024-01-03--09-37-12"
+CAMERA_FILE = "fcamera.hevc"
+
+
+class TestCameraSource:
+  def test_auto_camera_source_no_source(self):
+    with pytest.raises(LogsUnavailable):
+      auto_camera_source(f"{TEST_ROUTE_CAM}/0", [], FileName.FCAMERA)
+
+  def test_auto_camera_source_no_source_default_camera(self):
+    with pytest.raises(LogsUnavailable):
+      auto_camera_source(f"{TEST_ROUTE_CAM}/0", [])
+
+  def test_auto_camera_source_found(self, mocker):
+    mock_source = mocker.Mock()
+    mock_source.__name__ = "mock_source"
+    mock_source.return_value = {0: "http://fake/fcamera.hevc"}
+
+    result = auto_camera_source(f"{TEST_ROUTE_CAM}/0", [mock_source], FileName.FCAMERA)
+    assert len(result) == 1
+    assert result[0] == "http://fake/fcamera.hevc"
+
+  def test_auto_camera_source_multiple_segments(self, mocker):
+    mock_source = mocker.Mock()
+    mock_source.__name__ = "mock_source"
+    mock_source.return_value = {0: "http://fake/0/fcamera.hevc", 1: "http://fake/1/fcamera.hevc"}
+
+    result = auto_camera_source(f"{TEST_ROUTE_CAM}/0:2", [mock_source], FileName.FCAMERA)
+    assert len(result) == 2
+
+  def test_auto_camera_source_source_fallback(self, mocker):
+    source_a = mocker.Mock()
+    source_a.__name__ = "source_a"
+    source_a.return_value = {}
+
+    source_b = mocker.Mock()
+    source_b.__name__ = "source_b"
+    source_b.return_value = {0: "http://fake/fcamera.hevc"}
+
+    result = auto_camera_source(f"{TEST_ROUTE_CAM}/0", [source_a, source_b], FileName.FCAMERA)
+    assert len(result) == 1
+    assert source_a.called
+    assert source_b.called
+
+  def test_auto_camera_source_partial_fallback(self, mocker):
+    source_a = mocker.Mock()
+    source_a.__name__ = "source_a"
+    source_a.return_value = {0: "http://fake/0/fcamera.hevc"}
+
+    source_b = mocker.Mock()
+    source_b.__name__ = "source_b"
+    source_b.return_value = {1: "http://fake/1/fcamera.hevc"}
+
+    result = auto_camera_source(f"{TEST_ROUTE_CAM}/0:2", [source_a, source_b], FileName.FCAMERA)
+    assert len(result) == 2
+
+  def test_auto_camera_source_error_then_success(self, mocker):
+    source_a = mocker.Mock()
+    source_a.__name__ = "source_a"
+    source_a.side_effect = Exception("network error")
+
+    source_b = mocker.Mock()
+    source_b.__name__ = "source_b"
+    source_b.return_value = {0: "http://fake/fcamera.hevc"}
+
+    result = auto_camera_source(f"{TEST_ROUTE_CAM}/0", [source_a, source_b], FileName.FCAMERA)
+    assert len(result) == 1
+
+  def test_auto_camera_source_all_fail(self, mocker):
+    source_a = mocker.Mock()
+    source_a.__name__ = "source_a"
+    source_a.side_effect = Exception("network error")
+
+    source_b = mocker.Mock()
+    source_b.__name__ = "source_b"
+    source_b.return_value = {}
+
+    with pytest.raises(LogsUnavailable):
+      auto_camera_source(f"{TEST_ROUTE_CAM}/0:2", [source_a, source_b], FileName.FCAMERA)
+
+  def test_auto_camera_source_route_with_slash(self, mocker):
+    mocker.patch("openpilot.tools.lib.route.get_max_seg_number_cached", return_value=16)
+    mock_source = mocker.Mock()
+    mock_source.__name__ = "mock_source"
+    mock_source.side_effect = lambda sr, seg_idxs, fns: {seg: f"http://fake/{seg}/fcamera.hevc" for seg in seg_idxs}
+
+    result = auto_camera_source(f"{TEST_ROUTE_CAM.replace('/', '|')}", [mock_source], FileName.FCAMERA)
+    assert len(result) == 17
+
+  def test_auto_camera_source_route_with_segment(self, mocker):
+    mock_source = mocker.Mock()
+    mock_source.__name__ = "mock_source"
+    mock_source.side_effect = lambda sr, seg_idxs, fns: {seg: f"http://fake/{seg}/fcamera.hevc" for seg in seg_idxs}
+
+    result = auto_camera_source(f"{TEST_ROUTE_CAM}--5", [mock_source], FileName.FCAMERA)
+    assert len(result) == 1
+
+  def test_comma_api_source_extended(self, mocker):
+    """Verify comma_api_source can serve camera paths"""
+    mock_route = mocker.patch("openpilot.tools.lib.file_sources.Route")
+    mock_route_instance = mock_route.return_value
+    mock_route_instance.log_paths.return_value = ["fake_rlog"]
+    mock_route_instance.qlog_paths.return_value = ["fake_qlog"]
+    mock_route_instance.camera_paths.return_value = ["fake_fcamera"]
+    mock_route_instance.dcamera_paths.return_value = ["fake_dcamera"]
+    mock_route_instance.ecamera_paths.return_value = ["fake_ecamera"]
+    mock_route_instance.qcamera_paths.return_value = ["fake_qcamera"]
+
+    sr = SegmentRange(f"{TEST_ROUTE_CAM}/0")
+    for fns, expected in [
+      (FileName.RLOG, "fake_rlog"),
+      (FileName.QLOG, "fake_qlog"),
+      (FileName.FCAMERA, "fake_fcamera"),
+      (FileName.DCAMERA, "fake_dcamera"),
+      (FileName.ECAMERA, "fake_ecamera"),
+      (FileName.QCAMERA, "fake_qcamera"),
+    ]:
+      result = comma_api_source(sr, [0], fns)
+      assert result[0] == expected, f"Failed for {fns}"
+
+  def test_comma_api_source_unknown_type(self, mocker):
+    mocker.patch("openpilot.tools.lib.file_sources.Route")
+    sr = SegmentRange(f"{TEST_ROUTE_CAM}/0")
+    with pytest.raises(ValueError, match="Unknown file type"):
+      comma_api_source(sr, [0], ("unknown.ext",))


### PR DESCRIPTION
## Summary

Adds `auto_camera_source()` â€” the camera equivalent of the existing `auto_source()` for logs â€” enabling smart multi-source resolution of camera files (fcamera, dcamera, ecamera, qcamera) across all data sources.

## Motivation

Resolves the TODO at `tools/lib/logreader.py:149`:
```
# TODO this should apply to camera files as well
```

Previously, camera file resolution had no multi-source fallback mechanism. Tools like `replay`, `clip`, and `cabana` had to construct camera file URLs manually through `Route`, without any of the smart fallback behavior that logs already enjoyed (rlog â†’ qlog across internal API, comma API, openpilot CI, commaCarSegments).

## Changes

### `tools/lib/file_sources.py`
Extended `comma_api_source()` to serve all four camera file types through the Route API:
- `FileName.FCAMERA` â†’ `route.camera_paths()`
- `FileName.DCAMERA` â†’ `route.dcamera_paths()`
- `FileName.ECAMERA` â†’ `route.ecamera_paths()`
- `FileName.QCAMERA` â†’ `route.qcamera_paths()`

The previous `else` branch (which handled both QLOG and unknown types) is now explicit per type, with a `ValueError` raised for truly unknown file types.

### `tools/lib/logreader.py`
Added `auto_camera_source(identifier, sources, camera_type)` function that:
1. Parses route identifiers (supporting all existing formats: `/slice`, `--segment`, pipe `|`, etc.)
2. Iterates through provided sources in order, collecting camera file URLs
3. Falls back across sources when a source only partially covers the requested segments
4. Returns a flat list of resolved file URLs
5. Raises `LogsUnavailable` with a descriptive error (including per-source exception details) when files can't be found

### `tools/lib/tests/test_logreader.py`
Added `TestCameraSource` class with 12 test cases:

| Test | What it covers |
|------|---------------|
| `test_auto_camera_source_no_source` | Empty source list raises LogsUnavailable |
| `test_auto_camera_source_no_source_default_camera` | Default camera type (FCAMERA) |
| `test_auto_camera_source_found` | Single segment, single source |
| `test_auto_camera_source_multiple_segments` | Multiple segments resolved at once |
| `test_auto_camera_source_source_fallback` | First source empty, second succeeds |
| `test_auto_camera_source_partial_fallback` | Each source provides some segments |
| `test_auto_camera_source_error_then_success` | Source raises exception, fallback succeeds |
| `test_auto_camera_source_all_fail` | All sources fail â†’ LogsUnavailable |
| `test_auto_camera_source_route_with_slash` | Pipe-separated route name |
| `test_auto_camera_source_route_with_segment` | `--N` segment notation |
| `test_comma_api_source_extended` | All 6 file types work through comma_api_source |
| `test_comma_api_source_unknown_type` | Unknown type raises ValueError |

## Compatibility

- `auto_camera_source()` works with all existing sources (`comma_api_source`, `openpilotci_source`, `internal_source`) â€” they already construct URLs from the `FileNames` tuple parameter
- `comma_car_segments_source` is unaffected (it doesn't use the `fns` parameter)
- Backwards compatible: existing `comma_api_source` callers passing RLOG/QLOG see zero behavior change

## Usage Example

```python
from openpilot.tools.lib.logreader import auto_camera_source
from openpilot.tools.lib.file_sources import comma_api_source, openpilotci_source

# Resolve fcamera.hevc for segment 5 of a route
urls = auto_camera_source(
    a2a0ccea32023010/2023-07-27--13-01-19/5,
    sources=[comma_api_source, openpilotci_source],
    camera_type=FileName.FCAMERA,
)
# urls == [https://.../5/fcamera.hevc]
```

## Verification

All 12 new tests exercise the function logic through mocks. The `test_comma_api_source_extended` test validates that `comma_api_source` correctly dispatches to `Route.camera_paths()`, `Route.dcamera_paths()`, `Route.ecamera_paths()`, and `Route.qcamera_paths()`.
