### PR TITLE
replay: fix current time

### DIFF
--- a/tools/replay/replay.cc
+++ b/tools/replay/replay.cc
@@ -193,7 +193,7 @@ void Replay::startStream(const std::shared_ptr<Segment> segment) {
     auto event = reader.getRoot<cereal::Event>();
     uint64_t wall_time = event.getInitData().getWallTimeNanos();
     if (wall_time > 0) {
-      route_date_time_ = wall_time / 1e6;
+      route_date_time_ = wall_time / 1e9;
     }
   }
 

--- a/tools/replay/replay.h
+++ b/tools/replay/replay.h
@@ -100,7 +100,7 @@ private:
   std::atomic<bool> exit_ = false;
   std::atomic<bool> interrupt_requested_ = false;
   bool events_ready_ = false;
-  std::time_t route_date_time_;
+  std::time_t route_date_time_ = 0;
   uint64_t route_start_ts_ = 0;
   std::atomic<uint64_t> cur_mono_time_ = 0;
   cereal::Event::Which cur_which_ = cereal::Event::Which::INIT_DATA;


### PR DESCRIPTION
- `route_date_time_` was not initialized causing ctime to return NULL
- `route_date_time_` had wrong scaling, leading to wrong timestamps shown in the replay tui