### PR TITLE
Fix thumbnail creation

### DIFF
--- a/openpilot/system/loggerd/encoder/jpeg_encoder.cc
+++ b/openpilot/system/loggerd/encoder/jpeg_encoder.cc
@@ -93,7 +93,7 @@ void JpegEncoder::compressToJpeg(uint8_t *y_plane, uint8_t *u_plane, uint8_t *v_
   frame->data[2] = v_plane;
   // Required for MJPEG qscale to take effect (global_quality alone is not enough).
   frame->quality = FF_QP2LAMBDA * MJPEG_QSCALE;
-  frame->pts = 0;
+  frame->pts = AV_NOPTS_VALUE;
 
   int err = avcodec_send_frame(codec_ctx, frame);
   if (err < 0) {


### PR DESCRIPTION
the deps were too hard. fixes thumbnails after first seg from being empty due to libavcodec needing to see pts increment monotonically https://github.com/commaai/openpilot/pull/38305

works:

https://connect.comma.ai/ba3e5241ca8129d2/0000000b--5ba2edb3f6

<img width="1497" height="222" alt="image" src="https://github.com/user-attachments/assets/0e77a777-cea5-4943-8cec-742c334a438f" />
