### PR TITLE
usb logging on topology change

### DIFF
--- a/openpilot/common/hardware/usb.py
+++ b/openpilot/common/hardware/usb.py
@@ -1,8 +1,16 @@
+import os
 from pathlib import Path
 
 CHESTNUT_VENDOR_ID = 0xADD1
 CHESTNUT_PRODUCT_ID = 0x0001
 USB_DEVICES_PATH = Path("/sys/bus/usb/devices")
+
+
+def get_usb_topology() -> set[str]:
+  try:
+    return set(os.listdir(USB_DEVICES_PATH))
+  except OSError:
+    return set()
 
 
 def read(path: Path) -> str | None:

--- a/openpilot/system/hardware/hardwared.py
+++ b/openpilot/system/hardware/hardwared.py
@@ -16,7 +16,7 @@ from openpilot.common.params import Params
 from openpilot.common.realtime import DT_HW
 from openpilot.selfdrive.selfdrived.alertmanager import set_offroad_alert
 from openpilot.common.hardware import HARDWARE, TICI, PC
-from openpilot.common.hardware.usb import get_usb_state, set_usb_state
+from openpilot.common.hardware.usb import get_usb_state, get_usb_topology, set_usb_state
 from openpilot.common.linux import LinuxSystemStats
 from openpilot.system.loggerd.config import get_available_percent
 from openpilot.common.swaglog import cloudlog
@@ -105,10 +105,15 @@ def hw_state_thread(end_event, hw_queue):
   """Handles non critical hardware state, and sends over queue"""
   count = 0
   prev_hw_state = None
+  prev_usb_topology = set()
 
   while not end_event.is_set():
-    # these are expensive calls. update every 10s
-    if (count % int(10. / DT_HW)) == 0:
+    usb_topology = get_usb_topology()
+    usb_changed = usb_topology != prev_usb_topology
+
+    # these are expensive calls. update every 10s or when USB devices change
+    if (count % int(10. / DT_HW)) == 0 or usb_changed:
+      prev_usb_topology = usb_topology
       try:
         network_type = HARDWARE.get_network_type()
         modem_temps = HARDWARE.get_modem_temperatures()


### PR DESCRIPTION
speedup USB logging for faster eGPU discovery.
2HZ polling in main hardware.py loop: 0.068 ms/call, 0.014% of one CPU core.
Only do a full usb scan every 10s or on topology change.