### PR TITLE
skip redundant sqrt in RunningStatFilter

### DIFF
--- a/common/stat_live.py
+++ b/common/stat_live.py
@@ -1,4 +1,4 @@
-import numpy as np
+import math
 
 class RunningStat:
   # tracks realtime mean and standard deviation without storing any data
@@ -46,7 +46,7 @@ class RunningStat:
       return 0
 
   def std(self):
-    return np.sqrt(self.variance())
+    return math.sqrt(self.variance())
 
   def params_to_save(self):
     return [self.M, self.S, self.n]
@@ -61,10 +61,12 @@ class RunningStatFilter:
     self.filtered_stat.reset()
 
   def push_and_update(self, new_data):
-    _std_last = self.raw_stat.std()
+    # std is monotonic in variance, so compare variance directly and skip the
+    # two per-update sqrt() calls (this is on dmonitoringd's 20Hz hot path).
+    _var_last = self.raw_stat.variance()
     self.raw_stat.push_data(new_data)
-    _delta_std = self.raw_stat.std() - _std_last
-    if _delta_std <= 0:
+    _delta_var = self.raw_stat.variance() - _var_last
+    if _delta_var <= 0:
       self.filtered_stat.push_data(new_data)
     else:
       pass


### PR DESCRIPTION
**Description**

`RunningStatFilter.push_and_update()` called `RunningStat.std()` twice per update only to test whether the running std increased. Since `std = sqrt(variance)` and `variance >= 0`, std is monotonic in variance, so it is equivalent to compare variance directly, removing `sqrt()` calls.
No behavior change, no API change.

**Verification**

- `delta_std <= 0` is exactly equivalent to `delta_var <= 0`: sqrt is monotonic
  on [0, inf) and variance is always >= 0.
- Confirmed empirically — filtered output (mean and count) is identical to the
  old std-delta logic using a bunch of random test inputs.