### PR TITLE
fix: MetaDrive sim on macOS (#33207)

### DIFF
--- a/selfdrive/modeld/SConscript
+++ b/selfdrive/modeld/SConscript
@@ -33,6 +33,11 @@ def probe_devices():
     [sys.executable, '-c', 'from tinygrad import Device\nprint("\\n".join(Device.get_available_devices()))'],
     capture_output=True, text=True, check=True).stdout.strip().splitlines())
 
+def probe_cpu_llvm():
+  return subprocess.run(
+    [sys.executable, '-c', 'import os\nos.environ["DEV"]="CPU:LLVM"\nfrom tinygrad import Tensor\n(Tensor.zeros(4)+1).realize()'],
+    capture_output=True).returncode == 0
+
 available = probe_devices()
 if 'CUDA' in available:
   tg_backend = 'CUDA'
@@ -42,7 +47,7 @@ elif 'QCOM' in available:
   tg_flags = f'DEV={tg_backend} IMAGE=1 FLOAT16=1 NOLOCALS=1 JIT_BATCH_SIZE=0 OPENPILOT_HACKS=1'
 else:
   tg_backend = 'CPU'
-  tg_flags = f'DEV=CPU' if arch == 'Darwin' else 'DEV=CPU:LLVM'
+  tg_flags = 'DEV=CPU:LLVM' if arch != 'Darwin' or probe_cpu_llvm() else 'DEV=CPU'
 
 tg_devices = { # which device to put jit inputs to at runtime
   'selfdrive.modeld.modeld': {

--- a/system/manager/process.py
+++ b/system/manager/process.py
@@ -1,4 +1,5 @@
 import importlib
+import multiprocessing
 import os
 import signal
 import time
@@ -178,7 +179,7 @@ class PythonProcess(ManagerProcess):
     self.restart_if_crash = restart_if_crash
 
   def prepare(self) -> None:
-    if self.enabled:
+    if self.enabled and multiprocessing.get_start_method() == "fork":
       cloudlog.info(f"preimporting {self.module}")
       importlib.import_module(self.module)
 

--- a/tools/sim/lib/camerad.py
+++ b/tools/sim/lib/camerad.py
@@ -1,3 +1,5 @@
+import time
+
 import numpy as np
 
 from msgq.visionipc import VisionIpcServer, VisionStreamType
@@ -64,7 +66,7 @@ class Camerad:
     return rgb_to_nv12(rgb)
 
   def _send_yuv(self, yuv, frame_id, pub_type, yuv_type):
-    eof = int(frame_id * 0.05 * 1e9)
+    eof = time.monotonic_ns()
     self.vipc_server.send(yuv_type, yuv, frame_id, eof, eof)
 
     dat = messaging.new_message(pub_type, valid=True)


### PR DESCRIPTION
Makes `pytest tools/sim/tests/test_metadrive_bridge.py` pass on macOS, no test changes. Fixes #33207. Requires commaai/metadrive#15 (without it the road is invisible to the model on macOS and the car won't drive).

Three points worked on:

- manager dies silently at startup: `prepare()` pre-imports the ui module (pyray -> Cocoa) inside the forkpty child, which aborts on macOS. Pre-importing only helps with fork start method, so skip it under spawn
- locationd rejects every cameraOdometry, so openpilot never engages: sim camerad's synthetic `eof = frame_id * 0.05` is in a different clock domain than the IMU timestamps. Stamp eof from `time.monotonic_ns()`
- modeld only hits 13Hz on plain `DEV=CPU`, starving locationd. Use `CPU:LLVM` like everywhere else, with a probe fallback since libLLVM isn't guaranteed on macOS (afaik but safer anyway)

**Verification**

Verified on M1 Pro (macOS 27 beta)
