### PR TITLE
fix branch cleanup burning GH API requests

### DIFF
--- a/.github/workflows/repo-maintenance.yaml
+++ b/.github/workflows/repo-maintenance.yaml
@@ -89,12 +89,10 @@ jobs:
             const { owner, repo } = context.repo;
             const upstream = `${owner}/${repo}`;
 
-            // on PR close just delete that branch, the full scan burns the repo's API rate limit
             const closed = context.payload.pull_request;
             if (closed) {
               if (closed.head.repo?.full_name === upstream) {
-                await github.rest.git.deleteRef({ owner, repo, ref: `heads/${closed.head.ref}` })
-                  .catch((error) => console.log(`Skipping branch ${closed.head.ref}: ${error.message}`));
+                await github.rest.git.deleteRef({ owner, repo, ref: `heads/${closed.head.ref}` }).catch(console.log);
               }
               return;
             }

--- a/.github/workflows/repo-maintenance.yaml
+++ b/.github/workflows/repo-maintenance.yaml
@@ -89,6 +89,16 @@ jobs:
             const { owner, repo } = context.repo;
             const upstream = `${owner}/${repo}`;
 
+            // on PR close just delete that branch, the full scan burns the repo's API rate limit
+            const closed = context.payload.pull_request;
+            if (closed) {
+              if (closed.head.repo?.full_name === upstream) {
+                await github.rest.git.deleteRef({ owner, repo, ref: `heads/${closed.head.ref}` })
+                  .catch((error) => console.log(`Skipping branch ${closed.head.ref}: ${error.message}`));
+              }
+              return;
+            }
+
             for await (const response of github.paginate.iterator(github.rest.pulls.list, {
               owner,
               repo,


### PR DESCRIPTION
The cleanup_closed_branches job scans all 17k closed PRs on every PR close.
Other CI jobs like diff report hit API limit after that.

On PR close, only delete that branch. The weekly cron still does the full scan.