### PR TITLE
modeld: use correct intrinsics for extra transform when wide camera disabled

### DIFF
--- a/openpilot/selfdrive/modeld/modeld.py
+++ b/openpilot/selfdrive/modeld/modeld.py
@@ -253,7 +253,8 @@ def main(demo=False):
       device_from_calib_euler = np.array(sm["liveCalibration"].rpyCalib, dtype=np.float32)
       dc = DEVICE_CAMERAS[(str(sm['deviceState'].deviceType), str(sm['roadCameraState'].sensor))]
       model_transform_main = get_warp_matrix(device_from_calib_euler, dc.ecam.intrinsics if main_wide_camera else dc.fcam.intrinsics, False).astype(np.float32)
-      model_transform_extra = get_warp_matrix(device_from_calib_euler, dc.ecam.intrinsics, True).astype(np.float32)
+      has_wide_camera = use_extra_client or main_wide_camera
+      model_transform_extra = get_warp_matrix(device_from_calib_euler, dc.ecam.intrinsics if has_wide_camera else dc.fcam.intrinsics, True).astype(np.float32)
       live_calib_seen = True
 
     traffic_convention = np.zeros(2)


### PR DESCRIPTION
**Description**

`DISABLE_WIDE_ROAD` flag currently leads to using the ecam intrinsics on the narrow cam for the big_img model input. This PR uses the proper intrinsics if the wide camera is not available.

<img width="1024" height="768" alt="vlcsnap-2026-06-24-17h36m39s456" src="https://github.com/user-attachments/assets/de61669c-6371-4a0e-be5c-44f140d2adfe" />