### PR TITLE
fix: webjoystick connection from firefox

### DIFF
--- a/tools/bodyteleop/static/js/controls.js
+++ b/tools/bodyteleop/static/js/controls.js
@@ -1,7 +1,7 @@
 const keyVals = {w: 0, a: 0, s: 0, d: 0}
 
 export function getXY() {
-  let x = -keyVals.w + keyVals.s
+  let x = keyVals.w - keyVals.s
   let y = -keyVals.d + keyVals.a
   return {x, y}
 }

--- a/tools/bodyteleop/static/js/webrtc.js
+++ b/tools/bodyteleop/static/js/webrtc.js
@@ -24,7 +24,8 @@ export function pingHeadRequest() {
 
 export function createPeerConnection(pc) {
   var config = {
-    sdpSemantics: 'unified-plan'
+    sdpSemantics: 'unified-plan',
+    iceServers: [{urls: 'stun:stun.l.google.com:19302'}]
   };
 
   pc = new RTCPeerConnection(config);

--- a/tools/bodyteleop/web.py
+++ b/tools/bodyteleop/web.py
@@ -56,13 +56,14 @@ async def ping(request: 'web.Request'):
 
 async def offer(request: 'web.Request'):
   params = await request.json()
-  body = StreamRequestBody(params["sdp"], "driver", ["testJoystick"], ["carState"])
+  body = StreamRequestBody(params["sdp"], "wideRoad", ["testJoystick"], ["carState"])
   body_json = json.dumps(dataclasses.asdict(body))
 
   logger.info("Sending offer to webrtcd...")
   webrtcd_url = f"http://{WEBRTCD_HOST}:{WEBRTCD_PORT}/stream"
   async with ClientSession() as session, session.post(webrtcd_url, data=body_json) as resp:
-    assert resp.status == 200
+    if resp.status != 200:
+      return web.json_response(await resp.json(), status=resp.status)
     answer = await resp.json()
     return web.json_response(answer)
 


### PR DESCRIPTION
- add STUN server to resolve mDNS issues on firefox
- flip camera to wideRoad (and controls)