### PR TITLE
selfdrive/car/tests: add panda safety TX fuzz test

### DIFF
--- a/openpilot/selfdrive/car/tests/test_models.py
+++ b/openpilot/selfdrive/car/tests/test_models.py
@@ -12,12 +12,14 @@ from opendbc.car.can_definitions import CanData
 from opendbc.car.car_helpers import FRAME_FINGERPRINT, interfaces
 from opendbc.car.fingerprints import MIGRATION
 from opendbc.car.honda.values import HondaFlags
+from opendbc.car.interfaces import ACCEL_MIN, ACCEL_MAX
 from opendbc.car.structs import car
 from opendbc.car.tests.routes import non_tested_cars, routes, CarTestRoute
 from opendbc.car.values import Platform, PLATFORMS
 from opendbc.safety.tests.libsafety import libsafety_py
 from openpilot.common.basedir import BASEDIR
 from openpilot.selfdrive.pandad import can_capnp_to_list
+from openpilot.selfdrive.test.fuzzy_generation import FuzzyGenerator
 from openpilot.selfdrive.test.helpers import read_segment_list
 from openpilot.common.hardware.hw import DEFAULT_DOWNLOAD_CACHE_ROOT
 from openpilot.tools.lib.logreader import LogReader, LogsUnavailable, openpilotci_source, internal_source, comma_api_source
@@ -40,6 +42,9 @@ INTERNAL_SEG_LIST = os.environ.get("INTERNAL_SEG_LIST", "")
 INTERNAL_SEG_CNT = int(os.environ.get("INTERNAL_SEG_CNT", "0"))
 MAX_EXAMPLES = int(os.environ.get("MAX_EXAMPLES", "300"))
 CI = os.environ.get("CI", None) is not None
+
+MAX_CURVATURE = 0.2  # selfdrive/controls/lib/drive_helpers.py
+NUM_TX_FUZZY_FRAMES = 20
 
 
 def get_test_cases() -> list[tuple[str, CarTestRoute | None]]:
@@ -300,6 +305,68 @@ class TestCarModelBase(unittest.TestCase):
     self.safety.set_controls_allowed(True)
     CC = structs.CarControl(cruiseControl=structs.CarControl.CruiseControl(resume=True))
     test_car_controller(CC.as_reader())
+
+  # Skip stdout/stderr capture with pytest, causes elevated memory usage
+  @pytest.mark.nocapture
+  @settings(max_examples=MAX_EXAMPLES, deadline=None,
+            phases=(Phase.reuse, Phase.generate, Phase.shrink))
+  @given(data=st.data())
+  def test_panda_safety_tx_fuzzy(self, data):
+    """
+      For each example, fuzz a sequence of CarControl actuator commands and send them
+      through the car interface, checking that panda safety never blocks a message
+      openpilot generates. Catches state-history bugs (eg. panda#1948) that a single
+      fixed CarControl can't exercise.
+    """
+    if self.CP.dashcamOnly:
+      self.skipTest("no need to check panda safety for dashcamOnly")
+
+    if self.CP.notCar:
+      self.skipTest("Skipping test for notCar")
+
+    active = data.draw(st.booleans())
+    self.safety.set_controls_allowed(active)
+    self.safety.set_cruise_engaged_prev(data.draw(st.booleans()))
+
+    def get_fuzzed_actuators():
+      # structural scaffold via FuzzyGenerator handles enums + any future fields generically
+      actuators_msg = FuzzyGenerator.get_random_msg(data.draw, car.CarControl.Actuators, real_floats=True)
+      if not active:
+        # mirrors controlsd: actuators are reset/neutral when not active
+        return {'longControlState': actuators_msg['longControlState']}
+
+      # override known numeric fields with the physically realistic ranges controlsd
+      # actually enforces before calling CarController.apply() (eg. ACCEL_MIN/MAX, normalized
+      # torque, MAX_CURVATURE), since unconstrained float32 fuzzing produces inputs openpilot
+      # would never generate and panda is correct to reject. Drawn as a single fixed_dictionaries
+      # strategy (not one draw per field) to keep the number of draws per frame low.
+      actuators_msg.update(data.draw(st.fixed_dictionaries({
+        'accel': st.floats(min_value=ACCEL_MIN, max_value=ACCEL_MAX, allow_nan=False, allow_infinity=False),
+        'torque': st.floats(min_value=-1.0, max_value=1.0, allow_nan=False, allow_infinity=False),
+        'curvature': st.floats(min_value=-MAX_CURVATURE, max_value=MAX_CURVATURE, allow_nan=False, allow_infinity=False),
+        'steeringAngleDeg': st.floats(min_value=-180.0, max_value=180.0, allow_nan=False, allow_infinity=False),
+        'speed': st.floats(min_value=0.0, max_value=45.0, allow_nan=False, allow_infinity=False),
+        'gas': st.floats(min_value=0.0, max_value=1.0, allow_nan=False, allow_infinity=False),
+        'brake': st.floats(min_value=0.0, max_value=1.0, allow_nan=False, allow_infinity=False),
+      })))
+      return actuators_msg
+
+    CI = self.CarInterface(self.CP)
+    now_nanos = 0
+    msgs_sent = 0
+    for _ in range(NUM_TX_FUZZY_FRAMES):
+      CC = car.CarControl.new_message(actuators=get_fuzzed_actuators(), enabled=active,
+                                       latActive=active, longActive=active)
+      CI.update([])
+      _, sendcan = CI.apply(CC.as_reader(), now_nanos)
+      now_nanos += DT_CTRL * 1e9
+      msgs_sent += len(sendcan)
+      for addr, dat, bus in sendcan:
+        to_send = libsafety_py.make_CANPacket(addr, bus % 4, dat)
+        self.assertTrue(self.safety.safety_tx_hook(to_send), (addr, dat, bus, active))
+
+    # Make sure we attempted to send messages
+    self.assertGreater(msgs_sent, 0)
 
   # Skip stdout/stderr capture with pytest, causes elevated memory usage
   @pytest.mark.nocapture


