### PR TITLE
A valid livePose should not carry a timestamp produced from uninitialized Kalman filter time.

### DIFF
--- a/selfdrive/locationd/locationd.py
+++ b/selfdrive/locationd/locationd.py
@@ -209,6 +209,8 @@ class LocationEstimator:
   def get_msg(self, sensors_valid: bool, inputs_valid: bool, filter_valid: bool):
     state, cov = self.kf.x, self.kf.P
     std = np.sqrt(np.diag(cov))
+    filter_time_valid = np.isfinite(self.kf.t)
+    filter_valid = filter_valid and filter_time_valid
 
     orientation_ned, orientation_ned_std = state[States.NED_ORIENTATION], std[States.NED_ORIENTATION]
     velocity_device, velocity_device_std = state[States.DEVICE_VELOCITY], std[States.DEVICE_VELOCITY]

--- a/selfdrive/locationd/locationd.py
+++ b/selfdrive/locationd/locationd.py
@@ -206,11 +206,11 @@ class LocationEstimator:
       self._finite_check(t, new_x, new_P)
     return HandleLogResult.SUCCESS
 
-  def get_msg(self, sensors_valid: bool, inputs_valid: bool, filter_valid: bool):
+  def get_msg(self, sensors_valid: bool, inputs_valid: bool, filter_initialized: bool):
     state, cov = self.kf.x, self.kf.P
     std = np.sqrt(np.diag(cov))
-    filter_time_valid = np.isfinite(self.kf.t)
-    filter_valid = filter_valid and filter_time_valid
+    filter_time_valid = bool(np.isfinite(self.kf.t))
+    filter_valid = filter_initialized and filter_time_valid
 
     orientation_ned, orientation_ned_std = state[States.NED_ORIENTATION], std[States.NED_ORIENTATION]
     velocity_device, velocity_device_std = state[States.DEVICE_VELOCITY], std[States.DEVICE_VELOCITY]


### PR DESCRIPTION
This PR keeps `livePose.valid=false` until `self.kf.t` is finite.

After  `cameraOdometry` and sensor inputs pass readiness checks, `locationd` can set `filter_initialized=true` and publish `livePose` before the pose Kalman filter has processed an observation and initialized `self.kf.t`.

Since `livePose.timestamp` is serialized from `np.nan_to_num(self.kf.t)`, that can produce a valid `livePose` with `timestamp=0`; downstream consumers such as `paramsd` then treat that as an observation time. This can cause a huge filter time jump before paramsd applies the next yaw-rate observation once the next timestamp updates.

### Scope:
The guard introduced by this PR prevents the scenario where locationd starts or restarts with its pose filter time uninitialized while paramsd is also active, causing the bug.

The scenario where this bug could happen is:
```
> go onroad
>> locationd starts with pose filter time uninitialized
>>> modeld/cameraOdometry starts up
>>>> the car is moving before locationd publishes its first initialized livePose, paramsd is active
>>>>> locationd publishes valid livePose with timestamp=0
>>>>>> next livePose has normal timestamp (e.g. timestamp=472026.841)

then:
> `paramsd` processed `livePose` updates as if they were separated by that amount time (e.g. `472026.841s`)
>> the huge fake dt particularly affects yaw rate / stiffnessFactor
```

This was found while investigating sunnypilot issue [https://github.com/sunnypilot/sunnypilot/issues/1850](https://github.com/sunnypilot/sunnypilot/issues/1850), but the affected `locationd` / `paramsd` code is shared with upstream openpilot.  

- In that issue, the timestamp=0 livePose sets the paramsd filter time to 0; the next valid livePose then has a normal timestamp, causing a huge filter time jump before paramsd applies the next yaw-rate observation. It made stiffnessFactor fall from 1.0 to -0.021313252 in about 150ms. Causing this message to appear: `Check tires, pressure, or alignment (Factor: -0.0) Abnormal tire stiffness` and blocking engagement.

### Validation
Validation was done by replaying the failing startup sequence through `VehicleParamsLearner` with the logged `carState`, `liveCalibration`, and `livePose` inputs. 

From the real log, the valid timestamp-0 `livePose` was accepted and the replayed stiffness estimate became invalid shortly after:

| livePose time | livePose timestamp | replay stiffness | valid |
| --- | ---: | ---: | --- |
| `+13.733s` | `0.000s` | `1.000000000` | true |
| `+13.802s` | `472026.841s` | `0.910478711` | true |
| `+13.843s` | `472026.899s` | `0.710065007` | true |
| `+13.892s` | `472026.948s` | `-0.580070078` | false |

Rerunning the same replay while marking only the timestamp-0 `livePose` invalid kept `stiffnessFactor` valid:

| livePose time | livePose timestamp | simulated pose valid | replay stiffness | valid |
| --- | ---: | --- | ---: | --- |
| `+13.733s` | `0.000s` | false | `1.000000000` | true |
| `+13.802s` | `472026.841s` | true | `1.000000000` | true |
| `+13.843s` | `472026.899s` | true | `1.000000000` | true |
| `+13.892s` | `472026.948s` | true | `1.000000000` | true |

Acknowledgements:
- I acknowledge this bug happened on Sunnypilot and involves logs from a route recorded on the dev branch of SP. 
- The code that allows the bug to happen is shared between upstream stock OP and sunnypilot. 
  - Stock openpilot and sunnypilot both have the same locationd behavior: self.kf.t can be NaN, and np.nan_to_num(self.kf.t) turns that into livePose.timestamp=0. The bug ultimately stems from milisecond-level difference in paramsd ordering that both stock OP and sunnypilot should be suspecitble to in theory. 
