### PR TITLE
docs: quote pip extras install examples

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -7,7 +7,7 @@ Those commands must be run in the root directory of openpilot, **not /docs**
 
 **1. Install the docs dependencies**
 ``` bash
-uv pip install .[docs]
+uv pip install '.[docs]'
 ```
 
 **2. Build the new site**


### PR DESCRIPTION
## Summary
- Quote `pip install` examples that include extras.

## Why
- Shells such as zsh can expand unquoted bracket expressions before `pip` receives them.

## Scope
- Files changed:
- `docs/DEVELOPMENT.md`
- This does not change dependencies or runtime behavior.

## Testing
- `git diff --check`

## Maintainer Fit
- Small install-command correctness fix.
- Duplicate PR search terms checked: `quote pip extras`, `quote optional dependency`, `zsh pip install extras`, `pip extras install examples`