### PR TITLE
hardwared: gracefully handle failed thermal sensor reads

### DIFF
--- a/openpilot/common/hardware/base.py
+++ b/openpilot/common/hardware/base.py
@@ -1,3 +1,4 @@
+import math
 import os
 from abc import abstractmethod, ABC
 from dataclasses import dataclass, fields
@@ -28,8 +29,9 @@ class ThermalZone:
     try:
       with open(f"/sys/devices/virtual/thermal/thermal_zone{self.zone_number}/temp") as f:
         return int(f.read()) / self.scale
-    except FileNotFoundError:
-      return 0
+    except (OSError, ValueError):
+      # the zone doesn't exist, or the underlying sensor read failed (e.g. a PMIC regmap error)
+      return math.nan
 
 @dataclass
 class ThermalConfig:

--- a/openpilot/system/hardware/hardwared.py
+++ b/openpilot/system/hardware/hardwared.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import fcntl
+import math
 import os
 import queue
 import struct
@@ -58,6 +59,12 @@ OFFROAD_DANGER_TEMP = 85 if HARDWARE.get_device_type() == "mici" else 75
 
 prev_offroad_states: dict[str, tuple[bool, str | None]] = {}
 
+
+
+def safe_max(values, default: float = 0.) -> float:
+  # a failed sensor read reports NaN; max() doesn't reliably skip those,
+  # and feeding NaN into a FirstOrderFilter poisons it permanently
+  return max((v for v in values if not math.isnan(v)), default=default)
 
 
 def set_offroad_alert_if_changed(offroad_alert: str, show_alert: bool, extra_text: str | None=None):
@@ -249,14 +256,14 @@ def hardware_thread(end_event, hw_queue) -> None:
     # this subset is only used for offroad
     temp_sources = [
       msg.deviceState.memoryTempC,
-      max(msg.deviceState.cpuTempC, default=0.),
-      max(msg.deviceState.gpuTempC, default=0.),
+      safe_max(msg.deviceState.cpuTempC),
+      safe_max(msg.deviceState.gpuTempC),
     ]
-    offroad_comp_temp = offroad_temp_filter.update(max(temp_sources))
+    offroad_comp_temp = offroad_temp_filter.update(safe_max(temp_sources))
 
     # this drives the thermal status while onroad
-    temp_sources.append(max(msg.deviceState.pmicTempC, default=0.))
-    all_comp_temp = all_temp_filter.update(max(temp_sources))
+    temp_sources.append(safe_max(msg.deviceState.pmicTempC))
+    all_comp_temp = all_temp_filter.update(safe_max(temp_sources))
     msg.deviceState.maxTempC = all_comp_temp
 
     msg.deviceState.fanSpeedPercentDesired = fan_controller.update(all_comp_temp, onroad_conditions["ignition"])


### PR DESCRIPTION
## Summary
Fixes #36690.

The crash log in the issue is a kernel-level PMIC sensor read failure:
```
[18.147382] MAIN 0 kernel - spmi spmi-0: pmic_arb_wait_for_done: transaction failed (0x3)
[18.147695] MAIN 0 kernel - qcom,qpnp-temp-alarm c440000.qcom,spmi:qcom,pm8005@4:qcom,temp-alarm@2400: qpnp_tm_read: regmap_bulk_readl failed. sid=4, addr=2408, len=1, rc=-5
```
`pm8005` is one of the two PMIC thermal zones read by `ThermalZone` (`common/hardware/tici/hardware.py`'s `pmic=[ThermalZone("pm8998_tz"), ThermalZone("pm8005_tz")]`). When the kernel driver fails the read, the sysfs `temp` attribute raises `OSError` (or returns unparseable content), but `ThermalZone.read()` (`common/hardware/base.py`) only caught `FileNotFoundError` — so the exception propagated up through `get_msg()` and killed the `hardware_thread`, taking down `hardwared`.

- `ThermalZone.read()` now catches `(OSError, ValueError)` and returns `math.nan`, per the issue's suggestion ("temperature should probably be NaN ... then everything downstream needs to handle those values")
- For the "everything downstream" half of that: `hardwared.py` was taking `max()` of these sensor lists (`cpuTempC`, `gpuTempC`, `pmicTempC`) and feeding the result into a `FirstOrderFilter` that drives `thermal_status`. `max()` doesn't reliably skip `NaN` (comparisons against `NaN` are always `False`, so if the bad reading is first in the list, `max()` just returns `NaN`), and once a `NaN` enters the filter's running average (`(1-alpha)*x + alpha*new`), it stays `NaN` forever — silently disabling thermal monitoring for the rest of the drive. Added `safe_max()` to drop `NaN` readings before taking the max, used in place of the three raw `max()` calls.

## Test plan
- [x] `ruff check` passes on both files
- [x] Verified the `safe_max` vs raw `max` difference with a standalone script reproducing the exact `FirstOrderFilter.update()` math: with a `NaN` reading first in the list, raw `max()` permanently poisons the filter (stays `NaN` on every subsequent update even with valid readings), while `safe_max()` recovers immediately
- [x] Confirmed no existing tests reference `ThermalZone`/`ThermalConfig` directly (checked across the repo), so this doesn't change covered behavior