### PR TITLE
fix(athena): outbound rpc stuck behind low prio queue timeout

### DIFF
--- a/system/athena/athenad.py
+++ b/system/athena/athenad.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import base64
 import hashlib
 import io
+import itertools
 import json
 import os
 import queue
@@ -56,6 +57,9 @@ MAX_AGE = 31 * 24 * 3600  # seconds
 WS_FRAME_SIZE = 4096
 DEVICE_STATE_UPDATE_INTERVAL = 1.0  # in seconds
 DEFAULT_UPLOAD_PRIORITY = 99  # higher number = lower priority
+
+SEND_PRIORITY_HIGH = 0
+SEND_PRIORITY_LOW = 1
 
 # https://bytesolutions.com/dscp-tos-cos-precedence-conversion-chart,
 # https://en.wikipedia.org/wiki/Differentiated_services
@@ -126,13 +130,16 @@ class UploadItem:
 
 dispatcher["echo"] = lambda s: s
 recv_queue: Queue[str] = queue.Queue()
-send_queue: Queue[str] = queue.Queue()
+send_queue: Queue[tuple[int, int, str]] = queue.PriorityQueue()
 upload_queue: Queue[UploadItem] = queue.PriorityQueue()
-low_priority_send_queue: Queue[str] = queue.Queue()
 log_recv_queue: Queue[str] = queue.Queue()
 cancelled_uploads: set[str] = set()
 
 cur_upload_items: dict[int, UploadItem | None] = {}
+
+send_seq = itertools.count()
+def queue_send(data: str, priority: int = SEND_PRIORITY_HIGH) -> None:
+  send_queue.put_nowait((priority, next(send_seq), data)) # tie-break with a monotonic counter
 
 
 def strip_zst_extension(fn: str) -> str:
@@ -208,7 +215,7 @@ def jsonrpc_handler(end_event: threading.Event) -> None:
       if "method" in data:
         cloudlog.event("athena.jsonrpc_handler.call_method", data=data)
         response = JSONRPCResponseManager.handle(data, dispatcher)
-        send_queue.put_nowait(response.json)
+        queue_send(response.json)
       elif "id" in data and ("result" in data or "error" in data):
         log_recv_queue.put_nowait(data)
       else:
@@ -217,7 +224,7 @@ def jsonrpc_handler(end_event: threading.Event) -> None:
       pass
     except Exception as e:
       cloudlog.exception("athena jsonrpc handler failed")
-      send_queue.put_nowait(json.dumps({"error": str(e)}))
+      queue_send(json.dumps({"error": str(e)}))
 
 
 def retry_upload(tid: int, end_event: threading.Event, increase_count: bool = True) -> None:
@@ -596,7 +603,6 @@ def startStream(sdp: str) -> dict:
   except requests.ConnectionError as e:
     raise Exception("webrtc is not running. turn on comma body ignition.") from e
 
-
 @dispatcher.add_method
 def takeSnapshot() -> str | dict[str, str] | None:
   from openpilot.system.camerad.snapshot import jpeg_write, snapshot
@@ -666,7 +672,7 @@ def log_handler(end_event: threading.Event) -> None:
               "jsonrpc": "2.0",
               "id": log_entry
             }
-            low_priority_send_queue.put_nowait(json.dumps(jsonrpc))
+            queue_send(json.dumps(jsonrpc), SEND_PRIORITY_LOW)
             curr_log = log_entry
         except OSError:
           pass  # file could be deleted by log rotation
@@ -717,7 +723,7 @@ def stat_handler(end_event: threading.Event) -> None:
               "jsonrpc": "2.0",
               "id": stat_filenames[0]
             }
-            low_priority_send_queue.put_nowait(json.dumps(jsonrpc))
+            queue_send(json.dumps(jsonrpc), SEND_PRIORITY_LOW)
           os.remove(stat_path)
         last_scan = curr_scan
     except Exception:
@@ -799,10 +805,7 @@ def ws_recv(ws: WebSocket, end_event: threading.Event) -> None:
 def ws_send(ws: WebSocket, end_event: threading.Event) -> None:
   while not end_event.is_set():
     try:
-      try:
-        data = send_queue.get_nowait()
-      except queue.Empty:
-        data = low_priority_send_queue.get(timeout=1)
+      _, _, data = send_queue.get(timeout=1)
       for i in range(0, len(data), WS_FRAME_SIZE):
         frame = data[i:i+WS_FRAME_SIZE]
         last = i + WS_FRAME_SIZE >= len(data)

--- a/system/athena/athenad.py
+++ b/system/athena/athenad.py
@@ -216,7 +216,7 @@ def jsonrpc_handler(end_event: threading.Event) -> None:
       if "method" in data:
         cloudlog.event("athena.jsonrpc_handler.call_method", data=data)
         response = JSONRPCResponseManager.handle(data, dispatcher)
