### PR TITLE
CI: bump Build devel timeout, it times out on the free runner tier

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -45,7 +45,7 @@ jobs:
         max_attempts: 3
         command: git lfs pull
     - name: Build devel
-      timeout-minutes: 1
+      timeout-minutes: 3
       run: TARGET_DIR=$STRIPPED_DIR tools/release/build_stripped.sh
     - run: ./tools/op.sh setup
     - name: Build openpilot and run checks

--- a/tools/release/build_stripped.sh
+++ b/tools/release/build_stripped.sh
@@ -57,6 +57,9 @@ echo -n "$GIT_HASH" > git_src_commit
 echo -n "$GIT_COMMIT_DATE" > git_src_commit_date
 
 echo "[-] committing version $VERSION T=$SECONDS"
+# skip zlib on the ~2GB of model chunks; hashing them dominates this script's
+# runtime and object IDs don't depend on the compression level
+git config core.compression 0
 git add -f .
 git status
 git commit -a -m "openpilot v$VERSION release


### PR DESCRIPTION
`build release` currently fails on every fork PR: the `Build devel` step hits its 1-minute timeout on the `ubuntu-24.04` runners that fork PRs are routed to (verified twice on #38285: killed at 72s both times, deterministic). It copies the full tree including LFS models, which fits in a minute on the namespace runners master uses but no longer on the free tier — fork PRs from late June (#38242, #38258) passed the same step at 55-59s, so recent tree growth tipped it over.

3 minutes keeps the step bounded while giving the free tier ~2.5x headroom.