### PR TITLE
sim: use wall-clock time for IMU timestamps

### DIFF
--- a/tools/sim/lib/simulated_sensors.py
+++ b/tools/sim/lib/simulated_sensors.py
@@ -23,13 +23,13 @@ class SimulatedSensors:
   def send_imu_message(self, simulator_state: 'SimulatorState'):
     for _ in range(5):
       dat = messaging.new_message('accelerometer', valid=True)
-      dat.accelerometer.timestamp = dat.logMonoTime  # TODO: use the IMU timestamp
+      dat.accelerometer.timestamp = int(time.time() * 1e9)  # nanoseconds
       dat.accelerometer.init('acceleration')
       dat.accelerometer.acceleration.v = [simulator_state.imu.accelerometer.x, simulator_state.imu.accelerometer.y, simulator_state.imu.accelerometer.z]
       self.pm.send('accelerometer', dat)
 
       dat = messaging.new_message('gyroscope', valid=True)
-      dat.gyroscope.timestamp = dat.logMonoTime  # TODO: use the IMU timestamp
+      dat.gyroscope.timestamp = int(time.time() * 1e9)  # nanoseconds
       dat.gyroscope.init('gyroUncalibrated')
       dat.gyroscope.gyroUncalibrated.v = [simulator_state.imu.gyroscope.x, simulator_state.imu.gyroscope.y, simulator_state.imu.gyroscope.z]
       self.pm.send('gyroscope', dat)


### PR DESCRIPTION
Replace logMonoTime with time.time() for accelerometer and gyroscope timestamps, matching the approach used by GPS messages and ensuring consistent timing across simulated sensors.

This resolves the TODO comment in the code and improves consistency across simulated sensor implementations.