### PR TITLE
Re-Add USB Panda Support

### DIFF
--- a/openpilot/selfdrive/pandad/SConscript
+++ b/openpilot/selfdrive/pandad/SConscript
@@ -1,10 +1,16 @@
+import libusb
+
 Import('env', 'arch', 'common', 'messaging')
 
 if arch != "Darwin":
-  libs = [common, messaging, 'pthread']
-  panda = env.Library('panda', ['panda.cc', 'spi.cc'])
+  pandad_env = env.Clone()
+  pandad_env.Append(CPPPATH=[libusb.INCLUDE_DIR])
+  pandad_env.Append(LIBPATH=[libusb.LIB_DIR])
 
-  env.Program('pandad', ['main.cc', 'pandad.cc', 'panda_safety.cc'], LIBS=[panda] + libs)
+  libs = ['usb-1.0', common, messaging, 'pthread']
+  panda = pandad_env.Library('panda', ['panda.cc', 'panda_comms.cc', 'spi.cc'])
+
+  pandad_env.Program('pandad', ['main.cc', 'pandad.cc', 'panda_safety.cc'], LIBS=[panda] + libs)
 
   if GetOption('extras'):
-    env.Program('tests/test_pandad_canprotocol', ['tests/test_pandad_canprotocol.cc'], LIBS=[panda] + libs)
+    pandad_env.Program('tests/test_pandad_canprotocol', ['tests/test_pandad_canprotocol.cc'], LIBS=[panda] + libs)

--- a/openpilot/selfdrive/pandad/panda.cc
+++ b/openpilot/selfdrive/pandad/panda.cc
@@ -2,6 +2,7 @@
 
 #include <unistd.h>
 
+#include <algorithm>
 #include <cassert>
 #include <stdexcept>
 #include <vector>
