### PR TITLE
radard: fall back to model lead if any radar error

### DIFF
--- a/selfdrive/controls/radard.py
+++ b/selfdrive/controls/radard.py
@@ -208,7 +208,10 @@ class RadarD:
       self.v_ego_hist.append(self.v_ego)
       self.last_v_ego_frame = sm.recv_frame['carState']
 
-    ar_pts = {pt.trackId: [pt.dRel, pt.yRel, pt.vRel, pt.measured] for pt in rr.points}
+    if any(rr.errors.to_dict().values()):
+      ar_pts = {}
+    else:
+      ar_pts = {pt.trackId: [pt.dRel, pt.yRel, pt.vRel, pt.measured] for pt in rr.points}
 
     # *** remove missing points from meta data ***
     for ids in list(self.tracks.keys()):

--- a/selfdrive/selfdrived/events.py
+++ b/selfdrive/selfdrived/events.py
@@ -876,8 +876,8 @@ EVENTS: dict[int, dict[str, Alert | AlertCallbackType]] = {
   },
 
   EventName.radarTempUnavailable: {
-    ET.SOFT_DISABLE: soft_disable_alert("Radar Temporarily Unavailable"),
-    ET.NO_ENTRY: NoEntryAlert("Radar Temporarily Unavailable"),
+    # ET.SOFT_DISABLE: soft_disable_alert("Radar Temporarily Unavailable"),
+    # ET.NO_ENTRY: NoEntryAlert("Radar Temporarily Unavailable"),
   },
 
   # Every frame from the camera should be processed by the model. If modeld


### PR DESCRIPTION
Falls back to model long, not sure if we want to show this in the UI whatsoever?

before: any error -> soft disable and no entry
after: same except radar temp unavail -> silent (doesn't feel right?)

only two brands will implement this right now:

- ford: no radar in reverse, already can't engage
- toyota: can drop out when coming to stop, model lead should be good enough, especially after re-training with this data removed

@adeebshihadeh I'm adding the toyota points dropout signal to opendbc to keep the training generic, but we need to decide how to handle this in openpilot. do you have any UI ideas besides just silently falling back to model? this affects mostly non-US TSS2