### PR TITLE
selfdrived: add permanent alert for processNotRunning

### DIFF
--- a/openpilot/selfdrive/selfdrived/events.py
+++ b/openpilot/selfdrive/selfdrived/events.py
@@ -292,6 +292,12 @@ def process_not_running_alert(CP: car.CarParams, CS: car.CarState, sm: messaging
   return NoEntryAlert(msg, alert_text_1="Process Not Running")
 
 
+def process_not_running_permanent(CP: car.CarParams, CS: car.CarState, sm: messaging.SubMaster, metric: bool, soft_disable_time: int, personality) -> Alert:
+  not_running = [p.name for p in sm['managerState'].processes if not p.running and p.shouldBeRunning]
+  msg = ', '.join(not_running)
+  return NormalPermanentAlert("Process Not Running", msg, priority=Priority.LOW)
+
+
 def comm_issue_alert(CP: car.CarParams, CS: car.CarState, sm: messaging.SubMaster, metric: bool, soft_disable_time: int, personality) -> Alert:
   bs = [s for s in sm.data.keys() if not sm.all_checks([s, ])]
   msg = ', '.join(bs[:4])  # can't fit too many on one line
@@ -869,6 +875,7 @@ EVENTS: dict[int, dict[str, Alert | AlertCallbackType]] = {
   EventName.processNotRunning: {
     ET.NO_ENTRY: process_not_running_alert,
     ET.SOFT_DISABLE: soft_disable_alert("Process Not Running"),
+    ET.PERMANENT: process_not_running_permanent,
   },
 
   EventName.radarFault: {


### PR DESCRIPTION
## Summary
Fixes #34751.

`processNotRunning` only defines `ET.NO_ENTRY` and `ET.SOFT_DISABLE` alerts. The `SOFT_DISABLE` alert is transient (2-4s depending on `soft_disable_time`), and `NO_ENTRY` is only ever included in `current_alert_types` while the driver is actively trying to engage (see `StateMachine.update` in `selfdrive/selfdrived/state.py`, `ET.PERMANENT` is always active but `ET.NO_ENTRY` is only appended inside the `events.contains(ET.ENABLE)` branch).

So once a process dies, after both of those alerts expire there is nothing left in `EVENTS[processNotRunning]` for `ET.PERMANENT`, the alert type that's always considered. If a consequential fault is also active and has a `PERMANENT` alert (e.g. `steerUnavailable`'s "LKAS Fault: Restart the car to engage"), that unrelated, lower-severity alert is the only thing left to display, masking the real cause exactly as described in the issue.

`modeldLagging` already follows the pattern this needs: `SOFT_DISABLE` + `NO_ENTRY` + `PERMANENT`. This PR adds the same `PERMANENT` alert for `processNotRunning`, at `Priority.LOW` (one step above the default `Priority.LOWER` used by `NormalPermanentAlert`/`steerUnavailable`'s permanent alert) so it reliably outranks other default-priority permanent alerts that are just side effects of the same underlying process crash, regardless of which one happened to start first.

## Test plan
- [x] `ruff check` passes
- [x] Traced `AlertManager.process_alerts` (`selfdrive/selfdrived/alertmanager.py`) to confirm selection is `max(priority, start_frame)` across all active alerts, and reproduced both the before/after outcome with a standalone script mirroring that exact comparison using the real `Priority` values:
  - before: `processNotRunning` contributes no `PERMANENT` alert, so `steerUnavailable`'s `PERMANENT` (`Priority.LOWER`) wins by default
  - after: `processNotRunning`'s new `PERMANENT` alert (`Priority.LOW`) wins regardless of start order
- [x] Confirmed against the route from the issue (`ea1f52a90cc05090/00000001--1fc11d46d7`) that `processNotRunning` was present in `onroadEvents` with no `PERMANENT` entry, while `steerUnavailable` was permanent and is what actually displayed