### PR TITLE
torqued/lagd: fix missing steering pressed

### DIFF
--- a/openpilot/selfdrive/locationd/lagd.py
+++ b/openpilot/selfdrive/locationd/lagd.py
@@ -258,12 +258,18 @@ class LateralLagEstimator:
   def handle_log(self, t: float, which: str, msg: capnp._DynamicStructReader):
     if which == "carControl":
       self.lat_active = msg.latActive
+      if not self.lat_active:
+        self.last_lat_inactive_t = t
     elif which == "carState":
       self.steering_pressed = msg.steeringPressed
       self.v_ego = msg.vEgo
+      if self.steering_pressed:
+        self.last_steering_pressed_t = t
     elif which == "controlsState":
       self.steering_saturated = getattr(msg.lateralControlState, msg.lateralControlState.which()).saturated
       self.desired_curvature = msg.desiredCurvature
+      if self.steering_saturated:
+        self.last_steering_saturated_t = t
     elif which == "liveCalibration":
       self.calibrator.feed_live_calib(msg)
     elif which == "livePose":
@@ -290,12 +296,6 @@ class LateralLagEstimator:
     la_valid = np.abs(la_actual_pose) <= self.max_lat_accel and np.abs(la_desired - la_actual_pose) <= self.max_lat_accel_diff
     calib_valid = self.calibrator.calib_valid
 
-    if not self.lat_active:
-      self.last_lat_inactive_t = self.t
-    if self.steering_pressed:
-      self.last_steering_pressed_t = self.t
-    if self.steering_saturated:
-      self.last_steering_saturated_t = self.t
     if not sensors_valid or not la_valid:
       self.last_pose_invalid_t = self.t
 
@@ -390,7 +390,8 @@ def main():
   DEBUG = bool(int(os.getenv("DEBUG", "0")))
 
   pm = messaging.PubMaster(['liveDelay'])
-  sm = messaging.SubMaster(['livePose', 'liveCalibration', 'carState', 'controlsState', 'carControl'], poll='livePose')
+  # poll on carState to not miss transient steeringPressed/latActive frames
+  sm = messaging.SubMaster(['livePose', 'liveCalibration', 'carState', 'controlsState', 'carControl'], poll='carState')
 
   params = Params()
   CP = messaging.log_from_bytes(params.get("CarParams", block=True), car.CarParams)
@@ -407,14 +408,16 @@ def main():
         if sm.updated[which]:
           t = sm.logMonoTime[which] * 1e-9
           lag_learner.handle_log(t, which, sm[which])
-      lag_learner.update_points()
+      # sample points at the livePose rate
+      if sm.updated['livePose']:
+        lag_learner.update_points()
 
-    # 4Hz driven by livePose
-    if sm.frame % 5 == 0:
+    # 4Hz driven by carState
+    if sm.frame % 25 == 0:
       lag_learner.update_estimate()
       lag_msg = lag_learner.get_msg(sm.all_checks(), DEBUG)
       lag_msg_dat = lag_msg.to_bytes()
       pm.send('liveDelay', lag_msg_dat)
 
-      if sm.frame % 1200 == 0: # cache every 60 seconds
+      if sm.frame % 6000 == 0: # cache every 60 seconds
         params.put("LiveDelay", lag_msg_dat)

--- a/openpilot/selfdrive/locationd/torqued.py
+++ b/openpilot/selfdrive/locationd/torqued.py
@@ -8,7 +8,7 @@ from openpilot.cereal import log
 from opendbc.car.structs import car
 from openpilot.common.constants import ACCELERATION_DUE_TO_GRAVITY
 from openpilot.common.params import Params
-from openpilot.common.realtime import config_realtime_process, DT_MDL
+from openpilot.common.realtime import config_realtime_process, DT_CTRL, DT_MDL
 from openpilot.common.filter_simple import FirstOrderFilter
 from openpilot.common.swaglog import cloudlog
 from openpilot.selfdrive.locationd.helpers import PointBuckets, ParameterEstimator, PoseCalibrator, Pose
@@ -53,7 +53,7 @@ class TorqueBuckets(PointBuckets):
 
 class TorqueEstimator(ParameterEstimator):
   def __init__(self, CP, decimated=False, track_all_points=False):