-        send_queue_push(response.json)
+        send_queue_push(response.json, SEND_PRIORITY_HIGH)
       elif "id" in data and ("result" in data or "error" in data):
         log_recv_queue.put_nowait(data)
       else:
@@ -225,7 +225,7 @@ def jsonrpc_handler(end_event: threading.Event) -> None:
       pass
     except Exception as e:
       cloudlog.exception("athena jsonrpc handler failed")
-      send_queue_push(json.dumps({"error": str(e)}))
+      send_queue_push(json.dumps({"error": str(e)}), SEND_PRIORITY_HIGH)
 
 
 def retry_upload(tid: int, end_event: threading.Event, increase_count: bool = True) -> None:

--- a/system/athena/athenad.py
+++ b/system/athena/athenad.py
@@ -138,7 +138,8 @@ cancelled_uploads: set[str] = set()
 cur_upload_items: dict[int, UploadItem | None] = {}
 
 send_seq = itertools.count()
-def queue_send(data: str, priority: int = SEND_PRIORITY_HIGH) -> None:
+def send_queue_push(data: str, priority: int) -> None:
+  assert priority is not None, "send queue priority must be specified"
   send_queue.put_nowait((priority, next(send_seq), data)) # tie-break with a monotonic counter
 
 
@@ -215,7 +216,7 @@ def jsonrpc_handler(end_event: threading.Event) -> None:
       if "method" in data:
         cloudlog.event("athena.jsonrpc_handler.call_method", data=data)
         response = JSONRPCResponseManager.handle(data, dispatcher)
-        queue_send(response.json)
+        send_queue_push(response.json)
       elif "id" in data and ("result" in data or "error" in data):
         log_recv_queue.put_nowait(data)
       else:
@@ -224,7 +225,7 @@ def jsonrpc_handler(end_event: threading.Event) -> None:
       pass
     except Exception as e:
       cloudlog.exception("athena jsonrpc handler failed")
-      queue_send(json.dumps({"error": str(e)}))
+      send_queue_push(json.dumps({"error": str(e)}))
 
 
 def retry_upload(tid: int, end_event: threading.Event, increase_count: bool = True) -> None:
@@ -672,7 +673,7 @@ def log_handler(end_event: threading.Event) -> None:
               "jsonrpc": "2.0",
               "id": log_entry
             }
-            queue_send(json.dumps(jsonrpc), SEND_PRIORITY_LOW)
+            send_queue_push(json.dumps(jsonrpc), SEND_PRIORITY_LOW)
             curr_log = log_entry
         except OSError:
           pass  # file could be deleted by log rotation
@@ -723,7 +724,7 @@ def stat_handler(end_event: threading.Event) -> None:
               "jsonrpc": "2.0",
               "id": stat_filenames[0]
             }
-            queue_send(json.dumps(jsonrpc), SEND_PRIORITY_LOW)
+            send_queue_push(json.dumps(jsonrpc), SEND_PRIORITY_LOW)
           os.remove(stat_path)
         last_scan = curr_scan
     except Exception:

--- a/system/athena/tests/test_athenad.py
+++ b/system/athena/tests/test_athenad.py
@@ -422,11 +422,11 @@ class TestAthenadMethods:
     try:
       # with params
       athenad.recv_queue.put_nowait(json.dumps({"method": "echo", "params": ["hello"], "jsonrpc": "2.0", "id": 0}))
-      resp = athenad.send_queue.get(timeout=3)
+      _, _, resp = athenad.send_queue.get(timeout=3)
       assert json.loads(resp) == {'result': 'hello', 'id': 0, 'jsonrpc': '2.0'}
       # without params
       athenad.recv_queue.put_nowait(json.dumps({"method": "getNetworkType", "jsonrpc": "2.0", "id": 0}))
-      resp = athenad.send_queue.get(timeout=3)
+      _, _, resp = athenad.send_queue.get(timeout=3)
       assert json.loads(resp) == {'result': 1, 'id': 0, 'jsonrpc': '2.0'}
       # log forwarding
       athenad.recv_queue.put_nowait(json.dumps({'result': {'success': 1}, 'id': 0, 'jsonrpc': '2.0'}))


### PR DESCRIPTION
Using 2 seperate high and low queues creates a hidden bug in `ws_send`. When the high priority send queue is empty, `ws_send` runs `data = low_priority_send_queue.get(timeout=1)`. When low priority queue is also empty, a new message in the high priority queue doesn't cancel the `get()` because its a different queue, and we are forced to wait until the 1 second timeout expires before the high priority queue gets and sends its message in the websocket.

We can fix this by using a `PriorityQueue` instead which will still properly send high priority messages first, but will also unblock instantly when there are no messages and a high priority message is added to the queue.

