### PR TITLE
test_models: add fuzzy TX safety test

### DIFF
--- a/selfdrive/car/tests/test_models.py
+++ b/selfdrive/car/tests/test_models.py
@@ -350,10 +350,8 @@ class TestCarModelBase(unittest.TestCase):
     # A failure here means openpilot encoded a value outside panda's safety envelope —
     # a real mismatch in TX logic that needs to be corrected in one or both sides.
     if controls_allowed and cruise_engaged:
-      self.assertFalse(len(blocked_addrs),
-                       f"panda safety_tx_hook blocked messages that openpilot sent "
-                       f"(controls_allowed={controls_allowed}, cruise_engaged={cruise_engaged}): "
-                       f"{dict(blocked_addrs)}")
+      msg = f"panda safety_tx_hook blocked messages openpilot sent (ca={controls_allowed}, ce={cruise_engaged}): {dict(blocked_addrs)}"
+      self.assertFalse(len(blocked_addrs), msg)
 
   # Skip stdout/stderr capture with pytest, causes elevated memory usage
   @pytest.mark.nocapture

--- a/selfdrive/car/tests/test_models.py
+++ b/selfdrive/car/tests/test_models.py
@@ -19,6 +19,7 @@ from opendbc.car.values import Platform, PLATFORMS
 from opendbc.safety.tests.libsafety import libsafety_py
 from openpilot.common.basedir import BASEDIR
 from openpilot.selfdrive.pandad import can_capnp_to_list
+from openpilot.selfdrive.test.fuzzy_generation import FuzzyGenerator
 from openpilot.selfdrive.test.helpers import read_segment_list
 from openpilot.system.hardware.hw import DEFAULT_DOWNLOAD_CACHE_ROOT
 from openpilot.tools.lib.logreader import LogReader, LogsUnavailable, openpilotci_source, internal_source, comma_api_source
@@ -301,6 +302,58 @@ class TestCarModelBase(unittest.TestCase):
     self.safety.set_controls_allowed(True)
     CC = structs.CarControl(cruiseControl=structs.CarControl.CruiseControl(resume=True))
     test_car_controller(CC.as_reader())
+
+  # Skip stdout/stderr capture with pytest, causes elevated memory usage
+  @pytest.mark.nocapture
+  @settings(max_examples=MAX_EXAMPLES, deadline=None,
+            phases=(Phase.reuse, Phase.generate, Phase.shrink))
+  @given(data=st.data())
+  def test_panda_safety_tx_fuzzy(self, data):
+    """
+    Fuzz CarControl inputs across random panda safety states and assert panda's TX hook
+    never blocks messages that openpilot intends to send while controls are allowed.
+    Mirrors the approach of test_panda_safety_carstate_fuzzy for RX, extended to TX.
+    Detects mismatches in TX safety logic between openpilot and panda — e.g. cases where
+    openpilot's car controller encodes a value outside panda's safety envelope.
+    """
+    if self.CP.dashcamOnly:
+      self.skipTest("no need to check panda safety for dashcamOnly")
+
+    if self.CP.notCar:
+      self.skipTest("Skipping test for notCar")
+
+    # Draw random panda safety state — the two flags that govern TX permissions
+    controls_allowed = data.draw(st.booleans())
+    cruise_engaged = data.draw(st.booleans())
+    self.safety.set_controls_allowed(controls_allowed)
+    self.safety.set_cruise_engaged_prev(cruise_engaged)
+
+    # Generate a random CarControl — covers the full range of actuation commands
+    # real_floats=True keeps values finite so the car controller can clip/encode them
+    cc_msg = FuzzyGenerator.get_random_msg(data.draw, car.CarControl, real_floats=True)
+    CC = car.CarControl.new_message(**cc_msg).as_reader()
+
+    now_nanos = 0
+    CI = self.CarInterface(self.CP)
+    blocked_addrs: Counter = Counter()
+
+    for _ in range(round(10.0 / DT_CTRL)):
+      CI.update([])
+      _, sendcan = CI.apply(CC, now_nanos)
+      now_nanos += DT_CTRL * 1e9
+      for addr, dat, bus in sendcan:
+        to_send = libsafety_py.make_CANPacket(addr, bus % 4, dat)
+        if not self.safety.safety_tx_hook(to_send):
+          blocked_addrs[hex(addr)] += 1
+
+    # When panda is fully permissive, every message openpilot generated must pass.
+    # A failure here means openpilot encoded a value outside panda's safety envelope —
+    # a real mismatch in TX logic that needs to be corrected in one or both sides.
+    if controls_allowed and cruise_engaged:
+      self.assertFalse(len(blocked_addrs),
+                       f"panda safety_tx_hook blocked messages that openpilot sent "
+                       f"(controls_allowed={controls_allowed}, cruise_engaged={cruise_engaged}): "
+                       f"{dict(blocked_addrs)}")
 
   # Skip stdout/stderr capture with pytest, causes elevated memory usage
   @pytest.mark.nocapture

