### PR TITLE
logmessaged: drop records too big for the msgq queue instead of dying

### DIFF
--- a/openpilot/system/logmessaged.py
+++ b/openpilot/system/logmessaged.py
@@ -8,6 +8,13 @@ from openpilot.common.hardware.hw import Paths
 from openpilot.common.swaglog import get_file_handler
 
 
+# msgq queues are 256KiB and msgq asserts that a single message fits in a third
+# of the queue. Records over this limit must be dropped before publishing, or
+# logmessaged dies with SIGABRT - and the crash of the logging daemon is the
+# one crash that can never be logged.
+MAX_PUBLISH_BYTES = 80 * 1024
+
+
 def main() -> NoReturn:
   log_handler = get_file_handler()
   log_handler.setFormatter(SwagLogFileFormatter(None))
@@ -29,7 +36,7 @@ def main() -> NoReturn:
       if level >= log_level:
         log_handler.emit(record)
 
-      if len(record) > 2*1024*1024:
+      if len(record) > MAX_PUBLISH_BYTES:
         print("WARNING: log too big to publish", len(record))
         print(record[:100])
         continue

--- a/openpilot/system/tests/test_logmessaged.py
+++ b/openpilot/system/tests/test_logmessaged.py
@@ -53,3 +53,25 @@ class TestLogmessaged:
     logsize = sum([os.path.getsize(f) for f in self._get_log_files()])
     assert (n*len(msg)) < logsize < (n*(len(msg)+1024))
 
+  def test_medium_log(self):
+    # records between the msgq limit (a message must fit in a third of the
+    # 256KiB queue, ~85KB) and the old 2MB guard used to crash logmessaged
+    # with a msgq assertion, killing logging for the rest of the drive
+    big = "a" * (200 * 1024)
+    cloudlog.info(big)
+    cloudlog.error("alive after big record")
+    time.sleep(0.5)
+
+    # logmessaged survived the big record
+    assert managed_processes['logmessaged'].proc.is_alive()
+
+    # the big record is dropped from the socket, later records still flow
+    msgs = messaging.drain_sock(self.sock)
+    texts = [m.logMessage for m in msgs]
+    assert not any(len(t) >= len(big) for t in texts)
+    assert any("alive after big record" in t for t in texts)
+
+    # both records still land in the on-disk log
+    logsize = sum([os.path.getsize(f) for f in self._get_log_files()])
+    assert logsize > len(big)
+


### PR DESCRIPTION
**Description**

logmessaged re-publishes every log record onto the `logMessage` msgq socket. msgq
queues are 256KiB and `msgq_msg_send()` asserts that a message fits in a third of the
queue — so any record over ~85KB is a SIGABRT. The existing guard only rejects
records over 2MB, leaving an 85KB–2MB band where a single large log record kills the
daemon. Since a crashed logmessaged takes down the whole logging pipeline, the crash
itself is never logged: the only symptoms are a permanent
"Process Not Running: logmessaged" and silent loss of all swaglogs for the drive.

This is reachable from stock code: `updated.py` logs the full working-tree
`git diff output` as a single record — on a comma three with a dirty tree (~17 files)
that record was 130KB, and logmessaged died seconds after every boot and stayed down
for the rest of the drive (it isn't watchdogged or `restart_if_crash`).

Fix: lower the guard to fit the actual queue capacity. Oversized records are still
written to the on-disk log (the file write happens before the publish) — they are
only dropped from the msgq stream, same as the existing >2MB behavior.

**Verification**

New `test_medium_log`: a 200KB record must not kill logmessaged, later records must
still flow on the socket, and both records must land in the on-disk log. Fails on
master (logmessaged dies with the msgq assertion), passes with the fix — verified on
a comma three against this exact code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
