### PR TITLE
cabana: fix "seperated" typo in findsignal placeholders

### DIFF
--- a/tools/cabana/tools/findsignal.cc
+++ b/tools/cabana/tools/findsignal.cc
@@ -98,9 +98,9 @@ FindSignalDlg::FindSignalDlg(QWidget *parent) : QDialog(parent, Qt::WindowFlags(
   message_group = new QGroupBox(tr("Messages"), this);
   QFormLayout *message_layout = new QFormLayout(message_group);
   message_layout->addRow(tr("Bus"), bus_edit = new QLineEdit());
-  bus_edit->setPlaceholderText(tr("comma-seperated values. Leave blank for all"));
+  bus_edit->setPlaceholderText(tr("comma-separated values. Leave blank for all"));
   message_layout->addRow(tr("Address"), address_edit = new QLineEdit());
-  address_edit->setPlaceholderText(tr("comma-seperated hex values. Leave blank for all"));
+  address_edit->setPlaceholderText(tr("comma-separated hex values. Leave blank for all"));
   QHBoxLayout *hlayout = new QHBoxLayout();
   hlayout->addWidget(first_time_edit = new QLineEdit("0"));
   hlayout->addWidget(new QLabel("-"));


### PR DESCRIPTION
**Description**

Fixes a spelling typo in cabana's "Find Signal" tool. The Bus and Address input placeholders read "comma-seperated"; corrected to "comma-separated".

`tools/cabana/tools/findsignal.cc`: corrected the two `setPlaceholderText` strings. Text-only change inside Qt `tr()`, with no logic or behavior change.

**Verification**

Spelling-only edit with no functional impact. Verified via GitHub code search that this was the only occurrence of "comma-seperated" in the repo.