### PR TITLE
Jenkinsfile: use SSH ControlMaster to multiplex device connections

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,7 @@ def retryWithDelay(int maxRetries, int delay, Closure body) {
 def device(String ip, String step_label, String cmd) {
   withCredentials([file(credentialsId: 'id_rsa', variable: 'key_file')]) {
     def ssh_cmd = """
-ssh -o ConnectTimeout=5 -o ServerAliveInterval=5 -o ServerAliveCountMax=2 -o BatchMode=yes -o StrictHostKeyChecking=no -i ${key_file} 'comma@${ip}' exec /usr/bin/bash <<'END'
+ssh -o ControlMaster=auto -o ControlPath=/tmp/ssh_control_%C -o ControlPersist=yes -o ConnectTimeout=5 -o ServerAliveInterval=5 -o ServerAliveCountMax=2 -o BatchMode=yes -o StrictHostKeyChecking=no -i ${key_file} 'comma@${ip}' exec /usr/bin/bash <<'END'
 
 set -e
 


### PR DESCRIPTION
20x `ssh comma@<device> true` 

|  | median | min | max |
|---|---|---|---|
| before (new connection per step) | 0.38s | 0.36s | 2.09s |
| after (muxed over master) | **0.03s** | 0.02s | 0.03s |

## Real jobs

| step | baseline | ControlMaster | delta | n per arm |
|---|---|---|---|---|
| set time | 1.46s | 0.86s | **-0.61s (-41%)** | 28 |
| git checkout | 4.96s | 4.18s | **-0.79s (-16%)** | 28 |
| check dirty | 0.82s | 0.67s | -0.15s (-18%) | 4 |
| build | 11.73s | 11.19s | -0.53s | 20 |
| build openpilot | 12.19s | 12.01s | -0.18s | 8 |
| onroad tests | 54.50s | 52.49s | -2.01s | 4 |
| test pandad | 39.91s | 39.40s | -0.51s | 8 |
| test pandad loopback | 21.48s | 20.94s | -0.54s | 4 |
| test pandad spi | 18.87s | 18.27s | -0.60s | 4 |
| test power draw | 55.38s | 54.37s | -1.01s | 4 |
| test sensord | 28.82s | 28.55s | -0.27s | 4 |
| test camerad | 31.55s | 31.17s | -0.37s | 8 |
| test manager | 6.67s | 6.06s | -0.61s | 4 |
| model replay | 52.75s | 52.58s | -0.17s | 4 |
| test amp | 12.48s | 15.44s | +2.95s | 4 |
| test encoder | 30.36s | 33.79s | +3.43s | 4 |