### PR TITLE
cabana: fix macOS build and --zmq bridge path

### DIFF
--- a/openpilot/tools/cabana/signalview.h
+++ b/openpilot/tools/cabana/signalview.h
@@ -129,11 +129,11 @@ private:
       // update widget geometries in QTreeView::rowsInserted
       QTreeView::rowsInserted(parent, start, end);
     }
-    void setModel(QAbstractItemModel *model) override {
-      QTreeView::setModel(model);
+    void setModel(QAbstractItemModel *m) override {
+      QTreeView::setModel(m);
       // Bypass the slow call to QTreeView::dataChanged.
-      QObject::disconnect(model, &QAbstractItemModel::dataChanged, this, nullptr);
-      QObject::connect(model, &QAbstractItemModel::dataChanged, this,
+      QObject::disconnect(m, &QAbstractItemModel::dataChanged, this, nullptr);
+      QObject::connect(m, &QAbstractItemModel::dataChanged, this,
                        [this](const QModelIndex &tl, const QModelIndex &br, const auto &roles) { QAbstractItemView::dataChanged(tl, br, roles); });
     }
     void leaveEvent(QEvent *event) override {

--- a/openpilot/tools/cabana/streams/devicestream.cc
+++ b/openpilot/tools/cabana/streams/devicestream.cc
@@ -53,7 +53,7 @@ void DeviceStream::start() {
   if (!zmq_address.isEmpty()) {
     stopBridge();
     const std::string path = (std::filesystem::path(QCoreApplication::applicationDirPath().toStdString()) /
-                              "../../openpilot/cereal/messaging/bridge").lexically_normal().string();
+                              "../../cereal/messaging/bridge").lexically_normal().string();
     const std::string addr = zmq_address.toStdString();
     const char *can_filter = "/\"can/\"";
 


### PR DESCRIPTION
Two macOS-only cabana fixes:

- signalview.h: rename the SignalView::setModel parameter that shadowed the `model` member. Newer clang (Apple clang 21) folds "parameter shadows a field" into plain -Wshadow, so with -Werror this breaks the macOS build. Older clang (CI's image) only flags it under -Wshadow-all, which is why CI stays green. The rename is clean under any -Wshadow level and gcc.

- devicestream.cc: the --zmq bridge path had a stale `openpilot/` segment (`../../openpilot/cereal/messaging/bridge`), a monorepo-layout leftover that resolved to a non-existent triple-`openpilot` path, so the bridge failed to exec and live streaming was broken. Drop it to `../../cereal/messaging/bridge`.

<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Fingerprint *****

**Car**
Which car (make, model, year) this fingerprint is for

**Route**
A route with the fingerprint

-->

<!--- ***** Template: Car Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 

**Route**

Route: [a route with the bug fix]


-->

<!--- ***** Template: Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 


-->

<!--- ***** Template: Car Port *****

**Checklist**

- [ ] added entry to CAR in openpilot/selfdrive/car/*/values.py and ran `openpilot/selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/openpilot/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:
- [ ] car harness used (if comma doesn't sell it, put N/A):


-->

<!--- ***** Template: Refactor *****

**Description**

A description of the refactor, including the goals it accomplishes. 

**Verification**

Explain how you tested the refactor for regressions. 


-->

