### PR TITLE
Add Cabana microphone audio replay support

### DIFF
--- a/openpilot/tools/cabana/SConscript
+++ b/openpilot/tools/cabana/SConscript
@@ -20,7 +20,7 @@ if not has_qt:
   Return()
 
 qt_env = env.Clone()
-qt_modules = ["Widgets", "Gui", "Core"]
+qt_modules = ["Widgets", "Gui", "Core", "Multimedia"]
 
 qt_libs = []
 if arch == "Darwin":
@@ -57,6 +57,7 @@ qt_flags = [
   "-DQT_WIDGETS_LIB",
   "-DQT_GUI_LIB",
   "-DQT_CORE_LIB",
+  "-DQT_MULTIMEDIA_LIB",
   "-DQT_MESSAGELOGCONTEXT",
 ]
 qt_env['CXXFLAGS'] += qt_flags

--- a/openpilot/tools/cabana/cabana
+++ b/openpilot/tools/cabana/cabana
@@ -2,7 +2,7 @@
 set -e
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
-ROOT="$(cd "$DIR/../../" && pwd)"
+ROOT="$(cd "$DIR/../../../" && pwd)"
 
 install_qt() {
   if [[ "$(uname)" == "Darwin" ]]; then
@@ -18,6 +18,7 @@ install_qt() {
       qtbase5-dev-tools \
       qttools5-dev-tools \
       libqt5charts5-dev \
+      qtmultimedia5-dev \
       libqt5svg5-dev \
       libqt5serialbus5-dev \
       libqt5x11extras5-dev \

--- a/openpilot/tools/cabana/streams/replaystream.cc
+++ b/openpilot/tools/cabana/streams/replaystream.cc
@@ -1,5 +1,14 @@
 #include "tools/cabana/streams/replaystream.h"
 
+#include <cstdint>
+#include <utility>
+
+#include <QAudioDeviceInfo>
+#include <QAudioFormat>
+#include <QAudioOutput>
+#include <QByteArray>
+#include <QDebug>
+#include <QIODevice>
 #include <QLabel>
 #include <QFileDialog>
 #include <QGridLayout>
@@ -9,6 +18,80 @@
 #include "common/timing.h"
 #include "common/util.h"
 #include "tools/cabana/streams/routes.h"
+
+class ReplayAudioOutput : public QObject {
+public:
+  void play(const cereal::AudioData::Reader &audio) {
+    const auto data = audio.getData();
+    const uint32_t sample_rate = audio.getSampleRate();
+    if (data.size() == 0 || sample_rate == 0) return;
+
+    QByteArray pcm(reinterpret_cast<const char *>(data.begin()), data.size());
+    QMetaObject::invokeMethod(this, [this, pcm = std::move(pcm), sample_rate]() {
+      write(sample_rate, pcm);
+    }, Qt::QueuedConnection);
+  }
+
+  void reset() {
+    QMetaObject::invokeMethod(this, [this]() { resetOutput(); }, Qt::QueuedConnection);
+  }
+
+private:
+  bool ensureOutput(uint32_t sample_rate) {
+    if (audio_output && sample_rate == current_sample_rate) return true;
+    if (sample_rate == unsupported_sample_rate) return false;
+
+    resetOutput();
+
+    QAudioFormat format;
+    format.setSampleRate(sample_rate);
+    format.setChannelCount(1);
+    format.setSampleSize(16);
+    format.setCodec("audio/pcm");
+    format.setByteOrder(QAudioFormat::LittleEndian);
+    format.setSampleType(QAudioFormat::SignedInt);
+
+    const QAudioDeviceInfo device_info = QAudioDeviceInfo::defaultOutputDevice();
+    if (!device_info.isFormatSupported(format)) {
+      const QAudioFormat nearest = device_info.nearestFormat(format);
+      if (nearest.sampleRate() != format.sampleRate() ||
+          nearest.channelCount() != format.channelCount() ||
+          nearest.sampleSize() != format.sampleSize() ||
+          nearest.sampleType() != format.sampleType()) {
+        qWarning() << "rawAudioData playback format is not supported:" << format;
+        unsupported_sample_rate = sample_rate;
+        return false;
+      }
+    }
+
+    audio_output = std::make_unique<QAudioOutput>(format);
+    audio_output->setBufferSize(sample_rate * sizeof(int16_t) / 2);
+    audio_device = audio_output->start();
+    current_sample_rate = sample_rate;
+    return audio_device != nullptr;
+  }
+
+  void write(uint32_t sample_rate, const QByteArray &pcm) {
+    if (!ensureOutput(sample_rate)) return;
+    if (audio_output->bytesFree() >= pcm.size()) {
+      audio_device->write(pcm.constData(), pcm.size());
+    }
+  }
+
+  void resetOutput() {
+    if (audio_output) {
+      audio_output->stop();
+      audio_output.reset();
+    }
+    audio_device = nullptr;
+    current_sample_rate = 0;
+  }
+
+  std::unique_ptr<QAudioOutput> audio_output;
+  QIODevice *audio_device = nullptr;
+  uint32_t current_sample_rate = 0;
+  uint32_t unsupported_sample_rate = 0;
+};
 
 ReplayStream::ReplayStream(QObject *parent) : AbstractStream(parent) {
   unsetenv("ZMQ");
@@ -22,6 +105,13 @@ ReplayStream::ReplayStream(QObject *parent) : AbstractStream(parent) {
   QObject::connect(&settings, &Settings::changed, this, [this]() {
     if (replay) replay->setSegmentCacheLimit(settings.max_cached_minutes);
   });
+
+  audio_output = std::make_unique<ReplayAudioOutput>();
+}
+
+ReplayStream::~ReplayStream() {
+  replay.reset();
+  audio_output.reset();
 }
 
 void ReplayStream::mergeSegments() {
@@ -41,20 +131,30 @@ void ReplayStream::mergeSegments() {
           }
         }
       }
-      mergeEvents(new_events);
+      if (new_events.empty()) {
+        static const MessageEventsMap empty_events;
+        emit eventsMerged(empty_events);
+      } else {
+        mergeEvents(new_events);
+      }
     }
   }
 }
 
 bool ReplayStream::loadRoute(const std::string &route, const std::string &data_dir, uint32_t replay_flags, bool auto_source) {
-  replay.reset(new Replay(route, {"can", "roadEncodeIdx", "driverEncodeIdx", "wideRoadEncodeIdx", "carParams"},
+  audio_output->reset();
+  replay.reset(new Replay(route, {"can", "rawAudioData", "roadEncodeIdx", "driverEncodeIdx", "wideRoadEncodeIdx", "carParams"},
                           {}, nullptr, replay_flags, data_dir, auto_source));
   replay->setSegmentCacheLimit(settings.max_cached_minutes);
   replay->installEventFilter([this](const Event *event) { return eventFilter(event); });
 
   // Forward replay callbacks to corresponding Qt signals.
-  replay->onSeeking = [this](double sec) { emit seeking(sec); };
+  replay->onSeeking = [this](double sec) {
+    audio_output->reset();
+    emit seeking(sec);
+  };
   replay->onSeekedTo = [this](double sec) {
+    audio_output->reset();
     emit seekedTo(sec);
     waitForSeekFinshed();
   };
@@ -99,6 +199,10 @@ bool ReplayStream::eventFilter(const Event *event) {
       const auto dat = c.getDat();
       updateEvent(id, current_sec, (const uint8_t*)dat.begin(), dat.size());
     }
+  } else if (event->which == cereal::Event::Which::RAW_AUDIO_DATA && replay->getSpeed() == 1.0f && !replay->isPaused()) {
+    capnp::FlatArrayMessageReader reader(event->data);
+    auto e = reader.getRoot<cereal::Event>();
+    audio_output->play(e.getRawAudioData());
   }
 
   double ts = millis_since_boot();
@@ -109,7 +213,15 @@ bool ReplayStream::eventFilter(const Event *event) {
   return true;
 }
 
+void ReplayStream::setSpeed(float speed) {
+  replay->setSpeed(speed);
+  if (speed != 1.0f) {
+    audio_output->reset();
+  }
+}
+
 void ReplayStream::pause(bool pause) {
+  audio_output->reset();
   replay->pause(pause);
   emit(pause ? paused() : resume());
 }

--- a/openpilot/tools/cabana/streams/replaystream.h
+++ b/openpilot/tools/cabana/streams/replaystream.h
@@ -12,11 +12,14 @@
 
 Q_DECLARE_METATYPE(std::shared_ptr<LogReader>);
 
+class ReplayAudioOutput;
+
 class ReplayStream : public AbstractStream {
   Q_OBJECT
 
 public:
   ReplayStream(QObject *parent);
+  ~ReplayStream() override;
   void start() override { replay->start(); }
   bool loadRoute(const std::string &route, const std::string &data_dir, uint32_t replay_flags = REPLAY_FLAG_NONE, bool auto_source = false);
   bool eventFilter(const Event *event);
@@ -28,8 +31,8 @@ public:
   double maxSeconds() const { return replay->maxSeconds(); }
   inline QDateTime beginDateTime() const { return QDateTime::fromSecsSinceEpoch(replay->routeDateTime()); }
   inline uint64_t beginMonoTime() const override { return replay->routeStartNanos(); }
-  inline void setSpeed(float speed) override { replay->setSpeed(speed); }
-  inline float getSpeed() const { return replay->getSpeed(); }
+  void setSpeed(float speed) override;
+  double getSpeed() override { return replay->getSpeed(); }
   inline Replay *getReplay() const { return replay.get(); }
   inline bool isPaused() const override { return replay->isPaused(); }
   void pause(bool pause) override;
@@ -42,6 +45,7 @@ private:
   std::unique_ptr<Replay> replay = nullptr;
   std::set<int> processed_segments;
   std::unique_ptr<OpenpilotPrefix> op_prefix;
+  std::unique_ptr<ReplayAudioOutput> audio_output;
 };
 
 class OpenReplayWidget : public AbstractOpenStreamWidget {


### PR DESCRIPTION
## Summary
- load rawAudioData while replaying routes in Cabana
- play mono PCM microphone samples through Qt Multimedia at 1x speed
- reset audio output on pause, seek, and non-1x playback
- close the segment loading dialog for replay logs without CAN messages

## Test
- uv run scons -j4 tools/cabana/_cabana
- git diff --check -- tools/cabana/SConscript tools/cabana/streams/replaystream.cc tools/cabana/streams/replaystream.h