### PR TITLE
Process eSIM notifications after profile operations per SGP.22 spec

### DIFF
--- a/openpilot/common/esim/esim.py
+++ b/openpilot/common/esim/esim.py
@@ -33,7 +33,7 @@ def execute_and_process_notifications(lpa: LPABase, operation) -> None:
   try:
     operation()
   finally:
-    time.sleep(1)
+    time.sleep(1)  # Need to wait for 1s after the operation is finished so the eUICC/modem can settle down.
     try:
       lpa.process_notifications()
     except Exception as e:

--- a/openpilot/common/esim/esim.py
+++ b/openpilot/common/esim/esim.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 
 import argparse
+import sys
+import time
 from openpilot.common.hardware import HARDWARE
 from openpilot.common.esim.base import LPABase, Profile
 
@@ -27,6 +29,17 @@ def print_profiles(lpa: LPABase) -> None:
     print(f'{i}. {p.iccid} (nickname: {p.nickname or "<none provided>"}) (provider: {p.provider}) - {"enabled" if p.enabled else "disabled"}')
 
 
+def execute_and_process_notifications(lpa: LPABase, operation) -> None:
+  try:
+    operation()
+  finally:
+    time.sleep(1)
+    try:
+      lpa.process_notifications()
+    except Exception as e:
+      print(f'failed to process eSIM notifications: {e}', file=sys.stderr)
+
+
 if __name__ == '__main__':
   parser = argparse.ArgumentParser(prog='esim.py', description='manage eSIM profiles on your comma device', epilog='comma.ai')
   sub = parser.add_subparsers(dest='cmd')
@@ -51,17 +64,18 @@ if __name__ == '__main__':
 
   lpa = HARDWARE.get_sim_lpa()
   if args.cmd == 'switch':
-    lpa.switch_profile(resolve_iccid(lpa, args.profile))
+    iccid = resolve_iccid(lpa, args.profile)
+    execute_and_process_notifications(lpa, lambda: lpa.switch_profile(iccid))
   elif args.cmd == 'delete':
     iccid = resolve_iccid(lpa, args.profile)
     confirm = input(f'are you sure you want to delete profile {iccid}? (y/N) ')
     if confirm == 'y':
-      lpa.delete_profile(iccid)
+      execute_and_process_notifications(lpa, lambda: lpa.delete_profile(iccid))
     else:
       print('cancelled')
       exit(0)
   elif args.cmd == 'download':
-    lpa.download_profile(args.qr, args.name)
+    execute_and_process_notifications(lpa, lambda: lpa.download_profile(args.qr, args.name))
   elif args.cmd == 'nickname':
     lpa.nickname_profile(resolve_iccid(lpa, args.profile), args.name)
   else:

--- a/openpilot/common/esim/lpa.py
+++ b/openpilot/common/esim/lpa.py
@@ -451,7 +451,7 @@ def process_notifications(client: AtClient) -> None:
       response = es10x_command(client, request)
       content = require_tag(require_tag(response, TAG_RETRIEVE_NOTIFICATION, "RetrieveNotificationsListResponse"),
                             TAG_OK, "RetrieveNotificationsListResponse")
-      pending_notif = next((v for t, v in iter_tlv(content) if t in (TAG_PROFILE_INSTALL_RESULT, 0x30)), None)
+      pending_notif = next((content[start:end] for t, _, start, end in iter_tlv(content, with_positions=True) if t in (TAG_PROFILE_INSTALL_RESULT, 0x30)), None)
       if pending_notif is None:
         raise RuntimeError("Missing PendingNotification")
 


### PR DESCRIPTION
## Summary

Process pending eSIM notifications after profile-changing operations and send the correct pending notification payload to the SM-DP+.

Without this PR, the pending notification will accumulate on the eUICC, and lead to inconsistency between the eUICC and SM-DP+ server.

## Why

GSMA SGP.22 defines notification handling as part of the consumer RSP flow. Profile operations such as install, enable/disable, and delete can leave pending notifications on the eUICC that should be delivered to the notification receiver using ES9+ `HandleNotification`, then removed from the eUICC with ES10b `NotificationSent` / `RemoveNotificationFromList`.

This matters especially after profile download failures and profile switches. The eUICC can generate pending notifications for install results and profile management operations. Leaving those queued can confuse later eSIM operations and carrier-side state.

References:
- GSMA SGP.22 v2.7: https://www.gsma.com/solutions-and-impact/technologies/esim/gsma_resources/sgp-22-v2-7/
- GSMA SGP.22 v2.3: https://www.gsma.com/esim/gsma_resources/sgp-22-techncial-specification-v2-3/

## Changes

- After `download`, `switch`, and confirmed `delete`, attempt to process pending eSIM notifications.
- Wait 1 second before processing notifications to give the eUICC/modem a short settle window after the profile operation.
- Keep notification processing best-effort: failures are printed to stderr and do not change the main operation result.
- process_notifications() was sending only the value of the pending notification TLV to handleNotification, not the full TLV. For the pending Simlessly install notification:
  - value-only payload: HTTP 200 with GSMA failure 0.0/0.0.0 - Unknown error
  - full BF37 TLV payload: HTTP 204 accepted, then NotificationSent returned 0

## Testing

- Verified on a comma device with an equivalent eSIM implementation:
  - A value-only install notification payload was rejected by the SM-DP+ with `0.0/0.0.0 - Unknown error`.
  - Sending the full `BF37` Profile Installation Result TLV was accepted with HTTP 204.
  - For profile switch notifications, the eUICC returned a signed `0x30` pending notification object, which was accepted by `HandleNotification` and removed successfully with `NotificationSent`.
  - Immediate post-switch notification processing could hit `APDU failed with SW=6881` or see no notifications yet, so this adds a short settle delay before the best-effort notification pass.
