### PR TITLE
hardwared: gracefully handle failed thermal readings

### DIFF
--- a/openpilot/common/hardware/base.py
+++ b/openpilot/common/hardware/base.py
@@ -16,20 +16,22 @@ class ThermalZone:
   zone_number = -1
 
   def read(self) -> float:
-    if self.zone_number < 0:
-      for n in os.listdir("/sys/devices/virtual/thermal"):
-        if not n.startswith("thermal_zone"):
-          continue
-        with open(os.path.join("/sys/devices/virtual/thermal", n, "type")) as f:
-          if f.read().strip() == self.name:
-            self.zone_number = int(n.removeprefix("thermal_zone"))
-            break
-
     try:
+      if self.zone_number < 0:
+        for n in os.listdir("/sys/devices/virtual/thermal"):
+          if not n.startswith("thermal_zone"):
+            continue
+          with open(os.path.join("/sys/devices/virtual/thermal", n, "type")) as f:
+            if f.read().strip() == self.name:
+              self.zone_number = int(n.removeprefix("thermal_zone"))
+              break
+
       with open(f"/sys/devices/virtual/thermal/thermal_zone{self.zone_number}/temp") as f:
         return int(f.read()) / self.scale
-    except FileNotFoundError:
-      return 0
+    except (OSError, ValueError):
+      # the zone may not exist on this platform, and reads themselves can
+      # fail (e.g. EIO when the sensor transaction fails)
+      return float("nan")
 
 @dataclass
 class ThermalConfig:

--- a/openpilot/common/hardware/tests/test_thermal_zone.py
+++ b/openpilot/common/hardware/tests/test_thermal_zone.py
@@ -1,0 +1,39 @@
+import errno
+import math
+from unittest import mock
+
+from openpilot.common.test import OpenpilotTestCase
+from openpilot.common.hardware.base import ThermalZone
+
+
+class TestThermalZone(OpenpilotTestCase):
+  def setUp(self):
+    self.zone = ThermalZone(name="cpu0-silver-usr")
+    self.zone.zone_number = 1  # skip discovery
+
+  def test_read_ok(self):
+    with mock.patch("builtins.open", mock.mock_open(read_data="45000")):
+      assert self.zone.read() == 45.0
+
+  def test_read_io_error_returns_nan(self):
+    # sensor transaction failures surface as EIO from sysfs (#36690)
+    with mock.patch("builtins.open", side_effect=OSError(errno.EIO, "i/o error")):
+      assert math.isnan(self.zone.read())
+
+  def test_missing_zone_returns_nan(self):
+    with mock.patch("builtins.open", side_effect=FileNotFoundError):
+      assert math.isnan(self.zone.read())
+
+  def test_garbage_read_returns_nan(self):
+    with mock.patch("builtins.open", mock.mock_open(read_data="")):
+      assert math.isnan(self.zone.read())
+
+
+class TestMaxTemp(OpenpilotTestCase):
+  def test_filters_nan(self):
+    from openpilot.system.hardware.hardwared import max_temp
+    nan = float("nan")
+    assert max_temp([40.0, nan, 55.0]) == 55.0
+    assert max_temp([nan, 41.0]) == 41.0  # max() alone would return nan here
+    assert max_temp([nan, nan]) == 0.0
+    assert max_temp([]) == 0.0

--- a/openpilot/system/hardware/hardwared.py
+++ b/openpilot/system/hardware/hardwared.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import fcntl
+import math
 import os
 import queue
 import struct
@@ -35,6 +36,10 @@ PANDA_STATES_TIMEOUT = round(1000 / SERVICE_LIST['pandaStates'].frequency * 1.5)
 ONROAD_CYCLE_TIME = 1  # seconds to wait offroad after requesting an onroad cycle
 
 ThermalBand = namedtuple("ThermalBand", ['min_temp', 'max_temp'])
+
+def max_temp(temps) -> float:
+  # unreadable sensors report NaN (see ThermalZone.read); never let it into the filters
+  return max((t for t in temps if not math.isnan(t)), default=0.)
 HardwareState = namedtuple("HardwareState", ['network_type', 'network_info', 'network_strength', 'network_stats',
                                              'network_metered', 'modem_temps', 'usb_state'])
 
@@ -254,14 +259,14 @@ def hardware_thread(end_event, hw_queue) -> None:
     # this subset is only used for offroad
     temp_sources = [
       msg.deviceState.memoryTempC,
-      max(msg.deviceState.cpuTempC, default=0.),
-      max(msg.deviceState.gpuTempC, default=0.),
+      max_temp(msg.deviceState.cpuTempC),
+      max_temp(msg.deviceState.gpuTempC),
     ]
-    offroad_comp_temp = offroad_temp_filter.update(max(temp_sources))
+    offroad_comp_temp = offroad_temp_filter.update(max_temp(temp_sources))
 
     # this drives the thermal status while onroad
-    temp_sources.append(max(msg.deviceState.pmicTempC, default=0.))
-    all_comp_temp = all_temp_filter.update(max(temp_sources))
+    temp_sources.append(max_temp(msg.deviceState.pmicTempC))
+    all_comp_temp = all_temp_filter.update(max_temp(temp_sources))
     msg.deviceState.maxTempC = all_comp_temp
 
     msg.deviceState.fanSpeedPercentDesired = fan_controller.update(all_comp_temp, onroad_conditions["ignition"])


### PR DESCRIPTION
Fixes #36690.

`ThermalZone.read()` only caught `FileNotFoundError`, but a failing sensor transaction (the `qpnp_tm_read ... rc=-5` in the issue) surfaces as `EIO` from the sysfs read, which escaped and crashed hardwared. Reads now return NaN on any failed read (per the issue: NaN in the log, downstream handles it), and the temp aggregation in hardwared filters NaN before the max/filters — python's `max()` is order-dependent with NaN (`max([nan, 41.0])` is nan), so dead sensors could otherwise poison `maxTempC` and the fan controller.

Unit tests cover EIO, missing zone, and garbage reads, plus the NaN-filtering aggregation.