### PR TITLE
bump sensors test limits

### DIFF
--- a/openpilot/system/sensord/tests/test_sensord.py
+++ b/openpilot/system/sensord/tests/test_sensord.py
@@ -14,8 +14,8 @@ SensorConfig = namedtuple('SensorConfig', ['service', 'measurement', 'sanity_min
 
 SENSOR_CONFIGS = (
   SensorConfig("accelerometer", "acceleration", 5, 15, 5),
-  SensorConfig("gyroscope", "gyroUncalibrated", 0, .15, 0.5),
-  SensorConfig("temperatureSensor", "temperature", 10, 40, 0.5),  # set for max range of our office
+  SensorConfig("gyroscope", "gyroUncalibrated", 0, .2, 0.5),
+  SensorConfig("temperatureSensor", "temperature", 10, 55, 0.5),  # office range + looser for variance and density
 )
 SENSOR_CONFIGS_BY_MEASUREMENT = {config.measurement: config for config in SENSOR_CONFIGS}
 

--- a/openpilot/system/sensord/tests/test_sensord.py
+++ b/openpilot/system/sensord/tests/test_sensord.py
@@ -14,7 +14,7 @@ SensorConfig = namedtuple('SensorConfig', ['service', 'measurement', 'sanity_min
 
 SENSOR_CONFIGS = (
   SensorConfig("accelerometer", "acceleration", 5, 15, 5),
-  SensorConfig("gyroscope", "gyroUncalibrated", 0, .2, 0.5),
+  SensorConfig("gyroscope", "gyroUncalibrated", 0, .3, 0.5),
   SensorConfig("temperatureSensor", "temperature", 10, 60, 0.5), # looser for device density
 )
 SENSOR_CONFIGS_BY_MEASUREMENT = {config.measurement: config for config in SENSOR_CONFIGS}

--- a/openpilot/system/sensord/tests/test_sensord.py
+++ b/openpilot/system/sensord/tests/test_sensord.py
@@ -15,7 +15,7 @@ SensorConfig = namedtuple('SensorConfig', ['service', 'measurement', 'sanity_min
 SENSOR_CONFIGS = (
   SensorConfig("accelerometer", "acceleration", 5, 15, 5),
   SensorConfig("gyroscope", "gyroUncalibrated", 0, .2, 0.5),
-  SensorConfig("temperatureSensor", "temperature", 10, 55, 0.5),  # office range + looser for variance and density
+  SensorConfig("temperatureSensor", "temperature", 10, 60, 0.5), # looser for device density
 )
 SENSOR_CONFIGS_BY_MEASUREMENT = {config.measurement: config for config in SENSOR_CONFIGS}
 


### PR DESCRIPTION
Revert limits to previous bands.

Datasheet expects up to 0.3 rad/s of gyro drift, +/-10 dps for each axis