### PR TITLE
hardwared: don't crash on thermal sensor read errors

### DIFF
--- a/system/hardware/base.py
+++ b/system/hardware/base.py
@@ -32,19 +32,20 @@ class ThermalZone:
   zone_number = -1
 
   def read(self) -> float:
-    if self.zone_number < 0:
-      for n in os.listdir("/sys/devices/virtual/thermal"):
-        if not n.startswith("thermal_zone"):
-          continue
-        with open(os.path.join("/sys/devices/virtual/thermal", n, "type")) as f:
-          if f.read().strip() == self.name:
-            self.zone_number = int(n.removeprefix("thermal_zone"))
-            break
-
     try:
+      if self.zone_number < 0:
+        for n in os.listdir("/sys/devices/virtual/thermal"):
+          if not n.startswith("thermal_zone"):
+            continue
+          with open(os.path.join("/sys/devices/virtual/thermal", n, "type")) as f:
+            if f.read().strip() == self.name:
+              self.zone_number = int(n.removeprefix("thermal_zone"))
+              break
+
       with open(f"/sys/devices/virtual/thermal/thermal_zone{self.zone_number}/temp") as f:
         return int(f.read()) / self.scale
-    except FileNotFoundError:
+    except (OSError, ValueError):
+      # sensor read can fail when the PMIC/regmap transaction errors out; don't crash hardwared
       return 0
 
 @dataclass

--- a/system/hardware/tests/test_base.py
+++ b/system/hardware/tests/test_base.py
@@ -1,0 +1,19 @@
+import pytest
+
+from openpilot.system.hardware.base import ThermalZone
+
+
+class TestThermalZone:
+  def test_read(self, mocker):
+    mocker.patch("builtins.open", mocker.mock_open(read_data="48000"))
+    zone = ThermalZone("cpu")
+    zone.zone_number = 0
+    assert zone.read() == 48.0
+
+  @pytest.mark.parametrize("exc", [FileNotFoundError, PermissionError, OSError, ValueError])
+  def test_read_failure_does_not_raise(self, mocker, exc):
+    # a failing sensor read (e.g. a PMIC/regmap transaction error) must not crash hardwared
+    mocker.patch("builtins.open", side_effect=exc)
+    zone = ThermalZone("cpu")
+    zone.zone_number = 0
+    assert zone.read() == 0


### PR DESCRIPTION
Fixes #36690.

`ThermalZone.read()` only caught `FileNotFoundError`. When a PMIC/regmap transaction fails, reading the sysfs temp raises `OSError` (e.g. `errno 5`, as in the logs on #36690), which propagates up through `get_msg()` into `hardware_thread()` and crashes `hardwared`.

This catches `OSError` (a superset of the old `FileNotFoundError`) and `ValueError` (in case a sensor read returns garbage), and falls back to the existing `0` value so a flaky sensor read degrades gracefully instead of taking down the daemon. The zone-discovery loop is moved inside the `try` since it opens sysfs files too.

I kept the `0` fallback rather than `NaN` so the downstream `max()` / thermal-status logic in `hardwared.py` keeps working as-is; `NaN` would silently break those comparisons.

## Verification
Added `system/hardware/tests/test_base.py` covering a normal read and that each failure mode (`FileNotFoundError`, `PermissionError`, `OSError`, `ValueError`) returns `0` without raising.
