### PR TITLE
webrtc: do not replace connection on prewarm

### DIFF
--- a/system/athena/athenad.py
+++ b/system/athena/athenad.py
@@ -580,7 +580,7 @@ def getNetworks():
 
 
 @dispatcher.add_method
-def startStream(sdp: str, enabled: bool | None = None) -> dict:
+def startStream(sdp: str, enabled: bool) -> dict:
   from openpilot.system.webrtc.models import StreamRequestBody
   bridge_services_in = []
 

--- a/system/athena/athenad.py
+++ b/system/athena/athenad.py
@@ -580,7 +580,7 @@ def getNetworks():
 
 
 @dispatcher.add_method
-def startStream(sdp: str, video_enabled: bool | None = None) -> dict:
+def startStream(sdp: str, enabled: bool | None = None) -> dict:
   from openpilot.system.webrtc.models import StreamRequestBody
   bridge_services_in = []
 
@@ -592,12 +592,10 @@ def startStream(sdp: str, video_enabled: bool | None = None) -> dict:
         bridge_services_in.append("testJoystick")
 
   t_start = time.monotonic()
-  body = StreamRequestBody(sdp=sdp, initCamera="wideRoad", bridge_services_in=bridge_services_in, bridge_services_out=["carState"], video_enabled=video_enabled)
+  body = StreamRequestBody(sdp=sdp, init_camera="wideRoad", bridge_services_in=bridge_services_in, bridge_services_out=["carState"], enabled=enabled)
   try:
     resp = WEBRTCD_SESS.post(f"http://localhost:{WEBRTCD_PORT}/stream", json=asdict(body), timeout=10)
     t_end = time.monotonic()
-    if not resp.ok:
-      raise Exception(resp.json().get("message", f"webrtcd returned {resp.status_code}"))
     ret = resp.json()
     ret["time"] = (t_end - t_start) * 1000
     return ret

