### PR TITLE
Update README for driver monitoring model changes and formats

### DIFF
--- a/openpilot/selfdrive/modeld/models/README.md
+++ b/openpilot/selfdrive/modeld/models/README.md
@@ -46,24 +46,20 @@ Refer to **slice_outputs** and **parse_vision_outputs/parse_policy_outputs** in 
 * **calib**: camera calibration angles (roll, pitch, yaw) from liveCalibration: 1 x 3 float32 tensor
 
 ### output format
-* 84 x float32 outputs = 2 + 41 * 2 ([parsing example](https://github.com/commaai/openpilot/blob/22ce4e17ba0d3bfcf37f8255a4dd1dc683fe0c38/openpilot/selfdrive/modeld/models/dmonitoring.cc#L33))
-  * for each person in the front seats (2 * 41)
-    * face pose: 12 = 6 + 6
-      * face orientation [pitch, yaw, roll] in camera frame: 3
-      * face position [dx, dy] relative to image center: 2
-      * normalized face size: 1
-      * standard deviations for above outputs: 6
-    * face visible probability: 1
-    * eyes: 20 = (8 + 1) + (8 + 1) + 1 + 1
-      * eye position and size, and their standard deviations: 8
-      * eye visible probability: 1
-      * eye closed probability: 1
-    * wearing sunglasses probability: 1
-    * face occluded probability: 1
-    * touching wheel probability: 1
-    * paying attention probability: 1
-    * (deprecated) distracted probabilities: 2
-    * using phone probability: 1
-    * distracted probability: 1
-  * common outputs 1
-    * left hand drive probability: 1
+* 553 x float32 raw model outputs. Output names and slices are stored in the ONNX metadata and exported to `dmonitoring_model_metadata.pkl`.
+* Per-driver outputs, first for `lhd` and then for `rhd`:
+  * face descriptors: 12 floats
+    * face orientation [pitch, yaw, roll] in camera frame: 3
+    * face position [dx, dy] relative to image center: 2
+    * normalized face size: 1
+    * standard deviations for above outputs: 6
+  * face visible probability: 1
+  * left eye visible probability: 1
+  * right eye visible probability: 1
+  * wearing sunglasses probability: 1
+  * left eye closed probability: 1
+  * right eye closed probability: 1
+  * using phone probability: 1
+  * sleep probability: 1
+* common outputs:
+  * wheel-on-right probability: 1

--- a/openpilot/selfdrive/modeld/models/README.md
+++ b/openpilot/selfdrive/modeld/models/README.md
@@ -40,10 +40,10 @@ Refer to **slice_outputs** and **parse_vision_outputs/parse_policy_outputs** in 
   * `dm_warp_<camera_width>x<camera_height>_tinygrad.pkl` for the driver-camera luminance warp
 
 ### input format
-* single image W = 1440 H = 960 luminance channel (Y) from the planar YUV420 format:
+* **input_img**: single image W = 1440 H = 960 luminance channel (Y) warped from the driver-camera NV12/YUV frame:
   * full input size is 1440 * 960 = 1382400
-  * normalized ranging from 0.0 to 1.0 in float32 (onnx runner) or ranging from 0 to 255 in uint8 (snpe runner)
-* camera calibration angles (roll, pitch, yaw) from liveCalibration: 3 x float32 inputs
+  * represented as a 1 x 1382400 uint8 tensor ranging from 0 to 255
+* **calib**: camera calibration angles (roll, pitch, yaw) from liveCalibration: 1 x 3 float32 tensor
 
 ### output format
 * 84 x float32 outputs = 2 + 41 * 2 ([parsing example](https://github.com/commaai/openpilot/blob/22ce4e17ba0d3bfcf37f8255a4dd1dc683fe0c38/openpilot/selfdrive/modeld/models/dmonitoring.cc#L33))

--- a/openpilot/selfdrive/modeld/models/README.md
+++ b/openpilot/selfdrive/modeld/models/README.md
@@ -33,8 +33,11 @@ Refer to **slice_outputs** and **parse_vision_outputs/parse_policy_outputs** in 
 
 
 ## Driver Monitoring Model
-* .onnx model can be run with onnx runtimes
-* .dlc file is a pre-quantized model and only runs on qualcomm DSPs
+* `dmonitoring_model.onnx` is the source model and can be inspected with ONNX tooling.
+* openpilot's runtime uses tinygrad artifacts generated from the ONNX model:
+  * `dmonitoring_model_tinygrad.pkl` for model inference
+  * `dmonitoring_model_metadata.pkl` for input shapes and output slices
+  * `dm_warp_<camera_width>x<camera_height>_tinygrad.pkl` for the driver-camera luminance warp
 
 ### input format
 * single image W = 1440 H = 960 luminance channel (Y) from the planar YUV420 format:


### PR DESCRIPTION
### History leading to misaligned docs 
- 2021-11-08: DM README was added with .dlc/SNPE docs (0aa7404922328b729242521276e5fa2592dea879).

- 2024-09-19: GPU DM path briefly landed (f79aca8e1ef9160a93b2609146b4074b2343f75c), then was reverted the same day (ffb6e11f968525f41567aedb8bd5a24b88998afd).

- 2024-09-26: mismatch of README began with 876f19211 / exec DM model with gpu (#33609): dmonitoring_model_q.dlc was deleted and DM moved off DSP/SNPE, but the README still documented .dlc.

- 2024-12-18: 17ca6389e / Tinygrad runner (#34261) established the ONNX-derived dmonitoring_model_tinygrad.pkl path.

- 2026 current state: tinygrad pickle inference plus generated metadata/warp pickles; no Qualcomm DSP .dlc/SNPE runtime path.

### Changes in PR
Current openpilot uses the ONNX-derived tinygrad pickle, not the Qualcomm DSP .dlc/SNPE path that was used in the past. This pull request updates openpilot/selfdrive/modeld/models/README.md to match the current model configuration and remove the DSP/.DLC documents that are no longer relavent.