### PR DESCRIPTION
## Goal

Closes #32425. Adds `test_panda_safety_tx_fuzzy`, fuzzing TX messages the same way `test_panda_safety_carstate_fuzzy` already fuzzes RX, so we catch state-history-dependent panda safety bugs (eg. [panda#1948](https://github.com/commaai/panda/pull/1948), a Toyota LTA torque winddown bug caused by stale torque sample windows) that the existing fixed-`CarControl` `test_panda_safety_tx_cases` can't exercise, since it never varies actuator values across frames.

## Approach

Per the issue and prior discussion ([#32572](https://github.com/commaai/openpilot/pull/32572), [#32577](https://github.com/commaai/openpilot/pull/32577)): the goal is "any control message openpilot generates, panda will accept" — not random/arbitrary byte fuzzing. So each example:
1. Toggles `active` (controls_allowed / latActive / longActive) and `cruise_engaged_prev`.
2. When inactive, sends neutral actuators (mirrors `controlsd`, which resets/zeroes actuator outputs when not active — fuzzing arbitrary torque while inactive isn't an input openpilot would ever generate).
3. When active, fuzzes a sequence of 20 `CarControl.Actuators` frames using `FuzzyGenerator` for the structural scaffold (enums + any future fields, generically/extensibly, same helper `test_car_interfaces.py` already uses), with the known numeric fields (`accel`, `torque`, `curvature`, `steeringAngleDeg`, `speed`, `gas`, `brake`) overridden to the same physically realistic bounds `controlsd` itself enforces before calling `CarController.apply()` (`ACCEL_MIN`/`ACCEL_MAX`, normalized `[-1, 1]` torque, `MAX_CURVATURE`). Unconstrained float32 fuzzing produces inputs openpilot would never generate, and panda is correct to reject those — that's not a bug.
4. Runs each frame through the actual `CarInterface.apply()` and asserts every resulting CAN message passes `safety_tx_hook`.

All draws for a frame are combined into one `st.fixed_dictionaries` strategy rather than one `data.draw()` per field, to keep Hypothesis's per-example draw count low (this matters: at higher draw counts I hit Hypothesis's `filter_too_much` health check intermittently across different platforms, with no underlying test-logic bug — purely from compounding internal retry overhead).

## Verification

Built and ran the full opendbc/panda/openpilot stack locally (compiling `libsafety` directly via `opendbc/safety/tests/libsafety/libsafety_py.py`) and ran this test against all 247 currently supported car platforms at production settings (`MAX_EXAMPLES=300`, full `reuse`/`generate`/`shrink` phases): 213 passed, 34 skipped (`dashcamOnly`/`notCar`), 0 failed. Runtime is ~15-20s/platform, matching the existing merged `test_panda_safety_carstate_fuzzy`'s budget.