--- a/system/manager/process_config.py
+++ b/system/manager/process_config.py
@@ -65,7 +65,7 @@ def and_(*fns):
   return lambda *args: operator.and_(*(fn(*args) for fn in fns))
 
 procs = [
-  # DaemonProcess("manage_athenad", "system.athena.manage_athenad", "AthenadPid"),
+  DaemonProcess("manage_athenad", "system.athena.manage_athenad", "AthenadPid"),
 
   NativeProcess("loggerd", "system/loggerd", ["./loggerd"], logging),
   NativeProcess("encoderd", "system/loggerd", ["./encoderd"], only_onroad),

--- a/system/manager/process_config.py
+++ b/system/manager/process_config.py
@@ -65,7 +65,7 @@ def and_(*fns):
   return lambda *args: operator.and_(*(fn(*args) for fn in fns))
 
 procs = [
-  DaemonProcess("manage_athenad", "system.athena.manage_athenad", "AthenadPid"),
+  # DaemonProcess("manage_athenad", "system.athena.manage_athenad", "AthenadPid"),
 
   NativeProcess("loggerd", "system/loggerd", ["./loggerd"], logging),
   NativeProcess("encoderd", "system/loggerd", ["./encoderd"], only_onroad),

--- a/system/webrtc/models.py
+++ b/system/webrtc/models.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass, field
 @dataclass
 class StreamRequestBody:
   sdp: str
-  initCamera: str
-  video_enabled: bool = True
+  init_camera: str
+  enabled: bool = True
   bridge_services_in: list[str] = field(default_factory=list)
   bridge_services_out: list[str] = field(default_factory=list)

--- a/system/webrtc/models.py
+++ b/system/webrtc/models.py
@@ -4,6 +4,6 @@ from dataclasses import dataclass, field
 class StreamRequestBody:
   sdp: str
   init_camera: str
-  enabled: bool = True
+  enabled: bool
   bridge_services_in: list[str] = field(default_factory=list)
   bridge_services_out: list[str] = field(default_factory=list)

--- a/system/webrtc/webrtcd.py
+++ b/system/webrtc/webrtcd.py
@@ -369,21 +369,19 @@ async def get_stream(request: 'web.Request'):
   body = StreamRequestBody(**raw_body)
 
   async with request.app['stream_lock']:
-    active = any(s.run_task and not s.run_task.done() for s in stream_dict.values())
-    if active:
-      active_enabled = any(s.run_task and not s.run_task.done() and s.enabled for s in stream_dict.values())
-      if active_enabled and body.enabled is False: # enabled = None defaults to video enabled
-        return web.json_response({"error": "busy", "message": "someone else is connected."})
+    enabled = any(s.run_task and not s.run_task.done() and s.enabled for s in stream_dict.values())
+    if enabled and body.enabled is False: # enabled = None defaults to video enabled
+      return web.json_response({"error": "busy", "message": "someone else is connected."})
 
-      for sid, s in list(stream_dict.items()):
-        if s.run_task and not s.run_task.done():
-          try:
-            ch = s.stream.get_messaging_channel()
-            ch.send(json.dumps({"type": "disconnect", "data": "Another device has connected, closing this session."}))
-          except Exception:
-            pass
-        await s.stop()
-        stream_dict.pop(sid, None)
+    for sid, s in list(stream_dict.items()):
+      if s.run_task and not s.run_task.done():
+        try:
+          ch = s.stream.get_messaging_channel()
+          ch.send(json.dumps({"type": "disconnect", "data": "Another device has connected, closing this session."}))
+        except Exception:
+          pass
+      await s.stop()
+      stream_dict.pop(sid, None)
 
     session = StreamSession(body, debug_mode)
     stream_dict[session.identifier] = session

--- a/system/webrtc/webrtcd.py
+++ b/system/webrtc/webrtcd.py
@@ -369,12 +369,10 @@ async def get_stream(request: 'web.Request'):
 
   async with request.app['stream_lock']:
     active = any(s.run_task and not s.run_task.done() for s in stream_dict.values())
-    if active and body.enabled is False: # enabled = None defaults to video enabled
-      # Don't drop existing connection on prewarm request
-      return web.json_response({"error": "busy", "message": "someone else is connected."})
-
     if active:
-      # This is a video connection; fully disconnect any other active stream before taking over.
+      if body.enabled is False: # enabled = None defaults to video enabled
+        return web.json_response({"error": "busy", "message": "someone else is connected."})
+
       for sid, s in list(stream_dict.items()):
         if s.run_task and not s.run_task.done():
           try:

--- a/system/webrtc/webrtcd.py
+++ b/system/webrtc/webrtcd.py
@@ -244,15 +244,7 @@ class LivestreamBitrateController(AsyncTaskRunner):
 class StreamSession:
   shared_pub_master = DynamicPubMaster([])
 
-  def __init__(
-    self,
-    sdp: str,
-    init_camera: str,
-    incoming_services: list[str],
-    outgoing_services: list[str],
-    enabled: bool | None = None,
-    debug_mode: bool = False
-  ):
+  def __init__(self, body: StreamRequestBody, debug_mode: bool = False):
     if debug_mode:
       from aiortc.mediastreams import VideoStreamTrack
     from openpilot.system.webrtc.device.video import LiveStreamVideoStreamTrack
@@ -260,21 +252,21 @@ class StreamSession:
 
     self.identifier = str(uuid.uuid4())
     self.params = Params()
-    builder = WebRTCAnswerBuilder(sdp)
+    builder = WebRTCAnswerBuilder(body.sdp)
 
-    self.enabled = enabled if enabled else True # default to enabled
-    self.video_track = LiveStreamVideoStreamTrack(init_camera, self.enabled) if not debug_mode else VideoStreamTrack()
-    builder.add_video_stream(init_camera, self.video_track)
+    self.enabled = body.enabled if body.enabled else True # default to enabled
+    self.video_track = LiveStreamVideoStreamTrack(body.init_camera, self.enabled) if not debug_mode else VideoStreamTrack()
+    builder.add_video_stream(body.init_camera, self.video_track)
     self.stream = builder.stream()
 
     self.incoming_bridge: CerealIncomingMessageProxy | None = None
-    self.incoming_bridge_services = incoming_services
+    self.incoming_bridge_services = body.bridge_services_in
     self.outgoing_bridge: CerealOutgoingMessageProxy | None = None
     self.bitrate_controller: LivestreamBitrateController | None = None
-    if len(incoming_services) > 0:
+    if len(body.bridge_services_in) > 0:
       self.incoming_bridge = CerealIncomingMessageProxy(self.shared_pub_master)
-    if len(outgoing_services) > 0:
-      self.outgoing_bridge = CerealOutgoingMessageProxy(outgoing_services, self.enabled)
+    if len(body.bridge_services_out) > 0:
+      self.outgoing_bridge = CerealOutgoingMessageProxy(body.bridge_services_out, self.enabled)
     self.bitrate_controller = LivestreamBitrateController(self.stream.peer_connection, self.params, self.enabled)
 
     self.run_task: asyncio.Task | None = None
@@ -283,7 +275,7 @@ class StreamSession:
     self.logger = logging.getLogger("webrtcd")
     self.logger.info(
       "New stream session (%s), init camera %s, video enabled %s, incoming services %s, outgoing services %s",
-      self.identifier, init_camera, enabled, incoming_services, outgoing_services,
+      self.identifier, body.init_camera, body.enabled, body.bridge_services_in, body.bridge_services_out,
     )
 
   def start(self):
@@ -376,18 +368,24 @@ async def get_stream(request: 'web.Request'):
   body = StreamRequestBody(**raw_body)
 
   async with request.app['stream_lock']:
-    # Fully disconnect any other active stream before starting the replacement.
-    for sid, s in list(stream_dict.items()):
-      if s.run_task and not s.run_task.done():
-        try:
-          ch = s.stream.get_messaging_channel()
-          ch.send(json.dumps({"type": "connectionReplaced", "data": "Another device has connected, closing this session."}))
-        except Exception:
-          pass
-      await s.stop()
-      stream_dict.pop(sid, None)
+    active = any(s.run_task and not s.run_task.done() for s in stream_dict.values())
+    if active and body.enabled is False: # enabled = None defaults to video enabled
+      # Don't drop existing connection on prewarm request
+      return web.json_response({"error": "busy", "message": "someone else is connected."})
 
-    session = StreamSession(body.sdp, body.initCamera, body.bridge_services_in, body.bridge_services_out, body.video_enabled, debug_mode)
+    if active:
+      # This is a video connection; fully disconnect any other active stream before taking over.
+      for sid, s in list(stream_dict.items()):
+        if s.run_task and not s.run_task.done():
+          try:
+            ch = s.stream.get_messaging_channel()
+            ch.send(json.dumps({"type": "connectionReplaced", "data": "Another device has connected, closing this session."}))
+          except Exception:
+            pass
+        await s.stop()
+        stream_dict.pop(sid, None)
+
+    session = StreamSession(body, debug_mode)
     stream_dict[session.identifier] = session
     try:
       answer = await session.get_answer()

--- a/system/webrtc/webrtcd.py
+++ b/system/webrtc/webrtcd.py
@@ -305,6 +305,7 @@ class StreamSession:
             self.bitrate_controller.set_quality(payload["data"]["quality"])
           case "livestreamVideoEnable":
             enabled = payload["data"]["enabled"]
+            self.enabled = enabled
             self.video_track.enable(enabled)
             self.outgoing_bridge.enable(enabled)
             self.bitrate_controller.enable(enabled)
@@ -370,7 +371,8 @@ async def get_stream(request: 'web.Request'):
   async with request.app['stream_lock']:
     active = any(s.run_task and not s.run_task.done() for s in stream_dict.values())
     if active:
-      if body.enabled is False: # enabled = None defaults to video enabled
+      active_enabled = any(s.run_task and not s.run_task.done() and s.enabled for s in stream_dict.values())
+      if active_enabled and body.enabled is False: # enabled = None defaults to video enabled
         return web.json_response({"error": "busy", "message": "someone else is connected."})
 
       for sid, s in list(stream_dict.items()):

--- a/system/webrtc/webrtcd.py
+++ b/system/webrtc/webrtcd.py
@@ -369,8 +369,9 @@ async def get_stream(request: 'web.Request'):
   body = StreamRequestBody(**raw_body)
 
   async with request.app['stream_lock']:
+    # don't remove existing connection on prewarm request
     enabled = any(s.run_task and not s.run_task.done() and s.enabled for s in stream_dict.values())
-    if enabled and body.enabled is False: # enabled = None defaults to video enabled
+    if enabled and not body.enabled:
       return web.json_response({"error": "busy", "message": "someone else is connected."})
 
     for sid, s in list(stream_dict.items()):

--- a/system/webrtc/webrtcd.py
+++ b/system/webrtc/webrtcd.py
@@ -254,7 +254,7 @@ class StreamSession:
     self.params = Params()
     builder = WebRTCAnswerBuilder(body.sdp)
 
-    self.enabled = body.enabled if body.enabled is not None else True # default to enabled
+    self.enabled = body.enabled
     self.video_track = LiveStreamVideoStreamTrack(body.init_camera, self.enabled) if not debug_mode else VideoStreamTrack()
     builder.add_video_stream(body.init_camera, self.video_track)
     self.stream = builder.stream()

--- a/system/webrtc/webrtcd.py
+++ b/system/webrtc/webrtcd.py
@@ -442,8 +442,6 @@ async def on_shutdown(app: 'web.Application'):
 async def error_middleware(request: 'web.Request', handler):
   try:
     return await handler(request)
-  except web.HTTPException:
-    raise  # intentional responses (400/404/etc.) pass through untouched
   except Exception as e:
     logging.getLogger("webrtcd").exception("Unhandled error handling %s", request.path)
     return web.json_response({"error": "exception", "message": f"{type(e).__name__}: {e}"}, status=500)


### PR DESCRIPTION
if a connection is opened in prewarm state (not enabled) and existing connection is enabled, do not replace the existing connection

use StreamRequestBody to clean up param passing