### PR TITLE
Fix doc links broken by the openpilot/ restructure

### DIFF
--- a/openpilot/system/camerad/webcam/README.md
+++ b/openpilot/system/camerad/webcam/README.md
@@ -1,7 +1,7 @@
 # Run openpilot with webcam on PC
 
 ## Setup openpilot
-- Follow [this readme](../README.md) to install and build the requirements
+- Follow [this readme](/tools/README.md) to install and build the requirements
 
 ## Connect the hardware
 - Connect the camera first

--- a/openpilot/tools/plotjuggler/README.md
+++ b/openpilot/tools/plotjuggler/README.md
@@ -4,7 +4,7 @@
 
 ## Installation
 
-Once you've [set up the openpilot environment](../README.md), this command will download PlotJuggler and install our plugins:
+Once you've [set up the openpilot environment](/tools/README.md), this command will download PlotJuggler and install our plugins:
 
 `cd openpilot/tools/plotjuggler && ./juggle.py --install`
 

--- a/tools/CTF.md
+++ b/tools/CTF.md
@@ -5,7 +5,7 @@ Welcome to the first part of the comma CTF!
 * there's 2 flags in each segment, with roughly increasing difficulty
 * everything you'll need to find the flags is in the openpilot repo
   * grep is also your friend
-  * first, [setup](https://github.com/commaai/openpilot/tree/master/openpilot/tools#setup-your-pc) your PC
+  * first, [setup](https://github.com/commaai/openpilot/tree/master/tools) your PC
   * read the docs & checkout out the tools in openpilot/tools/
   * tip: once you get the replay and UI up, start by familiarizing yourself with seeking in replay
 

--- a/tools/README.md
+++ b/tools/README.md
@@ -46,14 +46,19 @@ Learn about the openpilot ecosystem and tools by playing our [CTF](/tools/CTF.md
 ## Directory Structure
 
 ```
+├── car_porting/        # Tools for porting new cars
+├── release/            # Scripts for building openpilot releases
+└── scripts/            # Miscellaneous scripts
+```
+
+Development tools such as cabana, plotjuggler, and replay live in [openpilot/tools/](/openpilot/tools/):
+
+```
 ├── cabana/             # View and plot CAN messages from drives or in realtime
 ├── camerastream/       # Cameras stream over the network
 ├── joystick/           # Control your car with a joystick
 ├── lib/                # Libraries to support the tools and reading openpilot logs
 ├── plotjuggler/        # A tool to plot openpilot logs
 ├── replay/             # Replay drives and mock openpilot services
-├── scripts/            # Miscellaneous scripts
-├── serial/             # Tools for using the comma serial
-├── sim/                # Run openpilot in a simulator
-└── webcam/             # Run openpilot on a PC with webcams
+└── sim/                # Run openpilot in a simulator
 ```


### PR DESCRIPTION
**Description**

#38219 moved the root dirs into the nested `openpilot/` package, which broke several doc links (same class as #38260, which fixed one of them). One commit per fix:

- `openpilot/tools/plotjuggler/README.md` — `../README.md` resolved to `openpilot/tools/README.md`, which no longer exists; now points at `/tools/README.md` (the style #38260 used)
- `openpilot/system/camerad/webcam/README.md` — same broken `../README.md`
- `tools/CTF.md` — linked `tree/master/openpilot/tools#setup-your-pc`, but that directory has no README so GitHub shows a bare listing and the anchor is dead; now points at `tree/master/tools`
- `tools/README.md` — the Directory Structure block still listed `cabana/`, `plotjuggler/`, `replay/`, etc. as living here; they're in `openpilot/tools/` now (`webcam/` → `openpilot/system/camerad/`, `serial/` no longer exists). Rewrote the block to match reality. Happy to drop this commit if you'd rather keep that section minimal.

**Verification**

- Resolved every old link against `git ls-tree` (target missing) and every new link against the current tree (target present)
- `scripts/lint/lint.sh` passes (8/8) and `python3 docs/serve.py --build` builds clean locally on macOS

Prepared with AI assistance (Claude); each link was mechanically verified as described above.