### PR TITLE
ui: remove interactive timeout callback when driver camera dialog closes

### DIFF
--- a/openpilot/selfdrive/ui/mici/onroad/driver_camera_dialog.py
+++ b/openpilot/selfdrive/ui/mici/onroad/driver_camera_dialog.py
@@ -232,8 +232,11 @@ class BaseDriverCameraDialog(Widget):
 class DriverCameraDialog(NavWidget, BaseDriverCameraDialog):
   def __init__(self):
     super().__init__()
-    # TODO: this can grow unbounded, should be given some thought
     device.add_interactive_timeout_callback(gui_app.pop_widget)
+
+  def hide_event(self):
+    super().hide_event()
+    device.remove_interactive_timeout_callback(gui_app.pop_widget)
 
 
 if __name__ == "__main__":

--- a/openpilot/selfdrive/ui/onroad/driver_camera_dialog.py
+++ b/openpilot/selfdrive/ui/onroad/driver_camera_dialog.py
@@ -13,12 +13,12 @@ class DriverCameraDialog(CameraView):
   def __init__(self):
     super().__init__("camerad", VisionStreamType.VISION_STREAM_DRIVER)
     self.driver_state_renderer = DriverStateRenderer()
-    # TODO: this can grow unbounded, should be given some thought
     device.add_interactive_timeout_callback(gui_app.pop_widget)
     ui_state.params.put_bool("IsDriverViewEnabled", True, block=True)
 
   def hide_event(self):
     super().hide_event()
+    device.remove_interactive_timeout_callback(gui_app.pop_widget)
     ui_state.params.put_bool("IsDriverViewEnabled", False, block=True)
     self.close()
 

--- a/openpilot/selfdrive/ui/ui_state.py
+++ b/openpilot/selfdrive/ui/ui_state.py
@@ -246,6 +246,9 @@ class Device:
   def add_interactive_timeout_callback(self, callback: Callable):
     self._interactive_timeout_callbacks.append(callback)
 
+  def remove_interactive_timeout_callback(self, callback: Callable):
+    self._interactive_timeout_callbacks.remove(callback)
+
   def update(self):
     self._start_brightness_thread()  # start thread after manager forks ui
 


### PR DESCRIPTION
## Summary
Fixes #37536.

`Device.add_interactive_timeout_callback()` only appends to a list; there was no way to remove a callback once added. The driver camera dialog (`DriverCameraDialog`, both tici and mici variants) is constructed fresh every time it's opened from settings, and each construction registered a new `gui_app.pop_widget` callback that was never removed. Opening the dialog repeatedly grows `_interactive_timeout_callbacks` unbounded, as flagged by the existing `# TODO: this can grow unbounded` comment.

- Added `Device.remove_interactive_timeout_callback()` in `selfdrive/ui/ui_state.py`
- Call it from `hide_event()` in both `selfdrive/ui/onroad/driver_camera_dialog.py` and `selfdrive/ui/mici/onroad/driver_camera_dialog.py`, removing the leftover TODO comments now that it's handled

The other three call sites listed in the issue (`MainLayout`, `MiciMainLayout`, `TrainingGuideDMTutorial`) register their callback once for the lifetime of the process and aren't constructed repeatedly, so they don't leak and weren't changed.

## Test plan
- [x] `ruff check` passes on all three changed files
- [x] Verified `Device.remove_interactive_timeout_callback()` removes exactly one matching entry from the list (mirrors `list.remove()` semantics, symmetric with `add_interactive_timeout_callback`'s `list.append()`)
- [x] Read through both `DriverCameraDialog` lifecycles to confirm `hide_event()` is the right place to remove the callback (mirrors how `IsDriverViewEnabled` and `set_override_interactive_timeout` are already reset there)