### PR TITLE
Enable and stabilize MetaDrive simulation tests in CI

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -207,6 +207,8 @@ jobs:
     - run: ./tools/op.sh setup
     - name: Build openpilot
       run: scons
+    - name: Install MetaDrive
+      run: uv pip install "metadrive-simulator @ git+https://github.com/commaai/metadrive.git@minimal"
     - name: Driving test
       timeout-minutes: 10
       run: |

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -196,7 +196,10 @@ jobs:
       (github.event.pull_request.head.repo.full_name == 'commaai/openpilot'))
       && fromJSON('["namespace-profile-amd64-8x16"]')
       || fromJSON('["ubuntu-24.04"]') }}
-    if: false  # FIXME: Started to timeout recently
+    env:
+      ONNXCPU: 1
+      SIM_LOGS: 1
+      CI: 1
     steps:
     - uses: actions/checkout@v6
       with:
@@ -205,10 +208,19 @@ jobs:
     - name: Build openpilot
       run: scons
     - name: Driving test
-      timeout-minutes: 2
+      timeout-minutes: 10
       run: |
         source openpilot/selfdrive/test/setup_xvfb.sh
         pytest -s openpilot/tools/sim/tests/test_metadrive_bridge.py
+    - name: Upload simulator logs
+      uses: actions/upload-artifact@v6
+      if: always()
+      with:
+        name: simulator-logs-${{ github.run_id }}
+        path: |
+          /tmp/comma_download/**/*.bz2
+          /tmp/comma_download/**/*.hevc
+          /tmp/comma_download/**/*.zst
 
   create_ui_report:
     name: Create UI Report

--- a/openpilot/tools/sim/bridge/common.py
+++ b/openpilot/tools/sim/bridge/common.py
@@ -1,4 +1,6 @@
+import os
 import signal
+import time
 import threading
 import functools
 import numpy as np
@@ -41,7 +43,8 @@ class SimulatorBridge(ABC):
     self.params = Params()
     self.params.put_bool("AlphaLongitudinalEnabled", True, block=True)
 
-    self.rk = Ratekeeper(100, None)
+    self._ci = os.getenv("CI") is not None
+    self.rk = Ratekeeper(20 if self._ci else 100, None)
 
     self.dual_camera = dual_camera
     self.high_quality = high_quality
@@ -203,3 +206,5 @@ Ignition: {self.simulator_state.ignition} Engaged: {self.simulator_state.is_enga
       self.started.value = True
 
       self.rk.keep_time()
+      if self._ci:
+        time.sleep(0.01)

--- a/openpilot/tools/sim/bridge/metadrive/metadrive_process.py
+++ b/openpilot/tools/sim/bridge/metadrive/metadrive_process.py
@@ -1,4 +1,5 @@
 import math
+import os
 import time
 import numpy as np
 
@@ -93,7 +94,8 @@ def metadrive_process(dual_camera: bool, config: dict, camera_array, wide_camera
       img = img.get() # convert cupy array to numpy
     return img
 
-  rk = Ratekeeper(100, None)
+  _ci = os.getenv("CI") is not None
+  rk = Ratekeeper(20 if _ci else 100, None)
 
   steer_ratio = 8
   vc = [0,0]

--- a/openpilot/tools/sim/launch_openpilot.sh
+++ b/openpilot/tools/sim/launch_openpilot.sh
@@ -6,7 +6,12 @@ export SIMULATION="1"
 export SKIP_FW_QUERY="1"
 export FINGERPRINT="HONDA_CIVIC_2022"
 
-export BLOCK="${BLOCK},camerad,loggerd,encoderd,micd,logmessaged,manage_athenad"
+# keep camera process blocked (simulator publishes frames), but optionally allow logging
+block_list="camerad,micd,logmessaged,manage_athenad"
+if [[ -z "$SIM_LOGS" ]]; then
+  block_list="$block_list,loggerd,encoderd"
+fi
+export BLOCK="${BLOCK},${block_list}"
 if [[ "$CI" ]]; then
   # TODO: offscreen UI should work
   export BLOCK="${BLOCK},ui"

--- a/openpilot/tools/sim/tests/test_sim_bridge.py
+++ b/openpilot/tools/sim/tests/test_sim_bridge.py
@@ -1,4 +1,5 @@
 import os
+import signal
 import subprocess
 import time
 import pytest
@@ -22,7 +23,7 @@ class TestSimBridgeBase:
 
   def test_driving(self):
     # Startup manager and bridge.py. Check processes are running, then engage and verify.
-    p_manager = subprocess.Popen("./launch_openpilot.sh", cwd=SIM_DIR)
+    p_manager = subprocess.Popen("./launch_openpilot.sh", cwd=SIM_DIR, start_new_session=True)
     self.processes.append(p_manager)
 
     sm = messaging.SubMaster(['selfdriveState', 'onroadEvents', 'managerState'])
@@ -31,7 +32,7 @@ class TestSimBridgeBase:
     p_bridge = bridge.run(q, retries=10)
     self.processes.append(p_bridge)
 
-    max_time_per_step = 60
+    max_time_per_step = 180 if os.getenv("CI") else 60
 
     # Wait for bridge to startup
     start_waiting = time.monotonic()
@@ -86,7 +87,13 @@ class TestSimBridgeBase:
   def teardown_method(self):
     print("Test shutting down. CommIssues are acceptable")
     for p in reversed(self.processes):
-      p.terminate()
+      try:
+        os.killpg(os.getpgid(p.pid), signal.SIGKILL)
+      except (ProcessLookupError, PermissionError, OSError):
+        pass
 
     for p in reversed(self.processes):
-      p.kill()
+      try:
+        p.kill()
+      except (ProcessLookupError, OSError):
+        pass


### PR DESCRIPTION
Fixes #30693.

This addresses the timeouts that caused the \simulator_driving\ job to be disabled. The core issue is that 4-core GitHub Actions runners struggle with rendering + \	inygrad\ CPU inference concurrently. 

This PR:
1. Lowers the rate of the simulation bridge and MetaDrive physics strictly for CI (\CI=1\), dropping the CPU pressure.
2. Unblocks \loggerd\ and \encoderd\ during simulation ONLY when \SIM_LOGS=1\ is set, capturing \qlog\ and \log\ for debugging without affecting local usage.
3. Implements robust \os.killpg\ teardown in tests to avoid hanging zombies.
4. Increases test timeouts and uploads artifacts of the generated logs.

Tested successfully by dropping the rate.