### PR TITLE
Handle missing thermal readings

### DIFF
--- a/openpilot/common/hardware/base.py
+++ b/openpilot/common/hardware/base.py
@@ -1,4 +1,5 @@
 import os
+import math
 from abc import abstractmethod, ABC
 from dataclasses import dataclass, fields
 
@@ -20,16 +21,22 @@ class ThermalZone:
       for n in os.listdir("/sys/devices/virtual/thermal"):
         if not n.startswith("thermal_zone"):
           continue
-        with open(os.path.join("/sys/devices/virtual/thermal", n, "type")) as f:
-          if f.read().strip() == self.name:
-            self.zone_number = int(n.removeprefix("thermal_zone"))
-            break
+        try:
+          with open(os.path.join("/sys/devices/virtual/thermal", n, "type")) as f:
+            if f.read().strip() == self.name:
+              self.zone_number = int(n.removeprefix("thermal_zone"))
+              break
+        except OSError:
+          continue
+
+    if self.zone_number < 0:
+      return math.nan
 
     try:
       with open(f"/sys/devices/virtual/thermal/thermal_zone{self.zone_number}/temp") as f:
         return int(f.read()) / self.scale
-    except FileNotFoundError:
-      return 0
+    except (OSError, ValueError):
+      return math.nan
 
 @dataclass
 class ThermalConfig:

--- a/openpilot/common/tests/test_hardware.py
+++ b/openpilot/common/tests/test_hardware.py
@@ -1,0 +1,24 @@
+import math
+from io import StringIO
+
+from openpilot.common.hardware.base import ThermalZone
+
+
+def test_thermal_zone_read_returns_nan_on_temp_read_error(monkeypatch):
+  def fake_open(path):
+    if path.endswith("/type"):
+      return StringIO("pmic\n")
+    if path.endswith("/temp"):
+      raise OSError("thermal read failed")
+    raise FileNotFoundError
+
+  monkeypatch.setattr("os.listdir", lambda _: ["thermal_zone0"])
+  monkeypatch.setattr("builtins.open", fake_open)
+
+  assert math.isnan(ThermalZone("pmic").read())
+
+
+def test_thermal_zone_read_returns_nan_when_zone_is_missing(monkeypatch):
+  monkeypatch.setattr("os.listdir", lambda _: [])
+
+  assert math.isnan(ThermalZone("missing").read())

