### PR TITLE
ui(body): hide body layout if no car fingerprint

### DIFF
--- a/openpilot/selfdrive/ui/mici/layouts/main.py
+++ b/openpilot/selfdrive/ui/mici/layouts/main.py
@@ -33,6 +33,9 @@ class MiciMainLayout(Scroller):
     self._car_onroad_layout = AugmentedRoadView(bookmark_callback=self._on_bookmark_clicked)
     self._body_onroad_layout = BodyLayout()
 
+    if ui_state.CP is None:
+      self._body_onroad_layout.set_visible(False)
+
     # Initialize widget rects
     for widget in (self._home_layout, self._alerts_layout, self._settings_layout,
                    self._car_onroad_layout, self._body_onroad_layout):

--- a/openpilot/selfdrive/ui/mici/layouts/main.py
+++ b/openpilot/selfdrive/ui/mici/layouts/main.py
@@ -33,9 +33,6 @@ class MiciMainLayout(Scroller):
     self._car_onroad_layout = AugmentedRoadView(bookmark_callback=self._on_bookmark_clicked)
     self._body_onroad_layout = BodyLayout()
 
-    if ui_state.CP is None:
-      self._body_onroad_layout.set_visible(False)
-
     # Initialize widget rects
     for widget in (self._home_layout, self._alerts_layout, self._settings_layout,
                    self._car_onroad_layout, self._body_onroad_layout):
@@ -63,6 +60,9 @@ class MiciMainLayout(Scroller):
     self._onboarding_window = OnboardingWindow(lambda: gui_app.pop_widgets_to(self))
     if not self._onboarding_window.completed:
       gui_app.push_widget(self._onboarding_window)
+
+    if ui_state.CP is None:
+      self._body_onroad_layout.set_visible(False)
 
   @property
   def _onroad_layout(self) -> Widget:

--- a/openpilot/selfdrive/ui/mici/layouts/main.py
+++ b/openpilot/selfdrive/ui/mici/layouts/main.py
@@ -61,8 +61,8 @@ class MiciMainLayout(Scroller):
     if not self._onboarding_window.completed:
       gui_app.push_widget(self._onboarding_window)
 
-    if ui_state.CP is None:
-      self._body_onroad_layout.set_visible(False)
+    # initialize correct onroad layout
+    self._on_body_changed()
 
   @property
   def _onroad_layout(self) -> Widget:

--- a/openpilot/selfdrive/ui/ui_state.py
+++ b/openpilot/selfdrive/ui/ui_state.py
@@ -83,7 +83,7 @@ class UIState:
     self.panda_type: log.PandaState.PandaType = log.PandaState.PandaType.unknown
     self.personality: log.LongitudinalPersonality = log.LongitudinalPersonality.standard
     self.has_longitudinal_control: bool = False
-    self.is_body: bool | None = None
+    self.is_body: bool | None = False
     self.CP: car.CarParams | None = None
     self.light_sensor: float = -1.0
 


### PR DESCRIPTION
body ui would show if there was no car fingerprint since we load both of the layouts on start and decide which to show based on the fingerprint.

hide it and only show onroad layout when CP is none