### PR TITLE
webrtc: initialize on medium bitrate

### DIFF
--- a/system/webrtc/webrtcd.py
+++ b/system/webrtc/webrtcd.py
@@ -144,7 +144,8 @@ class LivestreamBitrateController(AsyncTaskRunner):
     self.pc = peer_connection
     self.params = Params()
 
-    self.level = 0
+    self.level = 1
+    self._publish(self.bitrates[self.level])
     self.prev_lost, self.prev_sent = None, None
     self.counter = 0
     self.up_samples = 5 # 1s


### PR DESCRIPTION
initialize webrtc livestream bitrate controller on medium bitrate which then allows it to move quickly up or down based on connection quality