### PR TITLE
set max cpu core frequency

### DIFF
--- a/system/hardware/tici/hardware.py
+++ b/system/hardware/tici/hardware.py
@@ -313,6 +313,9 @@ class Tici(HardwareBase):
         continue
       gov = 'ondemand' if powersave_enabled else 'performance'
       sudo_write(gov, f'/sys/devices/system/cpu/cpufreq/policy{n}/scaling_governor')
+      if not powersave_enabled:
+        # cap max core freq to 1689 Mhz
+        sudo_write('1689600', f'/sys/devices/system/cpu/cpufreq/policy{n}/scaling_max_freq')
 
     # *** IRQ config ***
 


### PR DESCRIPTION
Limit max cpu core frequency, fixes a bug where agnos-builder set frequency to 2.6Ghz and big cluster would stay at that frequency, generating excessive heat.