### PR TITLE
selfdrived: surface processNotRunning alert when not engaged

### DIFF
--- a/cereal/log.capnp
+++ b/cereal/log.capnp
@@ -598,7 +598,7 @@ struct PandaState @0xa7649e2575e4591e {
     interruptRateUart7 @24;
     sirenMalfunction @25;
     heartbeatLoopWatchdog @26;
-    # Update max fault type in boardd when adding faults
+    # Update max fault type in pandad when adding faults
   }
 
   enum PandaType @0x8a58adf93e5b3751 {

--- a/selfdrive/selfdrived/events.py
+++ b/selfdrive/selfdrived/events.py
@@ -867,6 +867,7 @@ EVENTS: dict[int, dict[str, Alert | AlertCallbackType]] = {
   # Thrown when manager detects a service exited unexpectedly while driving
   EventName.processNotRunning: {
     ET.NO_ENTRY: process_not_running_alert,
+    ET.PERMANENT: NormalPermanentAlert("Process Not Running", priority=Priority.LOW),
     ET.SOFT_DISABLE: soft_disable_alert("Process Not Running"),
   },
 

--- a/selfdrive/selfdrived/tests/test_alerts.py
+++ b/selfdrive/selfdrived/tests/test_alerts.py
@@ -8,11 +8,12 @@ from cereal import log, car
 from cereal.messaging import SubMaster
 from openpilot.common.basedir import BASEDIR
 from openpilot.common.params import Params
-from openpilot.selfdrive.selfdrived.events import Alert, EVENTS, ET
-from openpilot.selfdrive.selfdrived.alertmanager import set_offroad_alert
+from openpilot.selfdrive.selfdrived.events import Alert, EVENTS, ET, Events
+from openpilot.selfdrive.selfdrived.alertmanager import set_offroad_alert, AlertManager
 from openpilot.selfdrive.test.process_replay.process_replay import CONFIGS
 
 AlertSize = log.SelfdriveState.AlertSize
+EventName = log.OnroadEvent.EventName
 
 OFFROAD_ALERTS_PATH = os.path.join(BASEDIR, "selfdrive/selfdrived/alerts_offroad.json")
 
@@ -103,6 +104,32 @@ class TestAlerts:
 
         if event_type not in (ET.WARNING, ET.PERMANENT, ET.PRE_ENABLE):
           assert a.creation_delay == 0.
+
+  # processNotRunning is a controls crash; when not engaged it should be shown over a
+  # downstream fault like steerUnavailable. https://github.com/commaai/openpilot/issues/34751
+  def test_process_not_running_permanent_not_shadowed(self):
+    events = Events()
+    events.add(EventName.steerUnavailable)
+    events.add(EventName.processNotRunning)
+    callback_args = [self.CP, self.CS, self.sm, False, 100, log.LongitudinalPersonality.standard]
+    alerts = events.create_alerts([ET.PERMANENT], callback_args)
+
+    am = AlertManager()
+    am.add_many(0, alerts)
+    am.process_alerts(0, set())
+    assert am.current_alert.alert_text_1 == "Process Not Running"
+
+  # ...but when engaged, the permanent alert must NOT mask the soft disable "take control" warning
+  def test_process_not_running_permanent_does_not_mask_soft_disable(self):
+    events = Events()
+    events.add(EventName.processNotRunning)
+    callback_args = [self.CP, self.CS, self.sm, False, 100, log.LongitudinalPersonality.standard]
+    alerts = events.create_alerts([ET.PERMANENT, ET.SOFT_DISABLE], callback_args)
+
+    am = AlertManager()
+    am.add_many(0, alerts)
+    am.process_alerts(0, set())
+    assert am.current_alert.alert_text_1 == "TAKE CONTROL IMMEDIATELY"
 
   def test_offroad_alerts(self):
     params = Params()


### PR DESCRIPTION
Fixes #34751.

When a process crashes, `processNotRunning` is raised correctly, but it only had `NO_ENTRY` and `SOFT_DISABLE` alerts, no `PERMANENT` one. So when you're not engaged, the screen shows the `PERMANENT` alert of some downstream fault instead (e.g. `steerUnavailable`'s "LKAS Fault: Restart the car to engage"), which hides the real reason and sends you down the wrong path when debugging. That's exactly what happened in the issue.

This adds a `PERMANENT` alert for `processNotRunning`, at `Priority.LOW` on purpose:
- above the downstream fault's permanent alert (`LOWER`), so the real cause shows when not engaged, but
- below the soft-disable "TAKE CONTROL IMMEDIATELY" alert (`MID`), so it never hides the take-control warning if a process dies while engaged.

Added two regression tests in `test_alerts.py`: one checks `processNotRunning` wins over `steerUnavailable` when not engaged, the other checks it does NOT mask the soft-disable alert when engaged. `pytest selfdrive/selfdrived/tests/test_alerts.py` passes.