### PR TITLE
setup: install libgles2 for the raylib headless backend

### DIFF
--- a/tools/setup_dependencies.sh
+++ b/tools/setup_dependencies.sh
@@ -44,7 +44,7 @@ function install_linux_deps() {
     echo "[ ] system packages already installed t=$SECONDS"
   elif command -v apt-get > /dev/null 2>&1; then
     $SUDO apt-get update
-    $SUDO apt-get install -y --no-install-recommends ca-certificates build-essential curl libcurl4-openssl-dev locales git xclip wl-clipboard
+    $SUDO apt-get install -y --no-install-recommends ca-certificates build-essential curl libcurl4-openssl-dev locales git xclip wl-clipboard libgles2 libegl1
   elif command -v dnf > /dev/null 2>&1; then
     $SUDO dnf install -y ca-certificates gcc gcc-c++ make curl libcurl-devel glibc-langpack-en git
   elif command -v yum > /dev/null 2>&1; then


### PR DESCRIPTION
The comma-deps-raylib headless backend links against `libGLESv2.so.2` and `libEGL.so.1`, neither of which is in the apt list, so importing raylib fails on machines without them:

```
ImportError: libGLESv2.so.2: cannot open shared object file: No such file or directory
ImportError: failed to load raylib headless backend extension _raylib_cffi_headless
```

which fails `test_raylib_ui.py` and the manager tests for every fork running unit tests on stock GitHub runners (recently reported by @therepanic among others). Master CI doesn't see it because the namespace runner image has the libraries preinstalled; stock runners have libEGL but not libGLESv2; bare Ubuntu has neither.

Verified in `ubuntu:24.04` docker with `pip install comma-deps-raylib`:
- no extra packages → `ImportError: libGLESv2.so.2`
- `libgles2` only → `ImportError: libEGL.so.1`
- `libgles2 libegl1` → raylib imports cleanly