### PR TITLE
usbgpu: pin modeld

### DIFF
--- a/selfdrive/modeld/modeld.py
+++ b/selfdrive/modeld/modeld.py
@@ -149,10 +149,7 @@ def main(demo=False):
   params.put_bool("UsbGpuPresent", _present)
   params.put_bool("UsbGpuCompiled", _compiled)
 
-  if not USBGPU:
-    # USB GPU currently saturates a core so can't do this yet,
-    # also need to move the aux USB interrupts for good timings
-    config_realtime_process(7, 54)
+  config_realtime_process(7, 54)
 
   # visionipc clients
   while True:


### PR DESCRIPTION
usbgpu pinned to core 7: `dffcf1de8723a20f/0000041d--cd00ea64a4`
no usbgpu, pinned to core 7: `dffcf1de8723a20f/0000041e--56a1484d86`
