### PR TITLE
car: match stock Hyundai longitudinal button behavior (#30950)

### DIFF
--- a/selfdrive/car/car_specific.py
+++ b/selfdrive/car/car_specific.py
@@ -1,6 +1,7 @@
 from cereal import car, log
 from opendbc.car import DT_CTRL, structs
 from opendbc.car.car_helpers import interfaces
+from opendbc.car.hyundai.values import HyundaiFlags
 from opendbc.car.interfaces import MAX_CTRL_SPEED
 from opendbc.car.toyota.values import ToyotaFlags
 
@@ -20,6 +21,10 @@ class CarSpecificEvents:
     self.low_speed_alert = False
     self.no_steer_warning = False
     self.silent_steer_warning = True
+
+    # Hyundai openpilot longitudinal button state (see issue #30950)
+    self._hyundai_cruise_speed_set = False  # True after Set is pressed
+    self._hyundai_cruise_paused = False     # True after pause/resume (CAN FD) pauses cruise
 
   def update(self, CS: car.CarState, CS_prev: car.CarState, CC: car.CarControl):
     if self.CP.brand in ('body', 'mock'):
@@ -89,6 +94,47 @@ class CarSpecificEvents:
       # TODO: this needs to be implemented generically in carState struct
       # if CC.eps_timer_soft_disable_alert:
       #   events.add(EventName.steerTimeLimit)
+
+    elif self.CP.brand == 'hyundai' and not self.CP.pcmCruise:
+      # Match stock Hyundai longitudinal button behavior (#30950):
+      # - Resume is blocked until Set is first pressed (speed must be set before resuming)
+      # - On CAN FD, the cancel/button-4 is a pause/resume toggle rather than a hard cancel
+      is_canfd = bool(self.CP.flags & HyundaiFlags.CANFD)
+
+      had_speed_set = self._hyundai_cruise_speed_set
+      was_paused = self._hyundai_cruise_paused
+
+      for b in CS.buttonEvents:
+        if b.type == ButtonType.decelCruise and not b.pressed:
+          self._hyundai_cruise_speed_set = True
+          self._hyundai_cruise_paused = False
+        elif b.type == ButtonType.accelCruise and not b.pressed:
+          if self._hyundai_cruise_speed_set:
+            self._hyundai_cruise_paused = False
+        elif b.type == ButtonType.cancel and not b.pressed:
+          if is_canfd and self._hyundai_cruise_speed_set:
+            self._hyundai_cruise_paused = not was_paused  # toggle pause state
+          else:
+            self._hyundai_cruise_speed_set = False
+            self._hyundai_cruise_paused = False
+        elif b.type == ButtonType.mainCruise:
+          self._hyundai_cruise_speed_set = False
+          self._hyundai_cruise_paused = False
+
+      is_set = any(b.type == ButtonType.decelCruise and not b.pressed for b in CS.buttonEvents)
+      is_resume = any(b.type == ButtonType.accelCruise and not b.pressed for b in CS.buttonEvents)
+      is_cancel = any(b.type == ButtonType.cancel and not b.pressed for b in CS.buttonEvents)
+
+      button_enable = (
+        is_set or
+        (is_resume and had_speed_set and not was_paused) or
+        (is_cancel and is_canfd and was_paused and had_speed_set)
+      )
+
+      if EventName.buttonEnable in events.events:
+        events.events.remove(EventName.buttonEnable)
+      if button_enable:
+        events.add(EventName.buttonEnable)
 
     return events
 

--- a/selfdrive/car/tests/test_hyundai_button_logic.py
+++ b/selfdrive/car/tests/test_hyundai_button_logic.py
@@ -1,0 +1,136 @@
+"""Tests for Hyundai stock longitudinal button behavior (#30950):
+  - Resume blocked until Set is pressed first
+  - CAN FD: cancel/button-4 is a pause/resume toggle
+"""
+import pytest
+from cereal import car, log
+from opendbc.car import structs
+from opendbc.car import gen_empty_fingerprint
+from opendbc.car.hyundai.interface import CarInterface
+from opendbc.car.hyundai.values import CAR
+from openpilot.selfdrive.car.car_specific import CarSpecificEvents
+
+ButtonType = structs.CarState.ButtonEvent.Type
+EventName = log.OnroadEvent.EventName
+
+
+def _make_btn(btn_type, pressed=False):
+  b = structs.CarState.ButtonEvent()
+  b.type = btn_type
+  b.pressed = pressed
+  return b
+
+
+def _make_cs(button_events, button_enable=False):
+  cs = car.CarState.new_message()
+  cs.buttonEnable = button_enable
+  if button_events:
+    btns = cs.init('buttonEvents', len(button_events))
+    for i, b in enumerate(button_events):
+      btns[i].type = b.type
+      btns[i].pressed = b.pressed
+  return cs
+
+
+def _make_spec(car_model, pcm_cruise=False):
+  CP = CarInterface.get_params(car_model, gen_empty_fingerprint(), [], False, False, False)
+  CP.pcmCruise = pcm_cruise
+  return CarSpecificEvents(CP)
+
+
+class TestHyundaiButtonLogicCAN:
+  """CAN (non-FD) Hyundai openpilot long: resume blocked until Set pressed."""
+
+  @pytest.fixture(autouse=True)
+  def setup(self):
+    self.spec = _make_spec(CAR.HYUNDAI_SONATA)
+    self.cc = car.CarControl.new_message()
+    self.cs_prev = _make_cs([])
+
+  def _run(self, buttons, button_enable=False):
+    cs = _make_cs(buttons, button_enable)
+    events = self.spec.update(cs, self.cs_prev, self.cc)
+    return EventName.buttonEnable in events.events
+
+  def test_resume_blocked_before_set(self):
+    assert not self._run([_make_btn(ButtonType.accelCruise)], button_enable=True)
+
+  def test_set_always_enables(self):
+    assert self._run([_make_btn(ButtonType.decelCruise)], button_enable=True)
+
+  def test_resume_after_set(self):
+    self._run([_make_btn(ButtonType.decelCruise)], button_enable=True)
+    assert self._run([_make_btn(ButtonType.accelCruise)], button_enable=True)
+
+  def test_cancel_resets_and_blocks_resume(self):
+    self._run([_make_btn(ButtonType.decelCruise)], button_enable=True)
+    self._run([_make_btn(ButtonType.cancel)])
+    assert not self._run([_make_btn(ButtonType.accelCruise)], button_enable=True)
+
+  def test_main_resets_and_blocks_resume(self):
+    self._run([_make_btn(ButtonType.decelCruise)], button_enable=True)
+    self._run([_make_btn(ButtonType.mainCruise, pressed=True)])
+    assert not self._run([_make_btn(ButtonType.accelCruise)], button_enable=True)
+
+  def test_set_after_cancel_reenables(self):
+    self._run([_make_btn(ButtonType.decelCruise)], button_enable=True)
+    self._run([_make_btn(ButtonType.cancel)])
+    assert self._run([_make_btn(ButtonType.decelCruise)], button_enable=True)
+
+
+class TestHyundaiButtonLogicCANFD:
+  """CAN FD Hyundai openpilot long: button-4 is pause/resume toggle."""
+
+  @pytest.fixture(autouse=True)
+  def setup(self):
+    self.spec = _make_spec(CAR.KIA_EV6)
+    self.cc = car.CarControl.new_message()
+    self.cs_prev = _make_cs([])
+
+  def _run(self, buttons, button_enable=False):
+    cs = _make_cs(buttons, button_enable)
+    events = self.spec.update(cs, self.cs_prev, self.cc)
+    return EventName.buttonEnable in events.events
+
+  def test_resume_blocked_before_set(self):
+    assert not self._run([_make_btn(ButtonType.accelCruise)], button_enable=True)
+
+  def test_set_enables(self):
+    assert self._run([_make_btn(ButtonType.decelCruise)], button_enable=True)
+
+  def test_cancel_pauses_after_set(self):
+    self._run([_make_btn(ButtonType.decelCruise)], button_enable=True)
+    assert not self._run([_make_btn(ButtonType.cancel)])
+
+  def test_cancel_resumes_after_pause(self):
+    self._run([_make_btn(ButtonType.decelCruise)], button_enable=True)
+    self._run([_make_btn(ButtonType.cancel)])
+    assert self._run([_make_btn(ButtonType.cancel)])
+
+  def test_cancel_without_speed_does_not_enable(self):
+    assert not self._run([_make_btn(ButtonType.cancel)])
+
+  def test_main_clears_pause_state(self):
+    self._run([_make_btn(ButtonType.decelCruise)], button_enable=True)
+    self._run([_make_btn(ButtonType.cancel)])
+    self._run([_make_btn(ButtonType.mainCruise, pressed=True)])
+    assert not self._run([_make_btn(ButtonType.cancel)])
+
+  def test_pause_resume_multiple_cycles(self):
+    self._run([_make_btn(ButtonType.decelCruise)], button_enable=True)
+    assert not self._run([_make_btn(ButtonType.cancel)])
+    assert self._run([_make_btn(ButtonType.cancel)])
+    assert not self._run([_make_btn(ButtonType.cancel)])
+    assert self._run([_make_btn(ButtonType.cancel)])
+
+
+class TestHyundaiButtonLogicPCMCruise:
+  """PCM cruise (non-alpha-long) should not be affected."""
+
+  def test_pcm_cruise_not_affected(self):
+    spec = _make_spec(CAR.HYUNDAI_SONATA, pcm_cruise=True)
+    cc = car.CarControl.new_message()
+    cs = _make_cs([_make_btn(ButtonType.accelCruise)], button_enable=False)
+    cs_prev = _make_cs([])
+    events = spec.update(cs, cs_prev, cc)
+    assert EventName.buttonEnable not in events.events


### PR DESCRIPTION
Closes #30950

  Implements stock Hyundai SCC button behavior for openpilot-longitudinal (non-PCM) cars:

  - **Resume blocked until Set pressed first**: pressing Resume/accelCruise before Set/decelCruise is
  a no-op (matches stock behavior where a target speed must exist before resuming)
  - **CAN FD cancel button is a pause/resume toggle**: on CAN FD cars, button-4 (cancel) toggles
  paused/resumed instead of hard-cancelling, matching stock HKG SCC pause/resume behavior
  - **PCM cruise unaffected**: cars running stock PCM/SCC (pcmCruise=True) bypass this logic entirely

  ### Implementation

  State machine added to `CarSpecificEvents` in `selfdrive/car/car_specific.py`:
  - `_hyundai_cruise_speed_set`: True once Set has been pressed; cleared by cancel (CAN) or main
  button
  - `_hyundai_cruise_paused`: True when CAN FD cancel puts cruise in paused state; toggles on each
  cancel press

  The `buttonEnable` event from `create_common_events` is suppressed and replaced with logic-gated
  version.

  ### Tests

  14 new pytest tests in `selfdrive/car/tests/test_hyundai_button_logic.py` covering:
  - CAN cars: resume-blocked-before-set, set-always-enables, resume-after-set, cancel/main reset
  - CAN FD cars: pause/resume toggle, multiple cycles, state cleanup on main button
  - PCM cruise passthrough (no regression)