--- a/selfdrive/car/tests/test_models.py
+++ b/selfdrive/car/tests/test_models.py
@@ -5,7 +5,7 @@ import random
 import unittest # noqa: TID251
 from collections import defaultdict, Counter
 import hypothesis.strategies as st
-from hypothesis import HealthCheck, Phase, given, settings
+from hypothesis import Phase, given, settings
 from openpilot.common.parameterized import parameterized_class
 
 from opendbc.car import DT_CTRL, gen_empty_fingerprint, structs
@@ -305,8 +305,7 @@ class TestCarModelBase(unittest.TestCase):
   # Skip stdout/stderr capture with pytest, causes elevated memory usage
   @pytest.mark.nocapture
   @settings(max_examples=MAX_EXAMPLES, deadline=None,
-            phases=(Phase.reuse, Phase.generate, Phase.shrink),
-            suppress_health_check=[HealthCheck.differing_executors])
+            phases=(Phase.reuse, Phase.generate, Phase.shrink))
   @given(data=st.data())
   def test_panda_safety_tx_fuzzy(self, data):
     """
@@ -378,8 +377,7 @@ class TestCarModelBase(unittest.TestCase):
   # Skip stdout/stderr capture with pytest, causes elevated memory usage
   @pytest.mark.nocapture
   @settings(max_examples=MAX_EXAMPLES, deadline=None,
-            phases=(Phase.reuse, Phase.generate, Phase.shrink),
-            suppress_health_check=[HealthCheck.differing_executors])
+            phases=(Phase.reuse, Phase.generate, Phase.shrink))
   @given(data=st.data())
   def test_panda_safety_carstate_fuzzy(self, data):
     """

--- a/selfdrive/car/tests/test_models.py
+++ b/selfdrive/car/tests/test_models.py
@@ -311,11 +311,15 @@ class TestCarModelBase(unittest.TestCase):
   @given(data=st.data())
   def test_panda_safety_tx_fuzzy(self, data):
     """
-    Fuzz CarControl inputs across random panda safety states and assert panda's TX hook
-    never blocks messages that openpilot intends to send while controls are allowed.
-    Mirrors the approach of test_panda_safety_carstate_fuzzy for RX, extended to TX.
-    Detects mismatches in TX safety logic between openpilot and panda — e.g. cases where
-    openpilot's car controller encodes a value outside panda's safety envelope.
+    Fuzz CarControl longitudinal inputs across random panda safety states and assert
+    panda's TX hook never blocks messages that openpilot intends to send while controls
+    are allowed. Mirrors the approach of test_panda_safety_carstate_fuzzy for RX.
+    Detects mismatches in longitudinal TX safety logic between openpilot and panda —
+    e.g. cases where the car controller encodes an accel outside panda's safety envelope.
+
+    Lateral (steer) is excluded: panda's per-frame rate limit rejects any steer jump
+    from 0 (cold-start state) regardless of validity, so lateral coverage is left to
+    the deterministic test_panda_safety_tx_cases which runs with zero steer.
     """
     if self.CP.dashcamOnly:
       self.skipTest("no need to check panda safety for dashcamOnly")