--- a/openpilot/selfdrive/selfdrived/events.py
+++ b/openpilot/selfdrive/selfdrived/events.py
@@ -341,10 +341,14 @@ def paramsd_invalid_alert(CP: car.CarParams, CS: car.CarState, sm: messaging.Sub
   return NoEntryAlert(alert_text_1=title, alert_text_2=text)
 
 def overheat_alert(CP: car.CarParams, CS: car.CarState, sm: messaging.SubMaster, metric: bool, soft_disable_time: int, personality) -> Alert:
-  cpu = max(sm['deviceState'].cpuTempC, default=0.)
-  gpu = max(sm['deviceState'].gpuTempC, default=0.)
-  temp = max((cpu, gpu, sm['deviceState'].memoryTempC))
-  return NormalPermanentAlert("System Overheated", f"{temp:.0f} °C")
+  temps = [
+    *sm['deviceState'].cpuTempC,
+    *sm['deviceState'].gpuTempC,
+    sm['deviceState'].memoryTempC,
+    sm['deviceState'].maxTempC,
+  ]
+  temp = max((t for t in temps if math.isfinite(t)), default=math.nan)
+  return NormalPermanentAlert("System Overheated", f"{temp:.0f} °C" if math.isfinite(temp) else "Temperature unavailable")
 
 
 def low_memory_alert(CP: car.CarParams, CS: car.CarState, sm: messaging.SubMaster, metric: bool, soft_disable_time: int, personality) -> Alert:

--- a/openpilot/selfdrive/selfdrived/tests/test_events.py
+++ b/openpilot/selfdrive/selfdrived/tests/test_events.py
@@ -1,0 +1,33 @@
+import math
+from types import SimpleNamespace
+
+from openpilot.selfdrive.selfdrived.events import overheat_alert
+
+
+class FakeSubMaster:
+  def __init__(self, device_state):
+    self.device_state = device_state
+
+  def __getitem__(self, service):
+    assert service == "deviceState"
+    return self.device_state
+
+
+def make_device_state(cpu_temp, gpu_temp, memory_temp, max_temp):
+  return SimpleNamespace(cpuTempC=cpu_temp, gpuTempC=gpu_temp, memoryTempC=memory_temp, maxTempC=max_temp)
+
+
+def test_overheat_alert_ignores_nan_temps():
+  sm = FakeSubMaster(make_device_state([math.nan], [64.0], math.nan, 72.0))
+
+  alert = overheat_alert(None, None, sm, False, 100, None)
+
+  assert alert.alert_text_2 == "72 °C"
+
+
+def test_overheat_alert_handles_only_nan_temps():
+  sm = FakeSubMaster(make_device_state([math.nan], [math.nan], math.nan, math.nan))
+
+  alert = overheat_alert(None, None, sm, False, 100, None)
+
+  assert alert.alert_text_2 == "Temperature unavailable"

--- a/openpilot/system/hardware/hardwared.py
+++ b/openpilot/system/hardware/hardwared.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env python3
 import fcntl
+import math
 import os
 import queue
 import struct
 import threading
 import time
 from collections import OrderedDict, namedtuple
+from collections.abc import Iterable
 
 import psutil
 
@@ -65,6 +67,10 @@ def set_offroad_alert_if_changed(offroad_alert: str, show_alert: bool, extra_tex
     return
   prev_offroad_states[offroad_alert] = (show_alert, extra_text)
   set_offroad_alert(offroad_alert, show_alert, extra_text)
+
+def max_finite(values: Iterable[float]) -> float | None:
+  finite_values = [v for v in values if math.isfinite(v)]
+  return max(finite_values, default=None)
 
 def touch_thread(end_event):
   count = 0
@@ -249,17 +255,18 @@ def hardware_thread(end_event, hw_queue) -> None:
     # this subset is only used for offroad
     temp_sources = [
       msg.deviceState.memoryTempC,
-      max(msg.deviceState.cpuTempC, default=0.),
-      max(msg.deviceState.gpuTempC, default=0.),
+      *msg.deviceState.cpuTempC,
+      *msg.deviceState.gpuTempC,
     ]
-    offroad_comp_temp = offroad_temp_filter.update(max(temp_sources))
+    offroad_temp = max_finite(temp_sources)
+    offroad_comp_temp = offroad_temp_filter.update(offroad_temp) if offroad_temp is not None else math.nan
 
     # this drives the thermal status while onroad
-    temp_sources.append(max(msg.deviceState.pmicTempC, default=0.))
-    all_comp_temp = all_temp_filter.update(max(temp_sources))
+    all_temp = max_finite([*temp_sources, *msg.deviceState.pmicTempC])
+    all_comp_temp = all_temp_filter.update(all_temp) if all_temp is not None else math.nan
     msg.deviceState.maxTempC = all_comp_temp
 
-    msg.deviceState.fanSpeedPercentDesired = fan_controller.update(all_comp_temp, onroad_conditions["ignition"])
+    msg.deviceState.fanSpeedPercentDesired = fan_controller.update(all_comp_temp if math.isfinite(all_comp_temp) else 0., onroad_conditions["ignition"])
 
     is_offroad_for_5_min = (started_ts is None) and ((not started_seen) or (off_ts is None) or (time.monotonic() - off_ts > 60 * 5))
     if is_offroad_for_5_min and offroad_comp_temp > OFFROAD_DANGER_TEMP:
@@ -295,7 +302,7 @@ def hardware_thread(end_event, hw_queue) -> None:
 
     # if the temperature enters the danger zone, go offroad to cool down
     onroad_conditions["device_temp_good"] = thermal_status < ThermalStatus.critical
-    extra_text = f"{offroad_comp_temp:.1f}C"
+    extra_text = f"{offroad_comp_temp:.1f}C" if math.isfinite(offroad_comp_temp) else "N/A"
     show_alert = (not onroad_conditions["device_temp_good"] or not startup_conditions["device_temp_engageable"]) and onroad_conditions["ignition"]
     set_offroad_alert_if_changed("Offroad_TemperatureTooHigh", show_alert, extra_text=extra_text)
 

--- a/openpilot/system/hardware/tests/test_hardwared.py
+++ b/openpilot/system/hardware/tests/test_hardwared.py
@@ -1,0 +1,11 @@
+import math
+
+from openpilot.system.hardware.hardwared import max_finite
+
+
+def test_max_finite_ignores_non_finite_values():
+  assert max_finite([math.nan, 42.0, math.inf, -math.inf]) == 42.0
+
+
+def test_max_finite_returns_none_without_finite_values():
+  assert max_finite([math.nan, math.inf, -math.inf]) is None


### PR DESCRIPTION
## Summary
- Return `NaN` when a thermal sysfs zone cannot be found or read instead of raising out of `hardwared`.
- Ignore non-finite thermal values for fan and thermal-status calculations while still logging missing readings as `NaN`.
- Keep the overheat alert readable when all temperature readings are unavailable.

Fixes #36690.

## Test plan
- `uvx ruff check openpilot/common/hardware/base.py openpilot/system/hardware/hardwared.py openpilot/selfdrive/selfdrived/events.py openpilot/common/tests/test_hardware.py openpilot/system/hardware/tests/test_hardwared.py openpilot/selfdrive/selfdrived/tests/test_events.py`
- `uv run --python 3.12.13 pytest -q openpilot/common/tests/test_hardware.py openpilot/system/hardware/tests/test_hardwared.py openpilot/selfdrive/selfdrived/tests/test_events.py`
