### PR TITLE
locationd: guard parabolic_peak_interp against empty/out-of-range input

### DIFF
--- a/openpilot/selfdrive/locationd/helpers.py
+++ b/openpilot/selfdrive/locationd/helpers.py
@@ -34,7 +34,7 @@ def fft_next_good_size(n: int) -> int:
 
 
 def parabolic_peak_interp(R, max_index):
-  if max_index == 0 or max_index == len(R) - 1:
+  if max_index <= 0 or max_index >= len(R) - 1:
     return max_index
 
   y_m1, y_0, y_p1 = R[max_index - 1], R[max_index], R[max_index + 1]

--- a/openpilot/selfdrive/locationd/test/test_helpers.py
+++ b/openpilot/selfdrive/locationd/test/test_helpers.py
@@ -1,0 +1,16 @@
+from openpilot.selfdrive.locationd.helpers import parabolic_peak_interp
+
+
+class TestParabolicPeakInterp:
+  def test_symmetric_peak_refines_to_center(self):
+    assert parabolic_peak_interp([0.0, 1.0, 0.0], 1) == 1.0
+
+  def test_endpoints_return_index(self):
+    R = [1.0, 0.5, 0.2]
+    assert parabolic_peak_interp(R, 0) == 0
+    assert parabolic_peak_interp(R, len(R) - 1) == len(R) - 1
+
+  def test_degenerate_inputs_do_not_raise(self):
+    # an empty array or an out-of-range index must not raise IndexError
+    assert parabolic_peak_interp([], 7) == 7
+    assert parabolic_peak_interp([1.0, 2.0], 5) == 5


### PR DESCRIPTION
## Summary

`parabolic_peak_interp` reads `R[max_index - 1]`, `R[max_index]`, and `R[max_index + 1]`
after a guard that only matches the exact endpoints (`max_index == 0` or
`max_index == len(R) - 1`). An empty `R`, or a `max_index` outside `[0, len(R) - 1]`,
therefore raises `IndexError` instead of being handled.

## Change

Widen the guard to `max_index <= 0 or max_index >= len(R) - 1` so a degenerate index
returns `max_index` unchanged, the same behavior the function already uses at the
boundaries where there is no neighbor to interpolate against. Valid interior peaks are
unaffected.

## Test

Adds `test/test_helpers.py` covering a symmetric peak, the endpoints, and the previously
crashing degenerate inputs (empty array and out-of-range index).