@@ -13,8 +14,13 @@
 const bool PANDAD_MAXOUT = getenv("PANDAD_MAXOUT") != nullptr;
 
 Panda::Panda(std::string serial) {
-  handle = std::make_unique<PandaSpiHandle>(serial);
-  LOGW("connected to %s over SPI", serial.c_str());
+  try {
+    handle = std::make_unique<PandaUsbHandle>(serial);
+    LOGW("connected to %s over USB", serial.c_str());
+  } catch (std::exception &e) {
+    handle = std::make_unique<PandaSpiHandle>(serial);
+    LOGW("connected to %s over SPI", serial.c_str());
+  }
 
   hw_type = get_hw_type();
   can_reset_communications();
@@ -33,7 +39,13 @@ std::string Panda::hw_serial() {
 }
 
 std::vector<std::string> Panda::list() {
-  return PandaSpiHandle::list();
+  std::vector<std::string> serials = PandaUsbHandle::list();
+  for (const auto &s : PandaSpiHandle::list()) {
+    if (std::find(serials.begin(), serials.end(), s) == serials.end()) {
+      serials.push_back(s);
+    }
+  }
+  return serials;
 }
 
 void Panda::set_safety_model(cereal::CarParams::SafetyModel safety_model, uint16_t safety_param) {

--- a/openpilot/selfdrive/pandad/panda.h
+++ b/openpilot/selfdrive/pandad/panda.h
@@ -45,7 +45,7 @@ struct can_frame {
 
 class Panda {
 private:
-  std::unique_ptr<PandaSpiHandle> handle;
+  std::unique_ptr<PandaCommsHandle> handle;
 
 public:
   Panda(std::string serial);

--- a/openpilot/selfdrive/pandad/panda_comms.cc
+++ b/openpilot/selfdrive/pandad/panda_comms.cc
@@ -1,0 +1,222 @@
+#include "selfdrive/pandad/panda.h"
+
+#include <cassert>
+#include <stdexcept>
+#include <memory>
+
+#include "common/swaglog.h"
+
+static libusb_context *init_usb_ctx() {
+  libusb_context *context = nullptr;
+  int err = libusb_init(&context);
+  if (err != 0) {
+    LOGE("libusb initialization error");
+    return nullptr;
+  }
+
+#if LIBUSB_API_VERSION >= 0x01000106
+  libusb_set_option(context, LIBUSB_OPTION_LOG_LEVEL, LIBUSB_LOG_LEVEL_INFO);
+#else
+  libusb_set_debug(context, 3);
+#endif
+  return context;
+}
+
+PandaUsbHandle::PandaUsbHandle(std::string serial) : PandaCommsHandle(serial) {
+  ssize_t num_devices;
+  libusb_device **dev_list = NULL;
+  int err = 0;
+  ctx = init_usb_ctx();
+  if (!ctx) { goto fail; }
+
+  num_devices = libusb_get_device_list(ctx, &dev_list);
+  if (num_devices < 0) { goto fail; }
+  for (size_t i = 0; i < num_devices; ++i) {
+    libusb_device_descriptor desc;
+    libusb_get_device_descriptor(dev_list[i], &desc);
+    if (desc.idVendor == 0x3801 && desc.idProduct == 0xddcc) {
+      int ret = libusb_open(dev_list[i], &dev_handle);
+      if (dev_handle == NULL || ret < 0) { goto fail; }
+
+      unsigned char desc_serial[26] = { 0 };
+      ret = libusb_get_string_descriptor_ascii(dev_handle, desc.iSerialNumber, desc_serial, std::size(desc_serial));
+      if (ret < 0) { goto fail; }
+
+      hw_serial = std::string((char *)desc_serial, ret);
+      if (serial.empty() || serial == hw_serial) {
+        break;
+      }
+      libusb_close(dev_handle);
+      dev_handle = NULL;
+    }
+  }
+  if (dev_handle == NULL) goto fail;
+  libusb_free_device_list(dev_list, 1);
+  dev_list = nullptr;
+
+  if (libusb_kernel_driver_active(dev_handle, 0) == 1) {
+    libusb_detach_kernel_driver(dev_handle, 0);
+  }
+
+  err = libusb_set_configuration(dev_handle, 1);
+  if (err != 0) { goto fail; }
+
+  err = libusb_claim_interface(dev_handle, 0);
+  if (err != 0) { goto fail; }
+
+  return;
+
+fail:
+  if (dev_list != NULL) {
+    libusb_free_device_list(dev_list, 1);
+  }
+  cleanup();
+  throw std::runtime_error("Error connecting to panda");
+}
+
+PandaUsbHandle::~PandaUsbHandle() {
+  std::lock_guard lk(hw_lock);
+  cleanup();
+  connected = false;
+}
+
+void PandaUsbHandle::cleanup() {
+  if (dev_handle) {
+    libusb_release_interface(dev_handle, 0);
+    libusb_close(dev_handle);
+  }
+
+  if (ctx) {
+    libusb_exit(ctx);
+  }
+}
+
+std::vector<std::string> PandaUsbHandle::list() {
+  static std::unique_ptr<libusb_context, decltype(&libusb_exit)> context(init_usb_ctx(), libusb_exit);
+  ssize_t num_devices;
+  libusb_device **dev_list = NULL;
+  std::vector<std::string> serials;
+  if (!context) { return serials; }
+
+  num_devices = libusb_get_device_list(context.get(), &dev_list);
+  if (num_devices < 0) {
+    LOGE("libusb can't get device list");
+    goto finish;
+  }
+  for (size_t i = 0; i < num_devices; ++i) {
+    libusb_device *device = dev_list[i];
+    libusb_device_descriptor desc;
+    libusb_get_device_descriptor(device, &desc);
+    if (desc.idVendor == 0x3801 && desc.idProduct == 0xddcc) {
+      libusb_device_handle *handle = NULL;
+      int ret = libusb_open(device, &handle);
+      if (ret < 0) { goto finish; }
+
+      unsigned char desc_serial[26] = { 0 };
+      ret = libusb_get_string_descriptor_ascii(handle, desc.iSerialNumber, desc_serial, std::size(desc_serial));
+      libusb_close(handle);
+      if (ret < 0) { goto finish; }
+
+      serials.push_back(std::string((char *)desc_serial, ret));
+    }
+  }
+
+finish:
+  if (dev_list != NULL) {
+    libusb_free_device_list(dev_list, 1);
+  }
+  return serials;
+}
+
+void PandaUsbHandle::handle_usb_issue(int err, const char func[]) {
+  LOGE_100("usb error %d \"%s\" in %s", err, libusb_strerror((enum libusb_error)err), func);
+  if (err == LIBUSB_ERROR_NO_DEVICE) {
+    LOGE("lost connection");
+    connected = false;
+  }
+}
+
+int PandaUsbHandle::control_write(uint8_t bRequest, uint16_t wValue, uint16_t wIndex, unsigned int timeout) {
+  int err;
+  const uint8_t bmRequestType = LIBUSB_ENDPOINT_OUT | LIBUSB_REQUEST_TYPE_VENDOR | LIBUSB_RECIPIENT_DEVICE;
+
+  if (!connected) {
+    return LIBUSB_ERROR_NO_DEVICE;
+  }
+
+  std::lock_guard lk(hw_lock);
+  do {
+    err = libusb_control_transfer(dev_handle, bmRequestType, bRequest, wValue, wIndex, NULL, 0, timeout);
+    if (err < 0) handle_usb_issue(err, __func__);
+  } while (err < 0 && connected);
+
+  return err;
+}
+
+int PandaUsbHandle::control_read(uint8_t bRequest, uint16_t wValue, uint16_t wIndex, unsigned char *data, uint16_t wLength, unsigned int timeout) {
+  int err;
+  const uint8_t bmRequestType = LIBUSB_ENDPOINT_IN | LIBUSB_REQUEST_TYPE_VENDOR | LIBUSB_RECIPIENT_DEVICE;
+
+  if (!connected) {
+    return LIBUSB_ERROR_NO_DEVICE;
+  }
+
+  std::lock_guard lk(hw_lock);
+  do {
+    err = libusb_control_transfer(dev_handle, bmRequestType, bRequest, wValue, wIndex, data, wLength, timeout);
+    if (err < 0) handle_usb_issue(err, __func__);
+  } while (err < 0 && connected);
+
+  return err;
+}
+
+int PandaUsbHandle::bulk_write(unsigned char endpoint, unsigned char* data, int length, unsigned int timeout) {
+  int err;
+  int transferred = 0;
+
+  if (!connected) {
+    return 0;
+  }
+
+  std::lock_guard lk(hw_lock);
+  do {
+    // If the panda receive buffer is full it will NAK; libusb retries until timeout. Drop the messages.
+    err = libusb_bulk_transfer(dev_handle, endpoint, data, length, &transferred, timeout);
+
+    if (err == LIBUSB_ERROR_TIMEOUT) {
+      LOGW("Transmit buffer full");
+      break;
+    } else if (err != 0 || length != transferred) {
+      handle_usb_issue(err, __func__);
+    }
+  } while (err != 0 && connected);
+
+  return transferred;
+}
+
+int PandaUsbHandle::bulk_read(unsigned char endpoint, unsigned char* data, int length, unsigned int timeout) {
+  int err;
+  int transferred = 0;
+
+  if (!connected) {
+    return 0;
+  }
+
+  std::lock_guard lk(hw_lock);
+
+  do {
+    err = libusb_bulk_transfer(dev_handle, endpoint, data, length, &transferred, timeout);
+
+    if (err == LIBUSB_ERROR_TIMEOUT) {
+      break; // timeout is okay to exit, recv still happened
+    } else if (err == LIBUSB_ERROR_OVERFLOW) {
+      comms_healthy = false;
+      LOGE_100("overflow got 0x%x", transferred);
+    } else if (err != 0) {
+      handle_usb_issue(err, __func__);
+    }
+
+  } while (err != 0 && connected);
+
+  return transferred;
+}

--- a/openpilot/selfdrive/pandad/panda_comms.h
+++ b/openpilot/selfdrive/pandad/panda_comms.h
@@ -6,17 +6,50 @@
 #include <string>
 #include <vector>
 
+#include <libusb-1.0/libusb.h>
+
 
 #define TIMEOUT 0
 #define SPI_BUF_SIZE 2048
 
 
-class PandaSpiHandle {
+class PandaCommsHandle {
 public:
+  PandaCommsHandle(std::string serial) {}
+  virtual ~PandaCommsHandle() {}
+  virtual void cleanup() = 0;
+
   std::string hw_serial;
   std::atomic<bool> connected = true;
   std::atomic<bool> comms_healthy = true;
 
+  virtual int control_write(uint8_t request, uint16_t param1, uint16_t param2, unsigned int timeout=TIMEOUT) = 0;
+  virtual int control_read(uint8_t request, uint16_t param1, uint16_t param2, unsigned char *data, uint16_t length, unsigned int timeout=TIMEOUT) = 0;
+  virtual int bulk_write(unsigned char endpoint, unsigned char* data, int length, unsigned int timeout=TIMEOUT) = 0;
+  virtual int bulk_read(unsigned char endpoint, unsigned char* data, int length, unsigned int timeout=TIMEOUT) = 0;
+};
+
+class PandaUsbHandle : public PandaCommsHandle {
+public:
+  PandaUsbHandle(std::string serial);
+  ~PandaUsbHandle();
+  int control_write(uint8_t request, uint16_t param1, uint16_t param2, unsigned int timeout=TIMEOUT);
+  int control_read(uint8_t request, uint16_t param1, uint16_t param2, unsigned char *data, uint16_t length, unsigned int timeout=TIMEOUT);
+  int bulk_write(unsigned char endpoint, unsigned char* data, int length, unsigned int timeout=TIMEOUT);
+  int bulk_read(unsigned char endpoint, unsigned char* data, int length, unsigned int timeout=TIMEOUT);
+  void cleanup();
+
+  static std::vector<std::string> list();
+
+private:
+  libusb_context *ctx = NULL;
+  libusb_device_handle *dev_handle = NULL;
+  std::recursive_mutex hw_lock;
+  void handle_usb_issue(int err, const char func[]);
+};
+
+class PandaSpiHandle : public PandaCommsHandle {
+public:
   PandaSpiHandle(std::string serial);
   ~PandaSpiHandle();
 

--- a/openpilot/selfdrive/pandad/pandad.py
+++ b/openpilot/selfdrive/pandad/pandad.py
@@ -76,14 +76,11 @@ def main() -> None:
     cloudlog.exception("pandad.uncaught_exception")
 
   count = 0
+  selected_serial = last_serial = None
+  using_usb_panda = False
   while not do_exit:
     try:
       cloudlog.event("pandad.flash_and_connect", count=count)
-      if (count % 2) == 0:
-        HARDWARE.reset_internal_panda()
-      else:
-        HARDWARE.recover_internal_panda()
-      count += 1
 
       # Flash all Pandas in DFU mode
       for serial in PandaDFU.list():
@@ -91,9 +88,21 @@ def main() -> None:
         PandaDFU(serial).recover()
         time.sleep(1)
 
-      panda_serials = Panda.list()
-      if len(panda_serials):
+      # prefer a USB panda (e.g. red panda for CAN FD) over the internal SPI panda
+      panda_serials = Panda.list(usb_only=True)
+      if panda_serials:
+        cloudlog.info(f"USB panda found, ignoring internal panda {panda_serials}")
+        using_usb_panda = True
+      else:
+        panda_serials = Panda.list()
+
+      # never hotswap to a different panda than the one we already connected to
+      if selected_serial is not None and panda_serials != [selected_serial]:
+        if panda_serials != last_serial: # only log if the list of pandas has changed
+          cloudlog.error(f"panda {selected_serial} no longer present or preferred ({panda_serials}), attempting to reconnect...")
+      elif panda_serials:
         assert len(panda_serials) == 1
+        selected_serial = panda_serials[0]
         cloudlog.info(f"{len(panda_serials)} panda found, connecting - {panda_serials}")
         flash_panda(panda_serials[0])
 
@@ -101,6 +110,18 @@ def main() -> None:
         os.environ['MANAGER_DAEMON'] = 'pandad'
         process = subprocess.Popen(["./pandad"], cwd=os.path.join(BASEDIR, "openpilot/selfdrive/pandad"))
         process.wait()
+
+      last_serial= panda_serials
+
+      if not using_usb_panda:
+        if (count % 2) == 0:
+          HARDWARE.reset_internal_panda()
+        else:
+          HARDWARE.recover_internal_panda()
+      count += 1
+
+      time.sleep(0.5) # Prevent busy loop if no panda is connected
+
     # TODO: wrap all panda exceptions in a base panda exception
     except (usb1.USBErrorNoDevice, usb1.USBErrorPipe):
       # a panda was disconnected while setting everything up. let's try again

--- a/openpilot/selfdrive/pandad/spi.cc
+++ b/openpilot/selfdrive/pandad/spi.cc
@@ -54,7 +54,7 @@ private:
          util::hexdump(tx_buf, std::min((int)header.tx_len, 8)).c_str()); \
       } while (0)
 
-PandaSpiHandle::PandaSpiHandle(std::string serial) {
+PandaSpiHandle::PandaSpiHandle(std::string serial) : PandaCommsHandle(serial) {
   int ret;
   const int uid_len = 12;
   uint8_t uid[uid_len] = {0};


### PR DESCRIPTION
# Goal
This PR follows the request in https://github.com/commaai/openpilot/issues/38251 and is a partial (USB Only) reversion of https://github.com/commaai/openpilot/pull/37217.

# Changes 
https://github.com/commaai/openpilot/pull/37217 cited code complexity as the reason for removing both multi-panda and USB support. This PR shows those are separable: reintroducing USB-only support requires touching only `selfdrive/pandad`, with the bulk of the complexity in #37217 coming from multi-panda handling, which this PR does not restore.

The only non-revert changes to existing logic are in `selfdrive/pandad/pandad.py`. 

# Highlights
* Added back USB panda support for PC. `selfdrive/pandad/pandad.py` always checks for a USB panda first, before falling back to SPI.
* **No hotswap**: If a USB panda is initially detected, it will not fall back on the SPI panda if it is unplugged. The UI will show No Panda if the USB panda is disconnected. `pandad` will continue attempting to reconnect to the USB panda and resume as normal if it is plugged back in. Similarly, if a USB panda is plugged in after `pandad` connects to the SPI panda, the USB panda is ignored.
* Relevant logging added for USB support in `selfdrive/pandad/pandad.py`

* **Bug Fix:** A 0.5 second sleep was added to the bottom of the loop in `selfdrive/pandad/pandad.py`, preventing a busy-loop with no backoff if no panda device is found. This is primarily for running on PC where no SPI panda exists.

# Testing
The logic was tested on Ubuntu 24.04 & TIZI hardware with a USB red panda on a 2020 Toyota RAV4. This PR has **not** been tested extensively on-road, or on MICI hardware.

## Note
The community guidelines state new feature PR's are closed, which this may qualify under. Even if closed, this may serve as a starting point for how USB support was added back on our private fork, if the maintainers decide to add USB support back in the future (https://github.com/commaai/openpilot/issues/38251#issuecomment-4878377796)