### PR TITLE
sensord: restart after IMU interrupt timeout

### DIFF
--- a/openpilot/system/manager/process_config.py
+++ b/openpilot/system/manager/process_config.py
@@ -88,7 +88,7 @@ procs = [
   PythonProcess("modeld", "openpilot.selfdrive.modeld.modeld", only_onroad),
   PythonProcess("dmonitoringmodeld", "openpilot.selfdrive.modeld.dmonitoringmodeld", driverview, enabled=(WEBCAM or not PC)),
 
-  PythonProcess("sensord", "openpilot.system.sensord.sensord", only_onroad, enabled=not PC),
+  PythonProcess("sensord", "openpilot.system.sensord.sensord", only_onroad, enabled=not PC, restart_if_crash=True),
   PythonProcess("ui", "openpilot.selfdrive.ui.ui", always_run, restart_if_crash=True),
   PythonProcess("soundd", "openpilot.selfdrive.ui.soundd", driverview),
   PythonProcess("locationd", "openpilot.selfdrive.locationd.locationd", only_onroad),

--- a/openpilot/system/sensord/sensord.py
+++ b/openpilot/system/sensord/sensord.py
@@ -18,6 +18,7 @@ from openpilot.system.sensord.sensors.lsm6ds3_gyro import LSM6DS3_Gyro
 from openpilot.system.sensord.sensors.lsm6ds3_temp import LSM6DS3_Temp
 
 I2C_BUS_IMU = 1
+SENSOR_IRQ_TIMEOUT_S = 2.0
 
 def interrupt_loop(sensors: list[tuple[Sensor, str, bool]], event) -> None:
   pm = messaging.PubMaster([service for sensor, service, interrupt in sensors if interrupt])
@@ -42,15 +43,19 @@ def interrupt_loop(sensors: list[tuple[Sensor, str, bool]], event) -> None:
 
   poller = select.poll()
   poller.register(fd, select.POLLIN | select.POLLPRI)
+  last_irq_time = time.monotonic()
   while not event.is_set():
     events = poller.poll(100)
     if not events:
-      cloudlog.error("poll timed out")
+      if time.monotonic() - last_irq_time >= SENSOR_IRQ_TIMEOUT_S:
+        cloudlog.error(f"sensor IRQ timed out for {SENSOR_IRQ_TIMEOUT_S:.1f}s")
+        return
       continue
     if not (events[0][1] & (select.POLLIN | select.POLLPRI)):
       cloudlog.error("no poll events set")
       continue
 
+    last_irq_time = time.monotonic()
     dat = os.read(fd, ctypes.sizeof(gpioevent_data)*16)
     evd = gpioevent_data.from_buffer_copy(dat)
 
@@ -110,7 +115,7 @@ def main() -> None:
   # Initialize sensors
   exit_event = threading.Event()
   threads = [
-    threading.Thread(target=interrupt_loop, args=(sensors_cfg, exit_event), daemon=True)
+    threading.Thread(target=interrupt_loop, args=(sensors_cfg, exit_event), name="sensor_interrupt", daemon=True)
   ]
   for sensor, service, interrupt in sensors_cfg:
     try:
@@ -120,6 +125,7 @@ def main() -> None:
         threads.append(threading.Thread(
           target=polling_loop,
           args=(sensor, service, exit_event),
+          name=f"{service}_poll",
           daemon=True
         ))
     except Exception:
@@ -128,8 +134,11 @@ def main() -> None:
   try:
     for t in threads:
       t.start()
-    while any(t.is_alive() for t in threads):
+    while all(t.is_alive() for t in threads):
       time.sleep(1)
+    if not exit_event.is_set():
+      dead_threads = [t.name for t in threads if not t.is_alive()]
+      raise RuntimeError(f"Sensor thread exited unexpectedly: {dead_threads}")
   except KeyboardInterrupt:
     pass
   finally:


### PR DESCRIPTION
## Purpose

Recover accelerometer and gyroscope publishing when the shared IMU interrupt stream stalls while sensord remains alive. In this failure mode, the independently polled temperature sensor continues publishing, so the existing process-liveness check does not recover the IMU.

## Changes

- Exit the interrupt thread after two seconds without an IMU IRQ.
- Treat any unexpected sensor thread exit as a sensord process failure.
- Configure manager to restart sensord after that failure.

Two seconds is well above the normal 104 Hz interrupt period and limits this behavior to a clearly stalled sensor.

## Verification

Tested on a comma device after reproducing the fault (temperature messages continued while accelerometer and gyroscope messages stopped):

- After recovery: 505 accelerometer, 504 gyroscope, and 10 temperature messages in five seconds; all services reported valid data at the expected frequency.
- Killed the managed sensord process and confirmed manager restarted it with a new PID; the same healthy message rates resumed.
- Ran `py_compile`, `check_indentation.py`, `check_shebang_format.sh`, `check_nomerge_comments.sh`, and `git diff --check` on the changed files.