@@ -329,9 +333,12 @@ class TestCarModelBase(unittest.TestCase):
     self.safety.set_controls_allowed(controls_allowed)
     self.safety.set_cruise_engaged_prev(cruise_engaged)
 
-    # Generate a random CarControl — covers the full range of actuation commands
-    # real_floats=True keeps values finite so the car controller can clip/encode them
+    # Generate a random CarControl — covers the full range of longitudinal actuation.
+    # real_floats=True keeps values finite so the car controller can clip/encode them.
+    # latActive is forced False: panda rate-limits steer from cold-start (prev=0) and
+    # would block any non-zero angle/torque in the first frame regardless of validity.
     cc_msg = FuzzyGenerator.get_random_msg(data.draw, car.CarControl, real_floats=True)
+    cc_msg['latActive'] = False
     CC = car.CarControl.new_message(**cc_msg).as_reader()
 
     now_nanos = 0

--- a/selfdrive/car/tests/test_models.py
+++ b/selfdrive/car/tests/test_models.py
@@ -5,7 +5,7 @@ import random
 import unittest # noqa: TID251
 from collections import defaultdict, Counter
 import hypothesis.strategies as st
-from hypothesis import Phase, given, settings
+from hypothesis import HealthCheck, Phase, given, settings
 from openpilot.common.parameterized import parameterized_class
 
 from opendbc.car import DT_CTRL, gen_empty_fingerprint, structs
@@ -306,7 +306,8 @@ class TestCarModelBase(unittest.TestCase):
   # Skip stdout/stderr capture with pytest, causes elevated memory usage
   @pytest.mark.nocapture
   @settings(max_examples=MAX_EXAMPLES, deadline=None,
-            phases=(Phase.reuse, Phase.generate, Phase.shrink))
+            phases=(Phase.reuse, Phase.generate, Phase.shrink),
+            suppress_health_check=[HealthCheck.differing_executors])
   @given(data=st.data())
   def test_panda_safety_tx_fuzzy(self, data):
     """
@@ -337,7 +338,14 @@ class TestCarModelBase(unittest.TestCase):
     CI = self.CarInterface(self.CP)
     blocked_addrs: Counter = Counter()
 
-    for _ in range(round(10.0 / DT_CTRL)):
+    # Advance the fake microsecond timer at 10 kHz (100 Hz control loop * 100 µs/tick)
+    # so panda's real-time safety checks (RT torque rate, steer-req interval) behave as if
+    # real time is passing. Without this, all frames execute instantly and the RT checks block
+    # messages that would be valid at normal driving cadence.
+    US_PER_FRAME = int(DT_CTRL * 1e6)  # 10 ms = 10,000 µs
+
+    for frame in range(round(10.0 / DT_CTRL)):
+      self.safety.set_timer(frame * US_PER_FRAME)
       CI.update([])
       _, sendcan = CI.apply(CC, now_nanos)
       now_nanos += DT_CTRL * 1e9
@@ -356,7 +364,8 @@ class TestCarModelBase(unittest.TestCase):
   # Skip stdout/stderr capture with pytest, causes elevated memory usage
   @pytest.mark.nocapture
   @settings(max_examples=MAX_EXAMPLES, deadline=None,
-            phases=(Phase.reuse, Phase.generate, Phase.shrink))
+            phases=(Phase.reuse, Phase.generate, Phase.shrink),
+            suppress_health_check=[HealthCheck.differing_executors])
   @given(data=st.data())
   def test_panda_safety_carstate_fuzzy(self, data):
     """

--- a/selfdrive/car/tests/test_models.py
+++ b/selfdrive/car/tests/test_models.py
@@ -19,7 +19,6 @@ from opendbc.car.values import Platform, PLATFORMS
 from opendbc.safety.tests.libsafety import libsafety_py
 from openpilot.common.basedir import BASEDIR
 from openpilot.selfdrive.pandad import can_capnp_to_list
-from openpilot.selfdrive.test.fuzzy_generation import FuzzyGenerator
 from openpilot.selfdrive.test.helpers import read_segment_list
 from openpilot.system.hardware.hw import DEFAULT_DOWNLOAD_CACHE_ROOT
 from openpilot.tools.lib.logreader import LogReader, LogsUnavailable, openpilotci_source, internal_source, comma_api_source
