### PR TITLE
feat: log latcontrol_torque low-speed proportional gain

### DIFF
--- a/openpilot/cereal/log.capnp
+++ b/openpilot/cereal/log.capnp
@@ -871,6 +871,7 @@ struct ControlsState @0x97ff69c53601abf1 {
     desiredLateralAccel @10 :Float32;
     desiredLateralJerk @11 :Float32;
     version @12 :Int32;
+    kp @13 :Float32;
    }
 
   struct LateralAngleState {

--- a/openpilot/selfdrive/controls/lib/latcontrol_torque.py
+++ b/openpilot/selfdrive/controls/lib/latcontrol_torque.py
@@ -94,6 +94,7 @@ class LatControlTorque(LatControl):
       output_torque = self.torque_from_lateral_accel(output_lataccel, self.torque_params)
 
       pid_log.active = True
+      pid_log.kp = float(self.pid.k_p)
       pid_log.p = float(self.pid.p)
       pid_log.i = float(self.pid.i)
       pid_log.d = float(self.pid.d)

--- a/openpilot/selfdrive/controls/tests/test_latcontrol_torque_buffer.py
+++ b/openpilot/selfdrive/controls/tests/test_latcontrol_torque_buffer.py
@@ -1,3 +1,6 @@
+import numpy as np
+import pytest
+
 from openpilot.common.parameterized import parameterized
 
 from openpilot.cereal import log
@@ -6,7 +9,7 @@ from opendbc.car.car_helpers import interfaces
 from opendbc.car.toyota.values import CAR as TOYOTA
 from opendbc.car.vehicle_model import VehicleModel
 from openpilot.common.realtime import DT_CTRL
-from openpilot.selfdrive.controls.lib.latcontrol_torque import LatControlTorque, LAT_ACCEL_REQUEST_BUFFER_SECONDS
+from openpilot.selfdrive.controls.lib.latcontrol_torque import KP, KP_INTERP, INTERP_SPEEDS, LatControlTorque, LAT_ACCEL_REQUEST_BUFFER_SECONDS
 
 def get_controller(car_name):
   CarInterface = interfaces[car_name]
@@ -35,3 +38,43 @@ class TestLatControlTorqueBuffer:
     for _ in range(buffer_steps):
       controller.update(False, CS, VM, params, False, 0.0, False, 0.2)
     assert all(val == 0 for val in controller.lat_accel_request_buffer)
+
+  @parameterized.expand([(TOYOTA.TOYOTA_COROLLA_TSS2,)])
+  def test_low_speed_kp_logged(self, car_name):
+    controller, VM = get_controller(car_name)
+
+    CS = car.CarState.new_message()
+    CS.vEgo = 2.0
+    CS.steeringPressed = False
+    params = log.LiveParametersData.new_message()
+
+    _, _, pid_log = controller.update(True, CS, VM, params, False, 0.001, False, 0.2)
+    assert pid_log.kp == pytest.approx(np.interp(CS.vEgo, INTERP_SPEEDS, KP_INTERP))
+
+  @parameterized.expand([(TOYOTA.TOYOTA_COROLLA_TSS2,)])
+  def test_high_speed_kp_logged(self, car_name):
+    controller, VM = get_controller(car_name)
+
+    CS = car.CarState.new_message()
+    CS.vEgo = 30.0
+    CS.steeringPressed = False
+    params = log.LiveParametersData.new_message()
+
+    _, _, pid_log = controller.update(True, CS, VM, params, False, 0.001, False, 0.2)
+    assert pid_log.kp == pytest.approx(KP)
+
+  @parameterized.expand([(TOYOTA.TOYOTA_COROLLA_TSS2,)])
+  def test_inactive_kp_default_serializes(self, car_name):
+    controller, VM = get_controller(car_name)
+
+    CS = car.CarState.new_message()
+    CS.vEgo = 2.0
+    CS.steeringPressed = False
+    params = log.LiveParametersData.new_message()
+
+    _, _, pid_log = controller.update(False, CS, VM, params, False, 0.001, False, 0.2)
+    assert pid_log.kp == 0.0
+
+    serialized = pid_log.to_bytes()
+    with log.ControlsState.LateralTorqueState.from_bytes(serialized) as deserialized:
+      assert deserialized.kp == 0.0


### PR DESCRIPTION
## Summary
Moves the low-speed proportional gain of `latcontrol_torque` into the logs: adds `kp` to `LateralTorqueState` in `log.capnp` and populates `pid_log.kp` from the controller. This makes the speed-interpolated `k_p` observable for tuning and analysis instead of only living in memory.

Extends the latcontrol_torque buffer test to assert `kp` is logged at low speed.

Fixes #34907
