### PR TITLE
Fix JotPluggler remote streaming

### DIFF
--- a/openpilot/cereal/messaging/bridge.cc
+++ b/openpilot/cereal/messaging/bridge.cc
@@ -1,4 +1,8 @@
 #include <cassert>
+#include <cerrno>
+#include <cstdio>
+#include <cstring>
+#include <unistd.h>
 
 #include "openpilot/cereal/messaging/msgq_to_zmq.h"
 #include "openpilot/cereal/services.h"
@@ -34,8 +38,17 @@ void zmq_to_msgq(const std::vector<std::string> &endpoints, const std::string &i
     auto pub_sock = new PubSocket();
     auto sub_sock = new BridgeZmqSubSocket();
     size_t queue_size = services.at(endpoint).queue_size;
-    pub_sock->connect(pub_context.get(), endpoint, true, queue_size);
-    sub_sock->connect(sub_context.get(), endpoint, ip, false);
+    if (pub_sock->connect(pub_context.get(), endpoint, true, queue_size) != 0) {
+      const int error = errno;
+      dprintf(STDERR_FILENO, "Failed to create MSGQ publisher for [%s]: %s\n", endpoint.c_str(), std::strerror(error));
+      _exit(1);
+    }
+    if (sub_sock->connect(sub_context.get(), endpoint, ip, false) != 0) {
+      const int error = zmq_errno();
+      dprintf(STDERR_FILENO, "Failed to connect ZMQ subscriber for [%s] at [%s]: %s\n",
+              endpoint.c_str(), ip.c_str(), zmq_strerror(error));
+      _exit(1);
+    }
 
     poller->registerSocket(sub_sock);
     sub2pub[sub_sock] = pub_sock;

--- a/openpilot/cereal/messaging/bridge.cc
+++ b/openpilot/cereal/messaging/bridge.cc
@@ -1,7 +1,9 @@
 #include <cassert>
 #include <cerrno>
 #include <cstdio>
+#include <cstdlib>
 #include <cstring>
+#include <filesystem>
 #include <unistd.h>
 
 #include "openpilot/cereal/messaging/msgq_to_zmq.h"
@@ -28,7 +30,7 @@ void msgq_to_zmq(const std::vector<std::string> &endpoints, const std::string &i
   bridge.run(endpoints, ip);
 }
 
-void zmq_to_msgq(const std::vector<std::string> &endpoints, const std::string &ip) {
+void zmq_to_msgq(const std::vector<std::string> &endpoints, const std::string &ip, pid_t parent_pid) {
   auto poller = std::make_unique<BridgeZmqPoller>();
   auto pub_context = std::make_unique<Context>();
   auto sub_context = std::make_unique<BridgeZmqContext>();
@@ -54,7 +56,7 @@ void zmq_to_msgq(const std::vector<std::string> &endpoints, const std::string &i
     sub2pub[sub_sock] = pub_sock;
   }
 
-  while (!do_exit) {
+  while (!do_exit && (parent_pid == 0 || getppid() == parent_pid)) {
     for (auto sub_sock : poller->poll(100)) {
       std::unique_ptr<Message> msg(sub_sock->receive(true));
       if (msg) {
@@ -74,10 +76,13 @@ int main(int argc, char **argv) {
   bool is_zmq_to_msgq = argc > 2;
   std::string ip = is_zmq_to_msgq ? argv[1] : "127.0.0.1";
   std::string whitelist_str = is_zmq_to_msgq ? std::string(argv[2]) : "";
+  const pid_t parent_pid = argc > 3 ? std::atoi(argv[3]) : 0;
   std::vector<std::string> endpoints = get_services(whitelist_str, is_zmq_to_msgq);
 
   if (is_zmq_to_msgq) {
-    zmq_to_msgq(endpoints, ip);
+    zmq_to_msgq(endpoints, ip, parent_pid);
+    std::error_code error;
+    if (argc > 4) std::filesystem::remove_all(argv[4], error);
   } else {
     msgq_to_zmq(endpoints, ip);
   }

--- a/openpilot/tools/jotpluggler/.gitignore
+++ b/openpilot/tools/jotpluggler/.gitignore
@@ -8,3 +8,4 @@ generated_dbcs/.stamp
 generated_dbcs/*.dbc
 layouts/.jotpluggler_autosave/
 reports/
+tests/test_stream_bridge

--- a/openpilot/tools/jotpluggler/.gitignore
+++ b/openpilot/tools/jotpluggler/.gitignore
@@ -8,4 +8,4 @@ generated_dbcs/.stamp
 generated_dbcs/*.dbc
 layouts/.jotpluggler_autosave/
 reports/
-tests/test_stream_bridge
+tests/test_stream_bridge*

--- a/openpilot/tools/jotpluggler/SConscript
+++ b/openpilot/tools/jotpluggler/SConscript
@@ -1,6 +1,7 @@
 import os
 import subprocess
 import bootstrap_icons
+import ffmpeg
 import imgui
 import libusb
 from opendbc import get_generated_dbcs
@@ -108,7 +109,14 @@ if arch == "Darwin":
 else:
   libs += ["GL", "dl"]
 
-program = jot_env.Program("jotpluggler", jot_env.Glob("*.cc"), LIBS=libs)
-jot_env.Depends(program, generated_dbc_stamp)
-jot_env.Depends(program, car_fingerprint_to_dbc)
-jot_env.Depends(program, event_extractors)
+jot_sources = [source for source in jot_env.Glob("*.cc") if os.path.basename(str(source)) != "main.cc"]
+jot_objects = jot_env.Object(jot_sources)
+jot_env.Depends(jot_objects, [generated_dbc_stamp, car_fingerprint_to_dbc, event_extractors])
+program = jot_env.Program("jotpluggler", ["main.cc"] + jot_objects, LIBS=libs)
+bridge = File("#openpilot/cereal/messaging/bridge")
+stream_test_env = jot_env.Clone()
+if arch == "Darwin":
+  stream_test_env["LINKFLAGS"] += [f"-Wl,-rpath,{ffmpeg.LIB_DIR}"]
+stream_bridge_test = stream_test_env.Program(
+  "tests/test_stream_bridge", ["tests/test_stream_bridge.cc"] + jot_objects, LIBS=libs)
+jot_env.Depends([program, stream_bridge_test], bridge)

--- a/openpilot/tools/jotpluggler/runtime.cc
+++ b/openpilot/tools/jotpluggler/runtime.cc
@@ -589,9 +589,9 @@ struct StreamPoller::Impl {
       const char *override = std::getenv("JOTP_STREAM_BRIDGE");
       const std::filesystem::path executable = override != nullptr
         ? override : repo_root() / "openpilot/cereal/messaging/bridge";
-      bridge_process.start(executable, {source.address, stream_bridge_whitelist(selected_services)});
+      bridge_process.start(executable, {source.address, stream_bridge_whitelist(selected_services)}, private_namespace->path());
     }
-    stream_setup_test_checkpoint(remote ? "remote-held" : "local-after", remote);
+    if (remote) stream_setup_test_checkpoint("remote-held", true);
 
     std::unique_ptr<Context> context(Context::create());
     std::unique_ptr<Poller> poller(Poller::create());
@@ -605,6 +605,7 @@ struct StreamPoller::Impl {
           msgq_socket->getQueue()->mmap_p = nullptr;
           msgq_socket->getQueue()->size = 0;
         }
+        if (!remote) continue;
         throw std::runtime_error("Failed to connect cereal service " + name + ": " + std::strerror(error));
       }
       socket->setTimeout(0);

--- a/openpilot/tools/jotpluggler/runtime.cc
+++ b/openpilot/tools/jotpluggler/runtime.cc
@@ -1,5 +1,6 @@
 #include "tools/jotpluggler/app.h"
 #include "tools/jotpluggler/common.h"
+#include "tools/jotpluggler/stream_bridge.h"
 
 #include "openpilot/cereal/services.h"
 #include "common/timing.h"
@@ -8,17 +9,20 @@
 #include "imgui_impl_opengl3_loader.h"
 #include "implot.h"
 #include "common/yuv.h"
-#include "msgq_repo/msgq/ipc.h"
+#include "msgq_repo/msgq/impl_msgq.h"
 #include "tools/replay/framereader.h"
 
 #include <GLFW/glfw3.h>
 
 #include <chrono>
+#include <cerrno>
 #include <cmath>
 #include <condition_variable>
 #include <cstdio>
 #include <cstdlib>
+#include <cstring>
 #include <deque>
+#include <fstream>
 #include <iomanip>
 #include <iostream>
 #include <mutex>
@@ -36,6 +40,15 @@ namespace {
 
 std::atomic<bool> g_glfw_alive{false};
 const bool kLogCameraTimings = env_flag_enabled("JOTP_CAMERA_TIMINGS");
+std::mutex stream_msgq_setup_mutex;
+void stream_setup_test_checkpoint(const char *name, bool wait_for_release = false) {
+  if (const char *root = std::getenv("JOTP_STREAM_SETUP_TEST"); root != nullptr && std::getenv("JOTP_STREAM_BRIDGE") != nullptr) {
+    std::ofstream(std::filesystem::path(root) / name).put('\n');
+    for (int i = 0; wait_for_release && !std::filesystem::exists(std::filesystem::path(root) / "release") && i < 5000; ++i) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+  }
+}
 
 CameraType decoder_camera_type(CameraViewKind view) {
   switch (view) {
@@ -559,29 +572,53 @@ struct StreamPoller::Impl {
   }
 
   void run_cereal_source(StreamAccumulator *accumulator) {
-    if (source.kind == StreamSourceKind::CerealRemote) {
-      setenv("ZMQ", "1", 1);
-    } else {
-      unsetenv("ZMQ");
+    const bool remote = source.kind == StreamSourceKind::CerealRemote;
+    std::vector<std::string> selected_services;
+    for (const auto &[name, _] : services) {
+      if (should_subscribe_stream_service(name)) selected_services.push_back(name);
     }
+    const bool setup_test = std::getenv("JOTP_STREAM_SETUP_TEST") != nullptr && std::getenv("JOTP_STREAM_BRIDGE") != nullptr;
+    std::unique_lock setup_lock(stream_msgq_setup_mutex, std::defer_lock);
+    if (!remote && setup_test && !setup_lock.try_lock()) stream_setup_test_checkpoint("local-blocked");
+    if (!setup_lock.owns_lock()) setup_lock.lock();
+    std::unique_ptr<ScopedMsgqPrefix> private_namespace;
+    StreamBridgeProcess bridge_process;
+    if (remote) {
+      private_namespace = std::make_unique<ScopedMsgqPrefix>();
+      private_namespace->activate();
+      const char *override = std::getenv("JOTP_STREAM_BRIDGE");
+      const std::filesystem::path executable = override != nullptr
+        ? override : repo_root() / "openpilot/cereal/messaging/bridge";
+      bridge_process.start(executable, {source.address, stream_bridge_whitelist(selected_services)});
+    }
+    stream_setup_test_checkpoint(remote ? "remote-held" : "local-after", remote);
 
     std::unique_ptr<Context> context(Context::create());
     std::unique_ptr<Poller> poller(Poller::create());
     std::vector<std::unique_ptr<SubSocket>> sockets;
-    sockets.reserve(services.size());
-    for (const auto &[name, info] : services) {
-      if (!should_subscribe_stream_service(name)) continue;
-      std::unique_ptr<SubSocket> socket(
-        SubSocket::create(context.get(), name.c_str(), source.address.c_str(), false, true, info.queue_size));
-      if (socket == nullptr) continue;
+    for (const std::string &name : selected_services) {
+      const service &info = services.at(name);
+      std::unique_ptr<SubSocket> socket(SubSocket::create());
+      if (socket->connect(context.get(), name, kStreamMsgqAddress, false, true, info.queue_size) != 0) {
+        const int error = errno;
+        if (auto *msgq_socket = dynamic_cast<MSGQSubSocket *>(socket.get()); msgq_socket && msgq_socket->getQueue()) {
+          msgq_socket->getQueue()->mmap_p = nullptr;
+          msgq_socket->getQueue()->size = 0;
+        }
+        throw std::runtime_error("Failed to connect cereal service " + name + ": " + std::strerror(error));
+      }
       socket->setTimeout(0);
       poller->registerSocket(socket.get());
       sockets.push_back(std::move(socket));
     }
+    if (private_namespace) private_namespace->restore();
+    setup_lock.unlock();
     if (sockets.empty()) throw std::runtime_error("Failed to connect to any cereal service");
+    if (remote) bridge_process.check_running();
     connected.store(true);
 
     while (running.load()) {
+      if (remote) bridge_process.check_running();
       std::vector<SubSocket *> ready = poller->poll(1);
       for (SubSocket *socket : ready) {
         while (running.load()) {

--- a/openpilot/tools/jotpluggler/stream_bridge.cc
+++ b/openpilot/tools/jotpluggler/stream_bridge.cc
@@ -1,0 +1,128 @@
+#include "tools/jotpluggler/stream_bridge.h"
+
+#include <cerrno>
+#include <csignal>
+#include <cstdlib>
+#include <cstring>
+#include <stdexcept>
+#include <thread>
+
+#include <spawn.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+extern char **environ;
+namespace {
+std::filesystem::path msgq_root() {
+#ifdef __APPLE__
+  return "/tmp";
+#else
+  return "/dev/shm";
+#endif
+}
+
+pid_t wait_nointr(pid_t pid, int *status, int options) {
+  pid_t result;
+  do { result = waitpid(pid, status, options); } while (result < 0 && errno == EINTR);
+  return result;
+}
+
+std::string exit_error(const std::string &executable, int status) {
+  if (WIFEXITED(status)) return executable + " exited with status " + std::to_string(WEXITSTATUS(status));
+  if (WIFSIGNALED(status)) return executable + " terminated by signal " + std::to_string(WTERMSIG(status));
+  return executable + " exited unexpectedly";
+}
+}  // namespace
+
+std::string stream_bridge_whitelist(const std::vector<std::string> &service_names) {
+  std::string whitelist;
+  for (const std::string &name : service_names) whitelist += "/\"" + name + "\"/";
+  return whitelist;
+}
+ScopedMsgqPrefix::ScopedMsgqPrefix() {
+  std::string path_template = (msgq_root() / ("msgq_jotp_" + std::to_string(getpid()) + "_XXXXXX")).string();
+  char *created = mkdtemp(path_template.data());
+  if (created == nullptr) throw std::runtime_error("Failed to create a private MSGQ namespace: " + std::string(std::strerror(errno)));
+  path_ = created;
+  prefix_ = path_.filename().string().substr(std::strlen("msgq_"));
+}
+ScopedMsgqPrefix::~ScopedMsgqPrefix() {
+  restore();
+  std::error_code error;
+  std::filesystem::remove_all(path_, error);
+}
+void ScopedMsgqPrefix::activate() {
+  if (active_) throw std::runtime_error("MSGQ namespace is already active");
+  previous_prefix_.reset();
+  if (const char *prefix = std::getenv("OPENPILOT_PREFIX")) previous_prefix_ = prefix;
+  if (setenv("OPENPILOT_PREFIX", prefix_.c_str(), 1) != 0) {
+    throw std::runtime_error("Failed to activate MSGQ namespace: " + std::string(std::strerror(errno)));
+  }
+  active_ = true;
+}
+void ScopedMsgqPrefix::restore() noexcept {
+  if (!active_) return;
+  if (previous_prefix_) setenv("OPENPILOT_PREFIX", previous_prefix_->c_str(), 1);
+  else unsetenv("OPENPILOT_PREFIX");
+  active_ = false;
+}
+StreamBridgeProcess::StreamBridgeProcess(std::chrono::milliseconds terminate_grace) : terminate_grace_(terminate_grace) {}
+StreamBridgeProcess::~StreamBridgeProcess() { stop(); }
+void StreamBridgeProcess::start(const std::filesystem::path &executable, const std::vector<std::string> &arguments) {
+  if (owned()) throw std::runtime_error("A stream bridge process is already running");
+  if (executable.empty()) throw std::runtime_error("Stream bridge executable path is empty");
+  executable_ = executable.string();
+  std::vector<std::string> storage{executable_};
+  storage.insert(storage.end(), arguments.begin(), arguments.end());
+  std::vector<char *> argv;
+  for (std::string &argument : storage) argv.push_back(argument.data());
+  argv.push_back(nullptr);
+  const int result = posix_spawn(&pid_, executable_.c_str(), nullptr, nullptr, argv.data(), environ);
+  if (result != 0) {
+    pid_ = -1;
+    throw std::runtime_error("Failed to start stream bridge " + executable_ + ": " + std::strerror(result));
+  }
+  const auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(100);
+  do {
+    check_running();
+    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+  } while (std::chrono::steady_clock::now() < deadline);
+  check_running();
+}
+void StreamBridgeProcess::check_running() {
+  if (!owned()) throw std::runtime_error("Stream bridge process is not running");
+  int status = 0;
+  const pid_t result = wait_nointr(pid_, &status, WNOHANG);
+  if (result == 0) return;
+  if (result == pid_) {
+    pid_ = -1;
+    throw std::runtime_error(exit_error(executable_, status));
+  }
+  if (result < 0 && errno == ECHILD) {
+    pid_ = -1;
+    throw std::runtime_error(executable_ + " is no longer waitable");
+  }
+  if (result < 0) throw std::runtime_error("Failed to inspect stream bridge " + executable_ + ": " + std::strerror(errno));
+}
+void StreamBridgeProcess::stop() noexcept {
+  if (!owned()) return;
+  const pid_t child = pid_;
+  int status = 0;
+  const pid_t initial = wait_nointr(child, &status, WNOHANG);
+  if (initial == child || (initial < 0 && errno == ECHILD)) {
+    pid_ = -1; return;
+  }
+  kill(child, SIGTERM);
+  const auto deadline = std::chrono::steady_clock::now() + terminate_grace_;
+  while (std::chrono::steady_clock::now() < deadline) {
+    const pid_t result = wait_nointr(child, &status, WNOHANG);
+    if (result == child || (result < 0 && errno == ECHILD)) {
+      pid_ = -1; return;
+    }
+    if (result < 0) break;
+    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+  }
+  kill(child, SIGKILL);
+  wait_nointr(child, &status, 0);
+  pid_ = -1;
+}

--- a/openpilot/tools/jotpluggler/stream_bridge.cc
+++ b/openpilot/tools/jotpluggler/stream_bridge.cc
@@ -20,20 +20,17 @@ std::filesystem::path msgq_root() {
   return "/dev/shm";
 #endif
 }
-
 pid_t wait_nointr(pid_t pid, int *status, int options) {
   pid_t result;
   do { result = waitpid(pid, status, options); } while (result < 0 && errno == EINTR);
   return result;
 }
-
 std::string exit_error(const std::string &executable, int status) {
   if (WIFEXITED(status)) return executable + " exited with status " + std::to_string(WEXITSTATUS(status));
   if (WIFSIGNALED(status)) return executable + " terminated by signal " + std::to_string(WTERMSIG(status));
   return executable + " exited unexpectedly";
 }
 }  // namespace
-
 std::string stream_bridge_whitelist(const std::vector<std::string> &service_names) {
   std::string whitelist;
   for (const std::string &name : service_names) whitelist += "/\"" + name + "\"/";
@@ -46,18 +43,12 @@ ScopedMsgqPrefix::ScopedMsgqPrefix() {
   path_ = created;
   prefix_ = path_.filename().string().substr(std::strlen("msgq_"));
 }
-ScopedMsgqPrefix::~ScopedMsgqPrefix() {
-  restore();
-  std::error_code error;
-  std::filesystem::remove_all(path_, error);
-}
+ScopedMsgqPrefix::~ScopedMsgqPrefix() { restore(); std::error_code error; std::filesystem::remove_all(path_, error); }
 void ScopedMsgqPrefix::activate() {
   if (active_) throw std::runtime_error("MSGQ namespace is already active");
   previous_prefix_.reset();
   if (const char *prefix = std::getenv("OPENPILOT_PREFIX")) previous_prefix_ = prefix;
-  if (setenv("OPENPILOT_PREFIX", prefix_.c_str(), 1) != 0) {
-    throw std::runtime_error("Failed to activate MSGQ namespace: " + std::string(std::strerror(errno)));
-  }
+  if (setenv("OPENPILOT_PREFIX", prefix_.c_str(), 1) != 0) throw std::runtime_error("Failed to activate MSGQ namespace: " + std::string(std::strerror(errno)));
   active_ = true;
 }
 void ScopedMsgqPrefix::restore() noexcept {
@@ -68,19 +59,20 @@ void ScopedMsgqPrefix::restore() noexcept {
 }
 StreamBridgeProcess::StreamBridgeProcess(std::chrono::milliseconds terminate_grace) : terminate_grace_(terminate_grace) {}
 StreamBridgeProcess::~StreamBridgeProcess() { stop(); }
-void StreamBridgeProcess::start(const std::filesystem::path &executable, const std::vector<std::string> &arguments) {
+void StreamBridgeProcess::start(const std::filesystem::path &executable, const std::vector<std::string> &arguments,
+                                const std::filesystem::path &cleanup_path) {
   if (owned()) throw std::runtime_error("A stream bridge process is already running");
   if (executable.empty()) throw std::runtime_error("Stream bridge executable path is empty");
   executable_ = executable.string();
   std::vector<std::string> storage{executable_};
   storage.insert(storage.end(), arguments.begin(), arguments.end());
+  if (!cleanup_path.empty()) { storage.push_back(std::to_string(getpid())); storage.push_back(cleanup_path.string()); }
   std::vector<char *> argv;
   for (std::string &argument : storage) argv.push_back(argument.data());
   argv.push_back(nullptr);
   const int result = posix_spawn(&pid_, executable_.c_str(), nullptr, nullptr, argv.data(), environ);
   if (result != 0) {
-    pid_ = -1;
-    throw std::runtime_error("Failed to start stream bridge " + executable_ + ": " + std::strerror(result));
+    pid_ = -1; throw std::runtime_error("Failed to start stream bridge " + executable_ + ": " + std::strerror(result));
   }
   const auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(100);
   do {
@@ -95,12 +87,10 @@ void StreamBridgeProcess::check_running() {
   const pid_t result = wait_nointr(pid_, &status, WNOHANG);
   if (result == 0) return;
   if (result == pid_) {
-    pid_ = -1;
-    throw std::runtime_error(exit_error(executable_, status));
+    pid_ = -1; throw std::runtime_error(exit_error(executable_, status));
   }
   if (result < 0 && errno == ECHILD) {
-    pid_ = -1;
-    throw std::runtime_error(executable_ + " is no longer waitable");
+    pid_ = -1; throw std::runtime_error(executable_ + " is no longer waitable");
   }
   if (result < 0) throw std::runtime_error("Failed to inspect stream bridge " + executable_ + ": " + std::strerror(errno));
 }
@@ -109,9 +99,7 @@ void StreamBridgeProcess::stop() noexcept {
   const pid_t child = pid_;
   int status = 0;
   const pid_t initial = wait_nointr(child, &status, WNOHANG);
-  if (initial == child || (initial < 0 && errno == ECHILD)) {
-    pid_ = -1; return;
-  }
+  if (initial == child || (initial < 0 && errno == ECHILD)) { pid_ = -1; return; }
   kill(child, SIGTERM);
   const auto deadline = std::chrono::steady_clock::now() + terminate_grace_;
   while (std::chrono::steady_clock::now() < deadline) {

--- a/openpilot/tools/jotpluggler/stream_bridge.h
+++ b/openpilot/tools/jotpluggler/stream_bridge.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <chrono>
+#include <filesystem>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include <sys/types.h>
+
+inline constexpr char kStreamMsgqAddress[] = "127.0.0.1";
+
+std::string stream_bridge_whitelist(const std::vector<std::string> &services);
+class ScopedMsgqPrefix {
+public:
+  ScopedMsgqPrefix();
+  ~ScopedMsgqPrefix();
+  ScopedMsgqPrefix(const ScopedMsgqPrefix &) = delete;
+  ScopedMsgqPrefix &operator=(const ScopedMsgqPrefix &) = delete;
+  void activate();
+  void restore() noexcept;
+  const std::string &prefix() const { return prefix_; }
+  const std::filesystem::path &path() const { return path_; }
+private:
+  std::string prefix_;
+  std::filesystem::path path_;
+  std::optional<std::string> previous_prefix_;
+  bool active_ = false;
+};
+
+class StreamBridgeProcess {
+public:
+  explicit StreamBridgeProcess(std::chrono::milliseconds terminate_grace = std::chrono::seconds(3));
+  ~StreamBridgeProcess();
+  StreamBridgeProcess(const StreamBridgeProcess &) = delete;
+  StreamBridgeProcess &operator=(const StreamBridgeProcess &) = delete;
+  void start(const std::filesystem::path &executable, const std::vector<std::string> &arguments = {});
+  void check_running();
+  void stop() noexcept;
+  bool owned() const { return pid_ > 0; }
+private:
+  std::chrono::milliseconds terminate_grace_;
+  std::string executable_;
+  pid_t pid_ = -1;
+};

--- a/openpilot/tools/jotpluggler/stream_bridge.h
+++ b/openpilot/tools/jotpluggler/stream_bridge.h
@@ -7,9 +7,7 @@
 #include <vector>
 
 #include <sys/types.h>
-
 inline constexpr char kStreamMsgqAddress[] = "127.0.0.1";
-
 std::string stream_bridge_whitelist(const std::vector<std::string> &services);
 class ScopedMsgqPrefix {
 public:
@@ -34,10 +32,12 @@ public:
   ~StreamBridgeProcess();
   StreamBridgeProcess(const StreamBridgeProcess &) = delete;
   StreamBridgeProcess &operator=(const StreamBridgeProcess &) = delete;
-  void start(const std::filesystem::path &executable, const std::vector<std::string> &arguments = {});
+  void start(const std::filesystem::path &executable, const std::vector<std::string> &arguments = {},
+             const std::filesystem::path &cleanup_path = {});
   void check_running();
   void stop() noexcept;
   bool owned() const { return pid_ > 0; }
+  pid_t pid() const { return pid_; }
 private:
   std::chrono::milliseconds terminate_grace_;
   std::string executable_;

--- a/openpilot/tools/jotpluggler/tests/test_stream_bridge.cc
+++ b/openpilot/tools/jotpluggler/tests/test_stream_bridge.cc
@@ -37,9 +37,7 @@ std::optional<std::string> env_value(const char *name) {
   return value ? std::make_optional<std::string>(value) : std::nullopt;
 }
 void restore_env(const char *name, const std::optional<std::string> &value) { value ? setenv(name, value->c_str(), 1) : unsetenv(name); }
-std::unique_ptr<PubSocket> publisher(Context *context) {
-  return std::unique_ptr<PubSocket>(PubSocket::create(context, "deviceState", true, services.at("deviceState").queue_size));
-}
+std::unique_ptr<PubSocket> publisher(Context *context) { return std::unique_ptr<PubSocket>(PubSocket::create(context, "deviceState", true, services.at("deviceState").queue_size)); }
 int send_state(PubSocket *socket, bool started) {
   MessageBuilder message;
   message.initEvent().initDeviceState().setStarted(started);
@@ -51,8 +49,7 @@ bool take_started(StreamPoller *poller) {
   StreamExtractBatch batch;
   if (!poller->consume(&batch, nullptr)) return false;
   for (const RouteSeries &series : batch.series) {
-    if (series.path == "/deviceState/started" &&
-        std::any_of(series.values.begin(), series.values.end(), [](double value) { return value > 0.5; })) return true;
+    if (series.path == "/deviceState/started" && std::any_of(series.values.begin(), series.values.end(), [](double value) { return value > 0.5; })) return true;
   }
   return false;
 }
@@ -81,8 +78,24 @@ TEST_CASE("stream bridge owns its prefix and child lifecycle") {
   errno = 0;
   REQUIRE((kill(child_pid, 0) == -1 && errno == ESRCH));
   int status = 0;
-  REQUIRE((waitpid(child_pid, &status, WNOHANG) == -1 && errno == ECHILD));
-  process.stop();
+  const auto orphan_pid_file = prefix.path() / "orphan.pid";
+  prefix.activate();
+  const pid_t owner = fork();
+  if (owner == 0) {
+    try {
+      StreamBridgeProcess orphan;
+      orphan.start(repo_root() / "openpilot/cereal/messaging/bridge",
+                   {"127.0.0.2", stream_bridge_whitelist({"deviceState"})}, prefix.path());
+      std::ofstream(orphan_pid_file) << orphan.pid();
+      while (true) pause();
+    } catch (...) { _exit(1); }
+  }
+  prefix.restore();
+  REQUIRE(owner > 0);
+  REQUIRE(wait_until(2s, [&] { return std::filesystem::exists(orphan_pid_file) && std::filesystem::file_size(orphan_pid_file) > 0; }));
+  const pid_t orphan_pid = std::stoi(util::read_file(orphan_pid_file.string()));
+  REQUIRE((kill(owner, SIGKILL) == 0 && waitpid(owner, &status, 0) == owner));
+  REQUIRE(wait_until(3s, [&] { return kill(orphan_pid, 0) == -1 && errno == ESRCH && !std::filesystem::exists(prefix.path()); }));
 }
 TEST_CASE("bridge failures are safe and a StreamPoller can restart") {
   const auto original = env_value("OPENPILOT_PREFIX");
@@ -112,13 +125,16 @@ TEST_CASE("bridge failures are safe and a StreamPoller can restart") {
   poller.start(local_source(), 5.0, "");
   REQUIRE(wait_until(2s, [&] { return !poller.snapshot().active; }));
   absent.restore();
-  REQUIRE_THAT(take_error(&poller), Catch::Matchers::Contains("Failed to connect cereal service"));
+  REQUIRE_THAT(take_error(&poller), Catch::Matchers::Contains("Failed to connect"));
   poller.start(remote_source("not a valid ZMQ host"), 5.0, "");
   REQUIRE(wait_until(2s, [&] { return !poller.snapshot().active; }));
-  REQUIRE(poller.consume(nullptr, nullptr));
   REQUIRE(env_value("OPENPILOT_PREFIX") == original);
   ScopedMsgqPrefix local;
   local.activate();
+  std::filesystem::create_directory(local.path() / "accelerometer");
+  poller.start(local_source(), 5.0, "");
+  REQUIRE((wait_until(2s, [&] { return poller.snapshot().connected || !poller.snapshot().active; }) && poller.snapshot().connected));
+  std::filesystem::remove(local.path() / "accelerometer");
   const auto previous_fake = env_value("CEREAL_FAKE");
   const auto previous_fake_prefix = env_value("CEREAL_FAKE_PREFIX");
   setenv("CEREAL_FAKE", "1", 1);
@@ -133,7 +149,6 @@ TEST_CASE("bridge failures are safe and a StreamPoller can restart") {
   restore_env("CEREAL_FAKE_PREFIX", previous_fake_prefix);
   local.restore();
   REQUIRE(connected);
-  REQUIRE(take_error(&poller).empty());
   fake_event.set_enabled(true);
   const bool fake_called = wait_until(2s, [&] { return fake_event.recv_called().peek(); });
   const int sent = send_state(pub.get(), true);
@@ -145,9 +160,10 @@ TEST_CASE("bridge failures are safe and a StreamPoller can restart") {
   poller.stop();
 }
 TEST_CASE("concurrent setup is isolated and bridge death is surfaced") {
-  const auto original = env_value("OPENPILOT_PREFIX");
   ScopedMsgqPrefix scratch;
-  const auto script = scratch.path() / "short-bridge";
+  std::string script_dir = (repo_root() / "openpilot/tools/jotpluggler/tests/test_stream_bridge_helper_XXXXXX").string();
+  REQUIRE(mkdtemp(script_dir.data()) != nullptr);
+  const auto script = std::filesystem::path(script_dir) / "bridge";
   const auto bridge_executable = repo_root() / "openpilot/cereal/messaging/bridge";
   const auto previous_override = env_value("JOTP_STREAM_BRIDGE");
   const auto previous_setup_test = env_value("JOTP_STREAM_SETUP_TEST");
@@ -155,35 +171,26 @@ TEST_CASE("concurrent setup is isolated and bridge death is surfaced") {
   setenv("JOTP_STREAM_SETUP_TEST", scratch.path().c_str(), 1);
   ScopedMsgqPrefix caller;
   caller.activate();
-  Context context;
-  auto pub = publisher(&context);
-  REQUIRE(pub != nullptr);
   StreamPoller remote, local;
   remote.start(remote_source("127.0.0.2"), 5.0, "");
   const bool remote_held = wait_until(2s, [&] { return std::filesystem::exists(scratch.path() / "remote-held"); });
-  const bool prefix_held = remote_held && env_value("OPENPILOT_PREFIX") != std::make_optional(caller.prefix());
   if (remote_held) local.start(local_source(), 5.0, "");
   const bool local_blocked = remote_held && wait_until(1s, [&] { return std::filesystem::exists(scratch.path() / "local-blocked"); });
   std::ofstream(scratch.path() / "release").put('\n');
   const bool both_connected = local_blocked && wait_until(5s, [&] { return remote.snapshot().connected && local.snapshot().connected; });
-  restore_env("JOTP_STREAM_BRIDGE", previous_override);
-  restore_env("JOTP_STREAM_SETUP_TEST", previous_setup_test);
-  REQUIRE((remote_held && prefix_held && local_blocked));
+  restore_env("JOTP_STREAM_BRIDGE", previous_override); restore_env("JOTP_STREAM_SETUP_TEST", previous_setup_test);
+  REQUIRE((remote_held && local_blocked));
   REQUIRE(both_connected);
-  REQUIRE(std::filesystem::exists(scratch.path() / "local-after"));
   REQUIRE(env_value("OPENPILOT_PREFIX") == std::make_optional(caller.prefix()));
-  REQUIRE(wait_until(2s, [&] { return send_state(pub.get(), true) > 0 && take_started(&local); }));
-  remote.stop();
-  local.stop();
+  remote.stop(); local.stop();
   caller.restore();
-  REQUIRE(env_value("OPENPILOT_PREFIX") == original);
   const auto pid_file = scratch.path() / "dying.pid";
-  std::ofstream(script) << "#!/bin/sh\necho $$ > \"$1\"\nexec " << shell_quote(bridge_executable.string()) << " 127.0.0.2 \"$2\"\n";
+  std::ofstream(script) << "#!/bin/sh\necho $$ > \"$1\"\nexec " << shell_quote(bridge_executable.string()) << " 127.0.0.2 \"$2\" \"$3\" \"$4\"\n";
   REQUIRE(chmod(script.c_str(), 0700) == 0);
   setenv("JOTP_STREAM_BRIDGE", script.c_str(), 1);
   StreamPoller dying;
   dying.start(remote_source(pid_file.string()), 5.0, "");
-  const bool connected = wait_until(15s, [&] { return (dying.snapshot().connected && std::filesystem::exists(pid_file)) || !dying.snapshot().active; }) && dying.snapshot().connected;
+  const bool connected = wait_until(15s, [&] { return (dying.snapshot().connected && std::filesystem::exists(pid_file) && std::filesystem::file_size(pid_file) > 0) || !dying.snapshot().active; }) && dying.snapshot().connected;
   restore_env("JOTP_STREAM_BRIDGE", previous_override);
   REQUIRE_THAT(connected ? "" : take_error(&dying), Catch::Matchers::Equals(""));
   REQUIRE(connected);
@@ -191,11 +198,11 @@ TEST_CASE("concurrent setup is isolated and bridge death is surfaced") {
   REQUIRE(wait_until(3s, [&] { return !dying.snapshot().active; }));
   REQUIRE_FALSE(dying.snapshot().connected);
   REQUIRE_THAT(take_error(&dying), Catch::Matchers::Contains("terminated by signal 9"));
-  REQUIRE(env_value("OPENPILOT_PREFIX") == original);
+  std::filesystem::remove_all(script_dir);
 }
 TEST_CASE("remote StreamPoller receives device data without displacing caller publishers") {
   const auto original = env_value("OPENPILOT_PREFIX");
-  std::filesystem::path caller_path, device_path;
+  std::filesystem::path caller_path;
   {
     ScopedMsgqPrefix caller;
     caller_path = caller.path();
@@ -204,7 +211,6 @@ TEST_CASE("remote StreamPoller receives device data without displacing caller pu
     auto caller_pub = publisher(&caller_context);
     REQUIRE(caller_pub != nullptr);
     ScopedMsgqPrefix device;
-    device_path = device.path();
     device.activate();
     StreamBridgeProcess device_bridge;
     device_bridge.start(repo_root() / "openpilot/cereal/messaging/bridge");
@@ -220,10 +226,8 @@ TEST_CASE("remote StreamPoller receives device data without displacing caller pu
     REQUIRE(wait_until(8s, [&] { return send_state(device_pub.get(), true) > 0 && take_started(&poller); }));
     poller.stop();
     REQUIRE(send_state(caller_pub.get(), false) > 0);
-    device_bridge.stop();
     caller.restore();
   }
   REQUIRE_FALSE(std::filesystem::exists(caller_path));
-  REQUIRE_FALSE(std::filesystem::exists(device_path));
   REQUIRE(env_value("OPENPILOT_PREFIX") == original);
 }

--- a/openpilot/tools/jotpluggler/tests/test_stream_bridge.cc
+++ b/openpilot/tools/jotpluggler/tests/test_stream_bridge.cc
@@ -1,0 +1,229 @@
+#define CATCH_CONFIG_MAIN
+#include "catch2/catch.hpp"
+#include "tools/jotpluggler/app.h"
+#include "tools/jotpluggler/common.h"
+#include "tools/jotpluggler/stream_bridge.h"
+
+#include "openpilot/cereal/messaging/messaging.h"
+#include "openpilot/cereal/services.h"
+#include "openpilot/common/util.h"
+#include "msgq_repo/msgq/event.h"
+
+#include <algorithm>
+#include <cerrno>
+#include <chrono>
+#include <csignal>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <memory>
+#include <optional>
+#include <thread>
+#include <sys/stat.h>
+#include <sys/wait.h>
+using namespace std::chrono_literals;
+namespace {
+template <typename Predicate>
+bool wait_until(std::chrono::milliseconds timeout, Predicate predicate) {
+  const auto deadline = std::chrono::steady_clock::now() + timeout;
+  do {
+    if (predicate()) return true;
+    std::this_thread::sleep_for(10ms);
+  } while (std::chrono::steady_clock::now() < deadline);
+  return predicate();
+}
+std::optional<std::string> env_value(const char *name) {
+  const char *value = std::getenv(name);
+  return value ? std::make_optional<std::string>(value) : std::nullopt;
+}
+void restore_env(const char *name, const std::optional<std::string> &value) { value ? setenv(name, value->c_str(), 1) : unsetenv(name); }
+std::unique_ptr<PubSocket> publisher(Context *context) {
+  return std::unique_ptr<PubSocket>(PubSocket::create(context, "deviceState", true, services.at("deviceState").queue_size));
+}
+int send_state(PubSocket *socket, bool started) {
+  MessageBuilder message;
+  message.initEvent().initDeviceState().setStarted(started);
+  auto bytes = message.toBytes();
+  return socket->send(reinterpret_cast<char *>(bytes.begin()), bytes.size());
+}
+std::string take_error(StreamPoller *poller) { std::string error; poller->consume(nullptr, &error); return error; }
+bool take_started(StreamPoller *poller) {
+  StreamExtractBatch batch;
+  if (!poller->consume(&batch, nullptr)) return false;
+  for (const RouteSeries &series : batch.series) {
+    if (series.path == "/deviceState/started" &&
+        std::any_of(series.values.begin(), series.values.end(), [](double value) { return value > 0.5; })) return true;
+  }
+  return false;
+}
+StreamSourceConfig local_source() { return {.kind = StreamSourceKind::CerealLocal, .address = "127.0.0.1"}; }
+StreamSourceConfig remote_source(std::string address) { return {.kind = StreamSourceKind::CerealRemote, .address = std::move(address)}; }
+}  // namespace
+TEST_CASE("stream bridge owns its prefix and child lifecycle") {
+  const auto original = env_value("OPENPILOT_PREFIX");
+  ScopedMsgqPrefix prefix;
+  StreamBridgeProcess process(20ms);
+  REQUIRE_THROWS_WITH(process.start("/does/not/exist"), Catch::Matchers::Contains("Failed to start"));
+  struct stat info = {};
+  REQUIRE(stat(prefix.path().c_str(), &info) == 0);
+  REQUIRE((info.st_mode & 0777) == 0700);
+  const auto pid_file = prefix.path() / "child.pid";
+  prefix.activate();
+  process.start("/bin/sh", {"-c", "test \"$OPENPILOT_PREFIX\" = \"$1\" || exit 1; echo $$ > \"$2\"; trap '' TERM; while :; do :; done",
+                                    "bridge", prefix.prefix(), pid_file.string()});
+  prefix.restore();
+  REQUIRE(env_value("OPENPILOT_PREFIX") == original);
+  REQUIRE(wait_until(1s, [&] { return std::filesystem::exists(pid_file); }));
+  const pid_t child_pid = std::stoi(util::read_file(pid_file.string()));
+  REQUIRE_THROWS(process.start("/usr/bin/false"));
+  process.stop();
+  REQUIRE_FALSE(process.owned());
+  errno = 0;
+  REQUIRE((kill(child_pid, 0) == -1 && errno == ESRCH));
+  int status = 0;
+  REQUIRE((waitpid(child_pid, &status, WNOHANG) == -1 && errno == ECHILD));
+  process.stop();
+}
+TEST_CASE("bridge failures are safe and a StreamPoller can restart") {
+  const auto original = env_value("OPENPILOT_PREFIX");
+  ScopedMsgqPrefix diagnostics;
+  ScopedMsgqPrefix missing;
+  const auto log = diagnostics.path() / "bridge.stderr";
+  missing.activate();
+  std::filesystem::remove_all(missing.path());
+  StreamBridgeProcess bridge;
+  std::string bridge_error;
+  try {
+    bridge.start("/bin/sh", {"-c", "exec \"$1\" \"$2\" \"$3\" >/dev/null 2>\"$4\"", "capture",
+      (repo_root() / "openpilot/cereal/messaging/bridge").string(), "127.0.0.2", stream_bridge_whitelist({"deviceState"}), log.string()});
+    wait_until(1s, [&] {
+      try { bridge.check_running(); } catch (const std::exception &err) { bridge_error = err.what(); return true; }
+      return false;
+    });
+  } catch (const std::exception &err) { bridge_error = err.what(); }
+  missing.restore();
+  bridge.stop();
+  REQUIRE_THAT(bridge_error, Catch::Matchers::Contains("status 1"));
+  REQUIRE(util::read_file(log.string()).find("MSGQ publisher") != std::string::npos);
+  StreamPoller poller;
+  ScopedMsgqPrefix absent;
+  absent.activate();
+  std::filesystem::remove_all(absent.path());
+  poller.start(local_source(), 5.0, "");
+  REQUIRE(wait_until(2s, [&] { return !poller.snapshot().active; }));
+  absent.restore();
+  REQUIRE_THAT(take_error(&poller), Catch::Matchers::Contains("Failed to connect cereal service"));
+  poller.start(remote_source("not a valid ZMQ host"), 5.0, "");
+  REQUIRE(wait_until(2s, [&] { return !poller.snapshot().active; }));
+  REQUIRE(poller.consume(nullptr, nullptr));
+  REQUIRE(env_value("OPENPILOT_PREFIX") == original);
+  ScopedMsgqPrefix local;
+  local.activate();
+  const auto previous_fake = env_value("CEREAL_FAKE");
+  const auto previous_fake_prefix = env_value("CEREAL_FAKE_PREFIX");
+  setenv("CEREAL_FAKE", "1", 1);
+  setenv("CEREAL_FAKE_PREFIX", local.prefix().c_str(), 1);
+  SocketEventHandle fake_event("deviceState", local.prefix());
+  Context context;
+  auto pub = publisher(&context);
+  REQUIRE(pub != nullptr);
+  poller.start(local_source(), 5.0, "");
+  const bool connected = wait_until(2s, [&] { return poller.snapshot().connected || !poller.snapshot().active; }) && poller.snapshot().connected;
+  restore_env("CEREAL_FAKE", previous_fake);
+  restore_env("CEREAL_FAKE_PREFIX", previous_fake_prefix);
+  local.restore();
+  REQUIRE(connected);
+  REQUIRE(take_error(&poller).empty());
+  fake_event.set_enabled(true);
+  const bool fake_called = wait_until(2s, [&] { return fake_event.recv_called().peek(); });
+  const int sent = send_state(pub.get(), true);
+  fake_event.set_enabled(false);
+  fake_event.recv_ready().set();
+  REQUIRE(fake_called);
+  REQUIRE(sent > 0);
+  REQUIRE(wait_until(2s, [&] { return take_started(&poller); }));
+  poller.stop();
+}
+TEST_CASE("concurrent setup is isolated and bridge death is surfaced") {
+  const auto original = env_value("OPENPILOT_PREFIX");
+  ScopedMsgqPrefix scratch;
+  const auto script = scratch.path() / "short-bridge";
+  const auto bridge_executable = repo_root() / "openpilot/cereal/messaging/bridge";
+  const auto previous_override = env_value("JOTP_STREAM_BRIDGE");
+  const auto previous_setup_test = env_value("JOTP_STREAM_SETUP_TEST");
+  setenv("JOTP_STREAM_BRIDGE", bridge_executable.c_str(), 1);
+  setenv("JOTP_STREAM_SETUP_TEST", scratch.path().c_str(), 1);
+  ScopedMsgqPrefix caller;
+  caller.activate();
+  Context context;
+  auto pub = publisher(&context);
+  REQUIRE(pub != nullptr);
+  StreamPoller remote, local;
+  remote.start(remote_source("127.0.0.2"), 5.0, "");
+  const bool remote_held = wait_until(2s, [&] { return std::filesystem::exists(scratch.path() / "remote-held"); });
+  const bool prefix_held = remote_held && env_value("OPENPILOT_PREFIX") != std::make_optional(caller.prefix());
+  if (remote_held) local.start(local_source(), 5.0, "");
+  const bool local_blocked = remote_held && wait_until(1s, [&] { return std::filesystem::exists(scratch.path() / "local-blocked"); });
+  std::ofstream(scratch.path() / "release").put('\n');
+  const bool both_connected = local_blocked && wait_until(5s, [&] { return remote.snapshot().connected && local.snapshot().connected; });
+  restore_env("JOTP_STREAM_BRIDGE", previous_override);
+  restore_env("JOTP_STREAM_SETUP_TEST", previous_setup_test);
+  REQUIRE((remote_held && prefix_held && local_blocked));
+  REQUIRE(both_connected);
+  REQUIRE(std::filesystem::exists(scratch.path() / "local-after"));
+  REQUIRE(env_value("OPENPILOT_PREFIX") == std::make_optional(caller.prefix()));
+  REQUIRE(wait_until(2s, [&] { return send_state(pub.get(), true) > 0 && take_started(&local); }));
+  remote.stop();
+  local.stop();
+  caller.restore();
+  REQUIRE(env_value("OPENPILOT_PREFIX") == original);
+  const auto pid_file = scratch.path() / "dying.pid";
+  std::ofstream(script) << "#!/bin/sh\necho $$ > \"$1\"\nexec " << shell_quote(bridge_executable.string()) << " 127.0.0.2 \"$2\"\n";
+  REQUIRE(chmod(script.c_str(), 0700) == 0);
+  setenv("JOTP_STREAM_BRIDGE", script.c_str(), 1);
+  StreamPoller dying;
+  dying.start(remote_source(pid_file.string()), 5.0, "");
+  const bool connected = wait_until(15s, [&] { return (dying.snapshot().connected && std::filesystem::exists(pid_file)) || !dying.snapshot().active; }) && dying.snapshot().connected;
+  restore_env("JOTP_STREAM_BRIDGE", previous_override);
+  REQUIRE_THAT(connected ? "" : take_error(&dying), Catch::Matchers::Equals(""));
+  REQUIRE(connected);
+  REQUIRE(kill(std::stoi(util::read_file(pid_file.string())), SIGKILL) == 0);
+  REQUIRE(wait_until(3s, [&] { return !dying.snapshot().active; }));
+  REQUIRE_FALSE(dying.snapshot().connected);
+  REQUIRE_THAT(take_error(&dying), Catch::Matchers::Contains("terminated by signal 9"));
+  REQUIRE(env_value("OPENPILOT_PREFIX") == original);
+}
+TEST_CASE("remote StreamPoller receives device data without displacing caller publishers") {
+  const auto original = env_value("OPENPILOT_PREFIX");
+  std::filesystem::path caller_path, device_path;
+  {
+    ScopedMsgqPrefix caller;
+    caller_path = caller.path();
+    caller.activate();
+    Context caller_context;
+    auto caller_pub = publisher(&caller_context);
+    REQUIRE(caller_pub != nullptr);
+    ScopedMsgqPrefix device;
+    device_path = device.path();
+    device.activate();
+    StreamBridgeProcess device_bridge;
+    device_bridge.start(repo_root() / "openpilot/cereal/messaging/bridge");
+    Context device_context;
+    auto device_pub = publisher(&device_context);
+    REQUIRE(device_pub != nullptr);
+    device.restore();
+    StreamPoller poller;
+    poller.start(remote_source("127.0.0.1"), 5.0, "");
+    REQUIRE((wait_until(3s, [&] { return poller.snapshot().connected || !poller.snapshot().active; }) && poller.snapshot().connected));
+    REQUIRE(std::string(std::getenv("OPENPILOT_PREFIX")) == caller.prefix());
+    REQUIRE(send_state(caller_pub.get(), false) > 0);
+    REQUIRE(wait_until(8s, [&] { return send_state(device_pub.get(), true) > 0 && take_started(&poller); }));
+    poller.stop();
+    REQUIRE(send_state(caller_pub.get(), false) > 0);
+    device_bridge.stop();
+    caller.restore();
+  }
+  REQUIRE_FALSE(std::filesystem::exists(caller_path));
+  REQUIRE_FALSE(std::filesystem::exists(device_path));
+  REQUIRE(env_value("OPENPILOT_PREFIX") == original);
+}


### PR DESCRIPTION
**Description**

Fixes #37969.

JotPluggler passed remote addresses to MSGQ, which only accepts localhost. Remote streams now run the existing bridge in a private MSGQ namespace and subscribe on `127.0.0.1`. Bridge failures are surfaced; the bridge exits and removes its namespace if its owner dies.

**Verification**

- macOS build and GUI smoke
- focused tests: 4 cases, 44 assertions
- synthetic MSGQ -> ZMQ -> MSGQ end-to-end test
- parent `SIGKILL` cleanup reproduction
- 60 lifecycle/concurrency stress runs
- pytest-xdist: 10 runs, 40/40 cases
- Linux CI: all 4 JotPluggler cases passed

No comma device was available; device validation is requested before marking this ready.