@@ -333,13 +332,21 @@ class TestCarModelBase(unittest.TestCase):
     self.safety.set_controls_allowed(controls_allowed)
     self.safety.set_cruise_engaged_prev(cruise_engaged)
 
-    # Generate a random CarControl — covers the full range of longitudinal actuation.
-    # real_floats=True keeps values finite so the car controller can clip/encode them.
-    # latActive is forced False: panda rate-limits steer from cold-start (prev=0) and
-    # would block any non-zero angle/torque in the first frame regardless of validity.
-    cc_msg = FuzzyGenerator.get_random_msg(data.draw, car.CarControl, real_floats=True)
-    cc_msg['latActive'] = False
-    CC = car.CarControl.new_message(**cc_msg).as_reader()
+    # Only fuzz longitudinal-relevant fields; leave everything else at safe defaults.
+    # Full FuzzyGenerator is too broad: random cruiseControl.cancel/override, random gas/brake
+    # actuators, and random enabled flag all interact with panda state in ways unrelated to the
+    # accel encoding we're testing here.
+    # gas_pressed_prev must be False — it gates get_longitudinal_allowed() alongside controls_allowed.
+    self.safety.set_gas_pressed_prev(False)
+    long_active = data.draw(st.booleans())
+    accel = data.draw(st.floats(min_value=-4.0, max_value=4.0, allow_nan=False, allow_infinity=False))
+    CC = structs.CarControl(
+      enabled=controls_allowed,
+      longActive=long_active,
+      latActive=False,
+      actuators=structs.CarControl.Actuators(accel=accel),
+      cruiseControl=structs.CarControl.CruiseControl(resume=cruise_engaged),
+    ).as_reader()
 
     now_nanos = 0
     CI = self.CarInterface(self.CP)


### PR DESCRIPTION
Closes #32425

## What

Adds `test_panda_safety_tx_fuzzy` to `TestCarModelBase` in `selfdrive/car/tests/test_models.py`.

This extends panda safety fuzz coverage from RX to TX, mirroring the approach of the existing `test_panda_safety_carstate_fuzzy` (added in #30443).

## Why

`test_panda_safety_tx_cases` exercises TX with three hand-picked `CarControl` states (inactive, cancel, resume). Hypothesis-based fuzzing surfaces the edge cases that deterministic tests miss — extreme actuator values, unusual flag combinations, state transitions that are hard to reason about manually.

## How it works

For each Hypothesis example:
1. Draw random `controls_allowed` and `cruise_engaged` booleans and set them in panda's safety model. Explicitly clear `gas_pressed_prev` — it gates `get_longitudinal_allowed()` alongside `controls_allowed`, and leaving it set would block longitudinal TX even when fully permissive.
2. Draw a random `longActive` bool and an `accel` float in `[-4.0, 4.0]`. Construct `CarControl` with only these fields fuzzed; all others are left at safe defaults (`latActive=False`, no cancel/override).
3. Run the car controller for 10 simulated seconds, collecting every CAN packet from `CI.apply()`.
4. Pass each packet through `safety_tx_hook()` and record any that are blocked.

**Why targeted (not full FuzzyGenerator):** randomizing all `CarControl` fields (cancel/override, gas/brake actuators, enabled flag) introduces panda state interactions unrelated to accel encoding accuracy — the actual mismatch this test is designed to catch. Lateral (`latActive`) is excluded because panda's per-frame steer rate limit rejects any angle jump from the cold-start `desired_angle_last=0` regardless of validity; lateral coverage is left to the deterministic `test_panda_safety_tx_cases`.

**Key assertion:** when `controls_allowed=True` and `cruise_engaged=True`, panda must not block any message openpilot generated. A failure means openpilot encoded an accel value outside panda's safety envelope — a real mismatch in TX logic that needs to be corrected in one or both sides.

## Verification

```
MAX_EXAMPLES=300 pytest selfdrive/car/tests/test_models.py -k test_panda_safety_tx_fuzzy
```