-    self.hist_len = int(HISTORY / DT_MDL)
+    self.hist_len = int(HISTORY / DT_CTRL)
     self.lag = 0.0
     self.track_all_points = track_all_points  # for offline analysis, without max lateral accel or max steer torque filters
     if decimated:
@@ -192,9 +192,9 @@ class TorqueEstimator(ParameterEstimator):
         yaw_rate = angular_velocity_calibrated.yaw
         roll = device_pose.orientation.roll
         # check lat active up to now (without lag compensation)
-        lat_active = np.interp(np.arange(t - MIN_ENGAGE_BUFFER, t + self.lag, DT_MDL),
+        lat_active = np.interp(np.arange(t - MIN_ENGAGE_BUFFER, t + self.lag, DT_CTRL),
                                self.raw_points['carControl_t'], self.raw_points['lat_active']).astype(bool)
-        steer_override = np.interp(np.arange(t - MIN_ENGAGE_BUFFER, t + self.lag, DT_MDL),
+        steer_override = np.interp(np.arange(t - MIN_ENGAGE_BUFFER, t + self.lag, DT_CTRL),
                                    self.raw_points['carState_t'], self.raw_points['steer_override']).astype(bool)
         vego = np.interp(t, self.raw_points['carState_t'], self.raw_points['vego'])
         steer = np.interp(t, self.raw_points['carOutput_t'], self.raw_points['steer_torque']).item()
@@ -250,7 +250,8 @@ def main(demo=False):
   DEBUG = bool(int(os.getenv("DEBUG", "0")))
 
   pm = messaging.PubMaster(['liveTorqueParameters'])
-  sm = messaging.SubMaster(['carControl', 'carOutput', 'carState', 'liveCalibration', 'livePose', 'liveDelay'], poll='livePose')
+  # poll on carState to not miss transient steeringPressed/latActive frames
+  sm = messaging.SubMaster(['carControl', 'carOutput', 'carState', 'liveCalibration', 'livePose', 'liveDelay'], poll='carState')
 
   params = Params()
   estimator = TorqueEstimator(messaging.log_from_bytes(params.get("CarParams", block=True), car.CarParams))
@@ -263,12 +264,12 @@ def main(demo=False):
           t = sm.logMonoTime[which] * 1e-9
           estimator.handle_log(t, which, sm[which])
 
-    # 4Hz driven by livePose
-    if sm.frame % 5 == 0:
+    # 4Hz driven by carState
+    if sm.frame % 25 == 0:
       pm.send('liveTorqueParameters', estimator.get_msg(valid=sm.all_checks(), with_points=DEBUG))
 
-    # Cache points every 60 seconds while onroad
-    if sm.frame % 240 == 0:
+    # Cache points every 12 seconds while onroad
+    if sm.frame % 1200 == 0:
       msg = estimator.get_msg(valid=sm.all_checks(), with_points=True)
       params.put("LiveTorqueParameters", msg.to_bytes())
 

--- a/openpilot/selfdrive/test/process_replay/process_replay.py
+++ b/openpilot/selfdrive/test/process_replay/process_replay.py
@@ -529,7 +529,7 @@ CONFIGS = [
     subs=["liveDelay"],
     ignore=["logMonoTime"],
     init_callback=get_car_params_callback,
-    should_recv_callback=MessageBasedRcvCallback("livePose"),
+    should_recv_callback=MessageBasedRcvCallback("carState"),
     tolerance=NUMPY_TOLERANCE,
   ),
   ProcessConfig(
@@ -544,7 +544,7 @@ CONFIGS = [
     subs=["liveTorqueParameters"],
     ignore=["logMonoTime"],
     init_callback=get_car_params_callback,
-    should_recv_callback=MessageBasedRcvCallback("livePose", True),
+    should_recv_callback=MessageBasedRcvCallback("carState", True),
     tolerance=NUMPY_TOLERANCE,
   ),
   ProcessConfig(


### PR DESCRIPTION
Fixes https://github.com/commaai/openpilot/issues/32964

Wonder if we should add some kind of `vl_all` to SubMaster (not conflate, and maybe only for specific messages), so we can remove the manual validity checks locationd does, which handles the same problem this PR fixes.

https://github.com/commaai/openpilot/blob/27122bbd281395fc74c796868532a8f0359aaeaa/openpilot/selfdrive/locationd/locationd.py#L249-L261

Plus this PR still only samples, so any jitter and we can miss one of these frames.