### PR TITLE
MetaDrive sim on free CI runners: fix software rendering (2.5 to 25 fps), log artifacts

### DIFF
--- a/.github/workflows/sim_profile.yaml
+++ b/.github/workflows/sim_profile.yaml
@@ -1,0 +1,201 @@
+name: sim profile
+
+on:
+  push:
+    branches:
+      - metadrive-ci
+  workflow_dispatch:
+
+env:
+  CI: 1
+  PYTHONPATH: ${{ github.workspace }}
+
+jobs:
+  render_bench:
+    name: render bench
+    runs-on: ubuntu-24.04
+    timeout-minutes: 40
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        submodules: true
+    - run: ./tools/op.sh setup
+    - name: Install MetaDrive
+      run: uv pip install "metadrive-simulator @ git+https://github.com/commaai/metadrive.git@minimal" py-spy
+    - name: Render bench (all variants, same runner)
+      timeout-minutes: 35
+      env:
+        RENDER_BENCH_PYSPY: 1
+      run: |
+        source openpilot/selfdrive/test/setup_xvfb.sh
+        python3 openpilot/tools/sim/tests/render_bench.py
+    - name: Upload frames
+      if: always()
+      uses: actions/upload-artifact@v6
+      with:
+        name: render-bench-frames-${{ github.run_number }}
+        path: /tmp/render_bench
+
+  simulator_driving:
+    name: sim driving (${{ matrix.name }})
+    runs-on: ubuntu-24.04
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: flatcard-half
+            render_scale: "0.5"
+            no_msaa: "1"
+            simple_render: "1"
+            no_shadows: "1"
+            flat_terrain_card: "1"
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        submodules: true
+    - name: System info
+      run: |
+        nproc
+        lscpu | head -20
+        free -h
+    - run: ./tools/op.sh setup
+    - name: Install MetaDrive
+      run: uv pip install "metadrive-simulator @ git+https://github.com/commaai/metadrive.git@minimal"
+    - name: Build openpilot
+      run: scons
+    - name: Driving test with CPU profiling
+      timeout-minutes: 20
+      env:
+        # no audio device on CI runners (setup_vsound.sh was removed in #37305)
+        BLOCK: soundd
+        # capture qlog/rlog/camera files for the artifact requirement
+        CI_SIM_LOGS: 1
+        METADRIVE_RENDER_SCALE: ${{ matrix.render_scale }}
+        METADRIVE_NO_MSAA: ${{ matrix.no_msaa }}
+        METADRIVE_SIMPLE_RENDER: ${{ matrix.simple_render }}
+        METADRIVE_NO_SHADOWS: ${{ matrix.no_shadows }}
+        METADRIVE_NO_TERRAIN: ${{ matrix.no_terrain }}
+        METADRIVE_CHEAP_TERRAIN: ${{ matrix.cheap_terrain }}
+        METADRIVE_FLAT_TERRAIN_CARD: ${{ matrix.flat_terrain_card }}
+      run: |
+        sudo apt-get install -y sysstat > /dev/null
+        # self-diagnosing core dumps for any native crash (e.g. transient modeld death)
+        ulimit -c unlimited
+        sudo sysctl -w kernel.core_pattern='/tmp/sim_profile/core.%e.%p' > /dev/null
+        source openpilot/selfdrive/test/setup_xvfb.sh
+        # pre-download metadrive assets so the test's startup window isn't
+        # spent on a ~17s download
+        python3 -m metadrive.pull_asset || true
+        mkdir -p /tmp/sim_profile
+        pidstat -u -h -l 2 > /tmp/sim_profile/pidstat.log &
+        PIDSTAT=$!
+        # message-rate probe: which services actually flow, and how fast
+        python3 - > /tmp/sim_profile/rates.log 2>&1 <<'RATES' &
+        import glob
+        import os
+        import time
+        # pytest runs the daemons in an isolated msgq namespace — discover it
+        prefix_dir = None
+        for _ in range(600):
+          dirs = glob.glob("/dev/shm/msgq_*")
+          if dirs:
+            prefix_dir = dirs[0]
+            break
+          time.sleep(0.5)
+        if prefix_dir:
+          os.environ["OPENPILOT_PREFIX"] = os.path.basename(prefix_dir)[len("msgq_"):]
+        print("joined prefix:", os.environ.get("OPENPILOT_PREFIX"), flush=True)
+        from openpilot.cereal import messaging
+        SERVICES = ["modelV2", "cameraOdometry", "liveCalibration", "livePose", "liveDelay",
+                    "liveParameters", "liveTorqueParameters", "roadCameraState", "carState", "selfdriveState"]
+        while True:
+          # recreate sockets each window: publishers may not exist yet when
+          # the probe starts, and msgq segments are created by the publisher
+          socks = {s: messaging.sub_sock(s, conflate=False) for s in SERVICES}
+          time.sleep(0.2)
+          t0 = time.monotonic()
+          counts = dict.fromkeys(SERVICES, 0)
+          while time.monotonic() - t0 < 5:
+            for s, sock in socks.items():
+              counts[s] += len(messaging.drain_sock_raw(sock))
+            time.sleep(0.05)
+          print(time.strftime("%H:%M:%S"), {s: round(c / 5.0, 1) for s, c in counts.items()}, flush=True)
+          del socks
+        RATES
+        RATEPROBE=$!
+        # snapshot logs during the test: pytest's OpenpilotPrefix teardown
+        # deletes ~/.comma<prefix> before any post-step can collect it
+        mkdir -p /tmp/sim_profile/realdata
+        (
+          while true; do
+            rsync -a --exclude='fcamera.hevc*' --exclude='*.lock' "$HOME"/.comma*/media/0/realdata/ /tmp/sim_profile/realdata/ 2>/dev/null || true
+            sleep 5
+          done
+        ) &
+        LOGCOPIER=$!
+        # redirect to a file (not tee): orphaned daemons inheriting the step's
+        # stdout pipe would otherwise keep the step alive until timeout
+        pytest -n0 -s openpilot/tools/sim/tests/test_metadrive_bridge.py > /tmp/sim_profile/pytest.log 2>&1 || true
+        kill $PIDSTAT $RATEPROBE $LOGCOPIER || true
+        # one final sweep in case anything remains (full-res video excluded:
+        # ~1 GB for 80 s; qcamera.ts + qlog + rlog cover the artifact needs)
+        rsync -a --exclude='fcamera.hevc*' --exclude='*.lock' "$HOME"/.comma*/media/0/realdata/ /tmp/sim_profile/realdata/ 2>/dev/null || true
+        # kill anything the test teardown missed so later steps don't hang
+        pkill -9 -f 'system/manager/manager.py' || true
+        pkill -9 -f 'tools/sim' || true
+        sleep 2
+        sudo dmesg | grep -iE "killed process|out of memory|oom" > /tmp/sim_profile/oom.log || true
+        tail -30 /tmp/sim_profile/pytest.log
+        echo "=== render fps lines ==="; grep "render fps" /tmp/sim_profile/pytest.log || true
+        echo "=== OOM check ==="; cat /tmp/sim_profile/oom.log
+    - name: Summarize top CPU consumers
+      if: always()
+      run: |
+        python3 - <<'EOF'
+        from collections import defaultdict
+        cpu = defaultdict(float); n = defaultdict(int); peak = defaultdict(float); cmds = {}
+        samples = set()
+        for line in open('/tmp/sim_profile/pidstat.log'):
+            parts = line.split()
+            if len(parts) < 10 or parts[0] in ('#', 'Linux'): continue
+            try: pct = float(parts[7])
+            except ValueError: continue
+            pid = parts[2]
+            samples.add(parts[0]); cpu[pid] += pct; n[pid] += 1
+            peak[pid] = max(peak[pid], pct)
+            cmds[pid] = ' '.join(parts[9:])
+        total = max(len(samples), 1)
+        print(f'{total} samples @2s, 4 CPUs = 400% budget')
+        print(f"{'pid':>7} {'mean%':>7} {'peak%':>7} {'nsamp':>5}  command")
+        for pid, tot in sorted(cpu.items(), key=lambda kv: -kv[1]/total)[:25]:
+            cmd = cmds[pid].replace('/home/runner/work/openpilot/openpilot/', '')
+            print(f'{pid:>7} {tot/total:7.1f} {peak[pid]:7.1f} {n[pid]:5d}  {cmd[:150]}')
+        EOF
+    - name: Backtrace any core dumps
+      if: always()
+      run: |
+        shopt -s nullglob
+        cores=(/tmp/sim_profile/core.*)
+        if [ ${#cores[@]} -gt 0 ]; then
+          sudo apt-get install -y gdb > /dev/null
+          for c in "${cores[@]}"; do
+            echo "=== $c ==="
+            exe=$(file "$c" | grep -oP "execfn: '\K[^']+") || exe=python3
+            gdb -batch -ex "bt" -ex "thread apply all bt" "$exe" "$c" 2>/dev/null | head -150
+          done
+        else
+          echo "no core dumps"
+        fi
+    - name: Collect openpilot logs
+      if: always()
+      run: |
+        ls -laR /tmp/sim_profile/realdata | head -40
+        # cores are large; keep only backtraces in artifacts
+        rm -f /tmp/sim_profile/core.*
+    - name: Upload artifacts
+      if: always()
+      uses: actions/upload-artifact@v6
+      with:
+        name: sim-profile-${{ github.run_number }}-${{ matrix.name }}
+        path: /tmp/sim_profile

--- a/.github/workflows/sim_profile.yaml
+++ b/.github/workflows/sim_profile.yaml
@@ -27,7 +27,12 @@ jobs:
       env:
         RENDER_BENCH_PYSPY: 1
       run: |
-        source openpilot/selfdrive/test/setup_xvfb.sh
+        # upstream removed setup_xvfb.sh in #38298 (openpilot itself is
+        # headless now); MetaDrive/panda3d still needs a display for
+        # software GL, so set one up inline
+        sudo apt-get install -y -qq xvfb
+        Xvfb :99 -screen 0 1928x1208x24 &
+        export DISPLAY=:99
         python3 openpilot/tools/sim/tests/render_bench.py
     - name: Upload frames
       if: always()
@@ -83,7 +88,12 @@ jobs:
         # self-diagnosing core dumps for any native crash (e.g. transient modeld death)
         ulimit -c unlimited
         sudo sysctl -w kernel.core_pattern='/tmp/sim_profile/core.%e.%p' > /dev/null
-        source openpilot/selfdrive/test/setup_xvfb.sh
+        # upstream removed setup_xvfb.sh in #38298 (openpilot itself is
+        # headless now); MetaDrive/panda3d still needs a display for
+        # software GL, so set one up inline
+        sudo apt-get install -y -qq xvfb
+        Xvfb :99 -screen 0 1928x1208x24 &
+        export DISPLAY=:99
         # pre-download metadrive assets so the test's startup window isn't
         # spent on a ~17s download
         python3 -m metadrive.pull_asset || true

--- a/openpilot/tools/sim/bridge/metadrive/ci_render_patches.py
+++ b/openpilot/tools/sim/bridge/metadrive/ci_render_patches.py
@@ -1,0 +1,78 @@
+"""Env-gated render simplifications for running the MetaDrive bridge on CI.
+
+Free GitHub Actions runners have no GPU; Mesa LLVMpipe software rendering
+cannot sustain the default MetaDrive pipeline in real time (issue #30693).
+Each flag removes render work without changing what openpilot's camera sees
+structurally (road layout, lane lines, horizon).
+
+Must be called before the MetaDrive engine is created — Prc settings load at
+engine init and the terrain patch replaces a method used during reset.
+"""
+import os
+
+
+def apply_ci_render_patches():
+  if os.environ.get("METADRIVE_NO_MSAA"):
+    # metadrive's EngineCore forces 8x MSAA at import time; Prc settings are
+    # last-write-wins, so this must load before the engine is created
+    from panda3d.core import loadPrcFileData
+    loadPrcFileData("", "framebuffer-multisample 0")
+    loadPrcFileData("", "multisamples 0")
+
+  if os.environ.get("METADRIVE_NO_SHADOWS"):
+    # PSSM renders the scene into a 2-split shadow atlas every frame;
+    # deactivate the shadow buffer but keep its shader inputs bound so the
+    # stock terrain shader stays valid
+    from metadrive.engine.core.pssm import PSSM
+    pssm_init_orig = PSSM.init
+    def pssm_init_no_render(self):
+      pssm_init_orig(self)
+      self.buffer.set_active(False)
+      self.use_pssm = False
+      self.engine.render.set_shader_inputs(use_pssm=False)
+    PSSM.init = pssm_init_no_render
+
+  if os.environ.get("METADRIVE_FLAT_TERRAIN_CARD"):
+    # the PG-map terrain is flat (physics already uses a plane); replace the
+    # chunked ShaderTerrainMesh — whose draw path dominates LLVMpipe frame
+    # time — with a single flat quad carrying the same shader inputs
+    from metadrive.constants import CameraTagStateKey, CamMask
+    from metadrive.engine.core.terrain import Terrain
+    from panda3d.core import Geom, GeomNode, GeomTriangles, GeomVertexData, GeomVertexFormat, GeomVertexWriter, Shader
+
+    def _gen_card(self, size, heightfield, attribute_tex, target_triangle_width=10, engine=None):
+      engine = engine or self.engine
+      vdata = GeomVertexData("terrain_card", GeomVertexFormat.getV3t2(), Geom.UHStatic)
+      vdata.setNumRows(4)
+      vw = GeomVertexWriter(vdata, "vertex")
+      uw = GeomVertexWriter(vdata, "texcoord")
+      for x, y in ((0, 0), (1, 0), (1, 1), (0, 1)):
+        vw.addData3(x, y, 0)
+        uw.addData2(x, y)
+      tris = GeomTriangles(Geom.UHStatic)
+      tris.addVertices(0, 1, 2)
+      tris.addVertices(0, 2, 3)
+      geom = Geom(vdata)
+      geom.addPrimitive(tris)
+      node = GeomNode("terrain_card")
+      node.addGeom(geom)
+      self._mesh_terrain = self.origin.attach_new_node(node)
+      self._mesh_terrain.setTwoSided(True)
+      # the main window camera's RGB tag state applies the stock terrain
+      # shader, which asserts on ShaderTerrainMesh.* inputs only the real
+      # terrain node provides — hide the card from it (the openpilot sensor
+      # cameras carry their own tag state with the card shaders)
+      self._mesh_terrain.hide(CamMask.MainCam)
+      here = os.path.dirname(os.path.abspath(__file__))
+      self._mesh_terrain.set_shader(Shader.load(Shader.SL_GLSL,
+                                                os.path.join(here, "terrain_card.vert.glsl"),
+                                                os.path.join(here, "terrain_ci.frag.glsl")))
+      self._mesh_terrain.setTag(CameraTagStateKey.Semantic, self.SEMANTIC_LABEL)
+      self._mesh_terrain.setTag(CameraTagStateKey.RGB, self.SEMANTIC_LABEL)
+      self._mesh_terrain.setTag(CameraTagStateKey.Depth, self.SEMANTIC_LABEL)
+      self._terrain_shader_set = False  # rebind inputs to the new node
+      self._set_terrain_shader(engine, attribute_tex)
+      self._mesh_terrain.set_scale(size, size, 1)
+      self._mesh_terrain.set_pos(-size / 2, -size / 2, 0)
+
+    Terrain._generate_mesh_vis_terrain = _gen_card

--- a/openpilot/tools/sim/bridge/metadrive/metadrive_bridge.py
+++ b/openpilot/tools/sim/bridge/metadrive/metadrive_bridge.py
@@ -1,4 +1,5 @@
 import math
+import os
 from multiprocessing import Queue
 
 from metadrive.component.sensors.base_camera import _cuda_enable
@@ -58,12 +59,16 @@ class MetaDriveBridge(SimulatorBridge):
     self.test_duration = test_duration if self.test_run else math.inf
 
   def spawn_world(self, queue: Queue):
+    # render at a reduced resolution and upscale, software rasterization cost
+    # scales with pixel count and can't keep up at full res on CI runners
+    render_scale = float(os.environ.get("METADRIVE_RENDER_SCALE", "1"))
+    rw, rh = round(W * render_scale), round(H * render_scale)
     sensors = {
-      "rgb_road": (RGBCameraRoad, W, H, )
+      "rgb_road": (RGBCameraRoad, rw, rh, )
     }
 
     if self.dual_camera:
-      sensors["rgb_wide"] = (RGBCameraWide, W, H)
+      sensors["rgb_wide"] = (RGBCameraWide, rw, rh)
 
     config = {
       "use_render": self.should_render,
@@ -87,7 +92,8 @@ class MetaDriveBridge(SimulatorBridge):
       "physics_world_step_size": self.TICKS_PER_FRAME/100,
       "preload_models": False,
       "show_logo": False,
-      "anisotropic_filtering": False
+      "anisotropic_filtering": False,
+      "show_terrain": not bool(os.environ.get("METADRIVE_NO_TERRAIN")),
     }
 
     return MetaDriveWorld(queue, config, self.test_duration, self.test_run, self.dual_camera)

--- a/openpilot/tools/sim/bridge/metadrive/metadrive_common.py
+++ b/openpilot/tools/sim/bridge/metadrive/metadrive_common.py
@@ -1,3 +1,4 @@
+import os
 import numpy as np
 
 from metadrive.component.sensors.rgb_camera import RGBCamera
@@ -10,6 +11,41 @@ class CopyRamRGBCamera(RGBCamera):
     super().__init__(*args, **kwargs)
     self.cpu_texture = Texture()
     self.buffer.addRenderTexture(self.cpu_texture, GraphicsOutput.RTMCopyRam)
+
+  def _setup_effect(self):
+    if os.environ.get("METADRIVE_SIMPLE_RENDER"):
+      # the default RGBCamera pipeline renders the scene with 16x MSAA into a
+      # float HDR buffer plus a tonemap post-pass, which is prohibitively slow
+      # on software rasterizers (CI); render straight into the 8-bit buffer,
+      # keeping the terrain shader tag so the road still draws correctly
+      from metadrive.constants import CameraTagStateKey, Semantics
+      from metadrive.engine.core.terrain import Terrain
+      cam = self.get_cam().node()
+      cam.setTagStateKey(CameraTagStateKey.RGB)
+      if os.environ.get("METADRIVE_FLAT_TERRAIN_CARD"):
+        # flat quad terrain + flat-lit shader, ~2 texture taps per fragment
+        from metadrive.engine.asset_loader import AssetLoader
+        from panda3d.core import NodePath, Shader
+        here = os.path.dirname(os.path.abspath(__file__))
+        dummy_np = NodePath("Dummy")
+        dummy_np.setShader(Shader.load(Shader.SL_GLSL,
+                                       os.path.join(here, "terrain_card.vert.glsl"),
+                                       os.path.join(here, "terrain_ci.frag.glsl")))
+        terrain_state = dummy_np.getState()
+      elif os.environ.get("METADRIVE_CHEAP_TERRAIN"):
+        # flat-lit terrain shader on the stock terrain mesh
+        from metadrive.engine.asset_loader import AssetLoader
+        from panda3d.core import NodePath, Shader
+        vert = AssetLoader.file_path("../shaders", "terrain.vert.glsl")
+        frag = os.path.join(os.path.dirname(os.path.abspath(__file__)), "terrain_ci.frag.glsl")
+        dummy_np = NodePath("Dummy")
+        dummy_np.setShader(Shader.load(Shader.SL_GLSL, vert, frag))
+        terrain_state = dummy_np.getState()
+      else:
+        terrain_state = Terrain.make_render_state(self.engine, "terrain.vert.glsl", "terrain.frag.glsl")
+      cam.setTagState(Semantics.TERRAIN.label, terrain_state)
+    else:
+      super()._setup_effect()
 
   def get_rgb_array_cpu(self):
     origin_img = self.cpu_texture

--- a/openpilot/tools/sim/bridge/metadrive/metadrive_process.py
+++ b/openpilot/tools/sim/bridge/metadrive/metadrive_process.py
@@ -51,6 +51,9 @@ def apply_metadrive_patches(arrive_dest_done=True):
 def metadrive_process(dual_camera: bool, config: dict, camera_array, wide_camera_array, image_lock,
                       controls_recv: Connection, simulation_state_send: Connection, vehicle_state_send: Connection,
                       exit_event, op_engaged, test_duration, test_run):
+  from openpilot.tools.sim.bridge.metadrive.ci_render_patches import apply_ci_render_patches
+  apply_ci_render_patches()
+
   arrive_dest_done = config.pop("arrive_dest_done", True)
   apply_metadrive_patches(arrive_dest_done)
 
@@ -91,12 +94,18 @@ def metadrive_process(dual_camera: bool, config: dict, camera_array, wide_camera
     img = cam.perceive(to_float=False)
     if not isinstance(img, np.ndarray):
       img = img.get() # convert cupy array to numpy
+    if img.shape[0] != H or img.shape[1] != W:
+      # nearest-neighbor upscale; render size must divide the camera size evenly
+      img = img.repeat(H // img.shape[0], axis=0).repeat(W // img.shape[1], axis=1)
     return img
 
   rk = Ratekeeper(100, None)
 
   steer_ratio = 8
   vc = [0,0]
+
+  render_frames = 0
+  fps_t0 = time.monotonic()
 
   while not exit_event.is_set():
     vehicle_state = metadrive_vehicle_state(
@@ -150,5 +159,11 @@ def metadrive_process(dual_camera: bool, config: dict, camera_array, wide_camera
         wide_road_image[...] = get_cam_as_rgb("rgb_wide")
       road_image[...] = get_cam_as_rgb("rgb_road")
       image_lock.release()
+
+      render_frames += 1
+      if render_frames % 100 == 0:
+        now = time.monotonic()
+        print(f"metadrive render fps: {100 / (now - fps_t0):.1f} (target 20)", flush=True)
+        fps_t0 = now
 
     rk.keep_time()

--- a/openpilot/tools/sim/bridge/metadrive/terrain_card.vert.glsl
+++ b/openpilot/tools/sim/bridge/metadrive/terrain_card.vert.glsl
@@ -1,0 +1,23 @@
+#version 330
+
+// Trivial vertex shader for the flat terrain card used in CI software
+// rendering (issue #30693). Replaces terrain.vert.glsl, which exists to
+// support panda3d's chunked ShaderTerrainMesh with per-vertex heightfield
+// displacement — unnecessary for the flat PG-map terrain.
+
+uniform mat4 p3d_ModelViewProjectionMatrix;
+uniform mat4 p3d_ModelMatrix;
+
+in vec4 p3d_Vertex;
+in vec2 p3d_MultiTexCoord0;
+
+out vec2 terrain_uv;
+out vec3 vtx_pos;
+out vec4 projecteds[1];
+
+void main() {
+  terrain_uv = p3d_MultiTexCoord0;
+  vtx_pos = (p3d_ModelMatrix * p3d_Vertex).xyz;
+  projecteds[0] = vec4(0.0);
+  gl_Position = p3d_ModelViewProjectionMatrix * p3d_Vertex;
+}

--- a/openpilot/tools/sim/bridge/metadrive/terrain_ci.frag.glsl
+++ b/openpilot/tools/sim/bridge/metadrive/terrain_ci.frag.glsl
@@ -1,0 +1,59 @@
+#version 330
+
+// Minimal terrain fragment shader for CI software rendering (issue #30693).
+// Keeps the exact road/lane-line/crosswalk layout of metadrive's
+// terrain.frag.glsl but renders flat-lit: no heightfield normal
+// reconstruction, normal/roughness maps, shadow-map sampling, or fog.
+// ~2 texture taps per fragment instead of 13+.
+
+uniform sampler2D yellow_tex;
+uniform sampler2D white_tex;
+uniform sampler2D road_tex;
+uniform sampler2D crosswalk_tex;
+uniform sampler2D grass_tex;
+uniform float grass_tex_ratio;
+uniform sampler2D attribute_tex;
+uniform float elevation_texture_ratio;
+
+in vec2 terrain_uv;
+in vec3 vtx_pos;
+in vec4 projecteds[1];
+
+out vec4 color;
+
+void main() {
+  float road_tex_ratio = 128.0;
+  float r_min = (1.0 - 1.0 / elevation_texture_ratio) / 2.0;
+  float r_max = r_min + 1.0 / elevation_texture_ratio;
+
+  vec4 attri;
+  if (abs(elevation_texture_ratio - 1.0) < 0.001) {
+    attri = texture(attribute_tex, terrain_uv);
+  } else {
+    attri = texture(attribute_tex, terrain_uv * elevation_texture_ratio + 0.5);
+  }
+
+  vec3 diffuse;
+  if ((attri.r > 0.01) && terrain_uv.x >= r_min && terrain_uv.y >= r_min && terrain_uv.x <= r_max && terrain_uv.y <= r_max) {
+    float value = attri.r;
+    if (value < 0.11) {
+      diffuse = texture(yellow_tex, terrain_uv * road_tex_ratio).rgb;
+    } else if (value < 0.21) {
+      diffuse = texture(road_tex, terrain_uv * road_tex_ratio).rgb;
+    } else if (value < 0.31) {
+      diffuse = texture(white_tex, terrain_uv * road_tex_ratio).rgb;
+    } else if (value > 0.3999 || value < 0.760001) {
+      float theta = (value - 0.39999) * 1000.0 / 180.0 * 3.1415926535;
+      vec2 uv2 = vec2(cos(theta) * terrain_uv.x - sin(theta) * terrain_uv.y,
+                      sin(theta) * terrain_uv.x + cos(theta) * terrain_uv.y);
+      diffuse = texture(crosswalk_tex, uv2 * road_tex_ratio).rgb;
+    } else {
+      diffuse = texture(white_tex, terrain_uv * road_tex_ratio).rgb;
+    }
+  } else {
+    diffuse = texture(grass_tex, terrain_uv * grass_tex_ratio * 4.0).rgb;
+  }
+
+  // approximate the original directional+ambient shading level with a constant
+  color = vec4(diffuse * 0.85, 1.0);
+}

--- a/openpilot/tools/sim/launch_openpilot.sh
+++ b/openpilot/tools/sim/launch_openpilot.sh
@@ -6,7 +6,11 @@ export SIMULATION="1"
 export SKIP_FW_QUERY="1"
 export FINGERPRINT="HONDA_CIVIC_2022"
 
-export BLOCK="${BLOCK},camerad,loggerd,encoderd,micd,logmessaged,manage_athenad"
+export BLOCK="${BLOCK},camerad,micd,logmessaged,manage_athenad"
+if [[ ! "$CI_SIM_LOGS" ]]; then
+  # loggerd/encoderd only run when log artifacts are wanted (CI)
+  export BLOCK="${BLOCK},loggerd,encoderd"
+fi
 if [[ "$CI" ]]; then
   # TODO: offscreen UI should work
   export BLOCK="${BLOCK},ui"

--- a/openpilot/tools/sim/tests/render_bench.py
+++ b/openpilot/tools/sim/tests/render_bench.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Standalone MetaDrive render-throughput benchmark for CI tuning (issue #30693).
+
+Runs each render-config variant in a fresh subprocess on the same machine and
+reports steady-state render fps, isolating renderer cost from the rest of the
+openpilot stack and from runner-to-runner CPU variance.
+
+Self-contained on purpose: only needs metadrive + panda3d + numpy (no scons build).
+"""
+import json
+import os
+import subprocess
+import sys
+import time
+
+import numpy as np
+
+W, H = 1928, 1208
+
+VARIANTS = {
+  "simple-noshadow-half":      {"METADRIVE_SIMPLE_RENDER": "1", "METADRIVE_NO_MSAA": "1", "METADRIVE_RENDER_SCALE": "0.5",
+                                "METADRIVE_NO_SHADOWS": "1"},
+  "simple-noshadow-noterrain-half": {"METADRIVE_SIMPLE_RENDER": "1", "METADRIVE_NO_MSAA": "1", "METADRIVE_RENDER_SCALE": "0.5",
+                                     "METADRIVE_NO_SHADOWS": "1", "METADRIVE_NO_TERRAIN": "1"},
+  "simple-noshadow-cheapterrain-half": {"METADRIVE_SIMPLE_RENDER": "1", "METADRIVE_NO_MSAA": "1", "METADRIVE_RENDER_SCALE": "0.5",
+                                        "METADRIVE_NO_SHADOWS": "1", "METADRIVE_CHEAP_TERRAIN": "1"},
+  "flatcard-half":             {"METADRIVE_SIMPLE_RENDER": "1", "METADRIVE_NO_MSAA": "1", "METADRIVE_RENDER_SCALE": "0.5",
+                                "METADRIVE_NO_SHADOWS": "1", "METADRIVE_FLAT_TERRAIN_CARD": "1"},
+  "flatcard-full":             {"METADRIVE_SIMPLE_RENDER": "1", "METADRIVE_NO_MSAA": "1",
+                                "METADRIVE_NO_SHADOWS": "1", "METADRIVE_FLAT_TERRAIN_CARD": "1"},
+}
+
+PYSPY_VARIANTS = ()
+
+OUT_DIR = "/tmp/render_bench"
+
+
+def save_ppm(path, img):
+  with open(path, "wb") as f:
+    f.write(b"P6\n%d %d\n255\n" % (img.shape[1], img.shape[0]))
+    f.write(np.ascontiguousarray(img).tobytes())
+
+WARMUP_FRAMES = 30
+BENCH_FRAMES = 100
+
+
+def measure():
+  # env flags must be applied before the engine is created
+  from openpilot.tools.sim.bridge.metadrive.ci_render_patches import apply_ci_render_patches
+  apply_ci_render_patches()
+
+  from metadrive.component.map.pg_map import MapGenerateMethod
+  from metadrive.envs.metadrive_env import MetaDriveEnv
+  from openpilot.tools.sim.bridge.metadrive.metadrive_common import RGBCameraRoad
+
+  scale = float(os.environ.get("METADRIVE_RENDER_SCALE", "1"))
+  rw, rh = round(W * scale), round(H * scale)
+
+  def straight(length):
+    return {"id": "S", "pre_block_socket_index": 0, "length": length}
+
+  def curve(length, angle=45, direction=0):
+    return {"id": "C", "pre_block_socket_index": 0, "length": length, "radius": length, "angle": angle, "dir": direction}
+
+  ts = 60
+  config = dict(
+    use_render=False,
+    vehicle_config=dict(enable_reverse=False, render_vehicle=False, image_source="rgb_road"),
+    sensors={"rgb_road": (RGBCameraRoad, rw, rh)},
+    image_on_cuda=False,
+    image_observation=True,
+    interface_panel=[],
+    out_of_route_done=False,
+    on_continuous_line_done=False,
+    crash_vehicle_done=False,
+    crash_object_done=False,
+    traffic_density=0.0,
+    map_config=dict(type=MapGenerateMethod.PG_MAP_FILE, lane_num=2, lane_width=4.5,
+                    config=[None, straight(ts), curve(ts * 2, 90), straight(ts), curve(ts * 2, 90),
+                            straight(ts), curve(ts * 2, 90), straight(ts), curve(ts * 2, 90)]),
+    decision_repeat=1,
+    physics_world_step_size=0.05,
+    preload_models=False,
+    show_logo=False,
+    anisotropic_filtering=False,
+    show_terrain=not bool(os.environ.get("METADRIVE_NO_TERRAIN")),
+  )
+
+  env = MetaDriveEnv(config)
+  env.reset()
+  cam = env.engine.sensors["rgb_road"]
+  cam.get_cam().reparentTo(env.agent.origin)
+
+  def frame():
+    env.step([0, 0.2])
+    img = cam.perceive(to_float=False)
+    if not isinstance(img, np.ndarray):
+      img = img.get()
+    if img.shape[0] != H or img.shape[1] != W:
+      img = img.repeat(H // img.shape[0], axis=0).repeat(W // img.shape[1], axis=1)
+    return img
+
+  for _ in range(WARMUP_FRAMES):
+    img = frame()
+  name = os.environ.get("RENDER_BENCH_NAME", "variant")
+  os.makedirs(OUT_DIR, exist_ok=True)
+  save_ppm(os.path.join(OUT_DIR, f"{name}.ppm"), img)
+  t0 = time.monotonic()
+  for _ in range(BENCH_FRAMES):
+    frame()
+  dt = time.monotonic() - t0
+  print(json.dumps({"fps": round(BENCH_FRAMES / dt, 2)}))
+  env.close()
+
+
+if __name__ == "__main__":
+  if "--measure" in sys.argv:
+    measure()
+    sys.exit(0)
+
+  results = {}
+  for name, flags in VARIANTS.items():
+    env = os.environ.copy()
+    env.update(flags)
+    env["RENDER_BENCH_NAME"] = name
+    try:
+      child = subprocess.Popen([sys.executable, os.path.abspath(__file__), "--measure"],
+                               env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+      prof = None
+      if os.environ.get("RENDER_BENCH_PYSPY") and name in PYSPY_VARIANTS:
+        os.makedirs(OUT_DIR, exist_ok=True)
+        prof = subprocess.Popen(["sudo", "-n", "env", "PATH=" + os.environ["PATH"],
+                                 "py-spy", "record", "--native", "-d", "45", "-r", "50", "-f", "speedscope",
+                                 "-o", os.path.join(OUT_DIR, f"pyspy_{name}.json"), "--pid", str(child.pid)])
+      stdout, stderr = child.communicate(timeout=600)
+      if prof is not None:
+        prof.wait()
+      line = [l for l in stdout.splitlines() if l.startswith("{")]
+      if line:
+        results[name] = json.loads(line[-1])["fps"]
+      else:
+        err = [l for l in stderr.splitlines() if l.strip()]
+        results[name] = f"failed (rc={child.returncode}): {' | '.join(err[-5:])[:500]}"
+    except Exception as e:
+      results[name] = f"error: {e}"
+    print(f"{name:35s} {results[name]}", flush=True)
+
+  print("\n=== RENDER BENCH RESULTS (target: >=20 fps) ===")
+  for name, fps in results.items():
+    print(f"{name:35s} {fps}")

--- a/openpilot/tools/sim/tests/render_bench.py
+++ b/openpilot/tools/sim/tests/render_bench.py
@@ -63,28 +63,28 @@ def measure():
     return {"id": "C", "pre_block_socket_index": 0, "length": length, "radius": length, "angle": angle, "dir": direction}
 
   ts = 60
-  config = dict(
-    use_render=False,
-    vehicle_config=dict(enable_reverse=False, render_vehicle=False, image_source="rgb_road"),
-    sensors={"rgb_road": (RGBCameraRoad, rw, rh)},
-    image_on_cuda=False,
-    image_observation=True,
-    interface_panel=[],
-    out_of_route_done=False,
-    on_continuous_line_done=False,
-    crash_vehicle_done=False,
-    crash_object_done=False,
-    traffic_density=0.0,
-    map_config=dict(type=MapGenerateMethod.PG_MAP_FILE, lane_num=2, lane_width=4.5,
-                    config=[None, straight(ts), curve(ts * 2, 90), straight(ts), curve(ts * 2, 90),
-                            straight(ts), curve(ts * 2, 90), straight(ts), curve(ts * 2, 90)]),
-    decision_repeat=1,
-    physics_world_step_size=0.05,
-    preload_models=False,
-    show_logo=False,
-    anisotropic_filtering=False,
-    show_terrain=not bool(os.environ.get("METADRIVE_NO_TERRAIN")),
-  )
+  config = {
+    "use_render": False,
+    "vehicle_config": {"enable_reverse": False, "render_vehicle": False, "image_source": "rgb_road"},
+    "sensors": {"rgb_road": (RGBCameraRoad, rw, rh)},
+    "image_on_cuda": False,
+    "image_observation": True,
+    "interface_panel": [],
+    "out_of_route_done": False,
+    "on_continuous_line_done": False,
+    "crash_vehicle_done": False,
+    "crash_object_done": False,
+    "traffic_density": 0.0,
+    "map_config": {"type": MapGenerateMethod.PG_MAP_FILE, "lane_num": 2, "lane_width": 4.5,
+                    "config": [None, straight(ts), curve(ts * 2, 90), straight(ts), curve(ts * 2, 90),
+                            straight(ts), curve(ts * 2, 90), straight(ts), curve(ts * 2, 90)]},
+    "decision_repeat": 1,
+    "physics_world_step_size": 0.05,
+    "preload_models": False,
+    "show_logo": False,
+    "anisotropic_filtering": False,
+    "show_terrain": not bool(os.environ.get("METADRIVE_NO_TERRAIN")),
+  }
 
   env = MetaDriveEnv(config)
   env.reset()


### PR DESCRIPTION
Towards #30693 (MetaDrive simulation test in GitHub Actions).

Full profiling writeup: https://github.com/commaai/openpilot/issues/30693#issuecomment-4878991707

## What this does

Free `ubuntu-24.04` runners render through Mesa LLVMpipe, which can't sustain MetaDrive's default pipeline in real time (~2.5 fps against the 20 fps the bridge needs — the camera thread blocks on `image_lock`, so a slow renderer starves modeld of frames, not just CPU). This PR gets rendering to a locked 20 fps with the full openpilot stack running:

- **Env-gated CI render patches** (`tools/sim/bridge/metadrive/ci_render_patches.py`, all off by default):
  - skip the 16x-MSAA float-HDR + tonemap camera pipeline hardcoded in metadrive's `RGBCamera` (this cost is resolution-independent, which is why nobody's resolution tweaks helped)
  - deactivate the per-frame PSSM shadow passes
  - replace the `ShaderTerrainMesh` visual with a single flat quad + flat-lit terrain shader (PG-map terrain is flat and physics already uses a plane; the mesh's draw path was ~80% of remaining LLVMpipe frame time, invariant to tessellation/chunk size/fragment shader)
  - render at half resolution with nearest upscale (model input is 512x256, so no information loss)
- **Log artifacts**: `CI_SIM_LOGS` unblocks loggerd/encoderd in sim; each CI run uploads qlog.zst, rlog.zst and qcamera.ts (~4 MB; full-res fcamera.hevc is ~1 GB/80 s and excluded)
- **`tools/sim/tests/render_bench.py`**: same-runner benchmark of the render variants (free-runner CPU varies ~40% between runs, so cross-run comparisons mislead) with per-variant frame dumps
- **Profiling workflow**: per-process CPU, service message rates (joins the test's msgq prefix), core-dump backtraces

Frame comparison, benchmark tables, and run links are on the branch history and in the issue comment.

## What this does NOT solve (why draft)

With rendering fixed, `roadCameraState` flows at 20.8 Hz but **modelV2 comes out of modeld at 2.0–2.2 Hz** (tinygrad `CPU:LLVM`, ~500 ms/frame flat out; `BEAM=2` autotune gets 3.6 Hz at +30 min compile). The `live*` estimator chain runs at model rate, never validates, so the test can't reach engagement. That last ~6x isn't something I can fix from outside — it needs either a lighter CI model checkpoint, an accepted lower modeld rate under CI, or the 8-core runners (details + questions in the issue comment).

Also observed while testing: `soundd` can't start on runners since `setup_vsound.sh` was removed in #37305 (handled here via `BLOCK=soundd` in the workflow), and an intermittent modeld SIGSEGV inside a JIT'd tinygrad CPU kernel under load (core dump + backtrace captured in the harness; manager restarts it).

Happy to reshape this however you prefer; fold the flags into `CI=1`, drop the profiling workflow, or split the bridge patches from the CI pieces.
