### PR TITLE
ui: fix value text eliding when it fits

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -102,6 +102,7 @@ jobs:
     steps:
     - uses: actions/checkout@v7
     - run: ./tools/op.sh setup
+    - run: sudo apt-get install -y --no-install-recommends libegl1 libgles2
     - name: Build openpilot
       run: scons
     - name: Run unit tests
@@ -212,6 +213,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - run: ./tools/op.sh setup
+      - run: sudo apt-get install -y --no-install-recommends libegl1 libgles2
       - name: Build openpilot
         run: scons
       - name: Create UI Report

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -102,7 +102,6 @@ jobs:
     steps:
     - uses: actions/checkout@v7
     - run: ./tools/op.sh setup
-    - run: sudo apt-get install -y --no-install-recommends libegl1 libgles2
     - name: Build openpilot
       run: scons
     - name: Run unit tests
@@ -213,7 +212,6 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - run: ./tools/op.sh setup
-      - run: sudo apt-get install -y --no-install-recommends libegl1 libgles2
       - name: Build openpilot
         run: scons
       - name: Create UI Report

--- a/openpilot/selfdrive/ui/tests/diff/replay_script.py
+++ b/openpilot/selfdrive/ui/tests/diff/replay_script.py
@@ -138,6 +138,10 @@ def setup_update_available(available: bool = True) -> None:
     params.remove("UpdaterTargetBranch")
 
 
+def set_updater_state(state: str) -> None:
+  Params().put("UpdaterState", state, block=True)
+
+
 def setup_calibration_params() -> None:
   params = Params()
   # live calibration
@@ -479,6 +483,9 @@ def build_tizi_script(pm: PubMaster, main_layout, script: Script) -> None:
   # === Settings - Software ===
   script.setup(lambda: setup_update_available(False), wait_after=0)  # start with no update available
   script.click(278, 720)  # software
+  script.setup(lambda: set_updater_state("checking..."))  # updater mid-check
+  script.setup(lambda: set_updater_state("downloading..."))  # updater mid-download
+  script.setup(lambda: set_updater_state("idle"), wait_after=0)
   for _ in range(2):
     script.click(720, 120)  # toggle current release notes
   script.setup(setup_update_available)  # set update available

--- a/openpilot/system/ui/widgets/list_view.py
+++ b/openpilot/system/ui/widgets/list_view.py
@@ -1,3 +1,4 @@
+import math
 import os
 import pyray as rl
 from collections.abc import Callable
@@ -104,7 +105,9 @@ class ButtonAction(ItemAction):
     value_text = self.value
     if value_text:
       text_width = measure_text_cached(self._font, value_text, ITEM_TEXT_FONT_SIZE).x
-      return text_width + BUTTON_WIDTH + TEXT_PADDING
+      # round up so the width survives float32 storage in rl.Rectangle, otherwise the
+      # value label can come out a fraction of a pixel too narrow and get elided
+      return math.ceil(text_width) + BUTTON_WIDTH + TEXT_PADDING
     else:
       return BUTTON_WIDTH
 


### PR DESCRIPTION
> [!NOTE]
> This branch temporarily includes the CI fix from #38514 so the `Create UI Report` job can run on fork PRs

**Description**
While checking for updates on my comma, I noticed the software panel showed `checkin...` instead of `checking...`. The last character is being eaten by `gui_label`'s eliding: `ButtonAction.get_width_hint()` sizes the value label to exactly fit the measured text, and that width gets rounded when stored as float32 in `rl.Rectangle`. When it rounds down, the label rect comes out a fraction of a pixel too narrow, so the elide logic chops a whole character and appends `...`.

Whether a given string trips this depends on its exact measured width. On current master, `checking...` happens to survive the rounding, but `downloading...` renders as `downloadin...` and a target branch of `nightly` renders as `nightl...`. Rounding the width hint up to a whole pixel makes it exactly representable in float32, so the label rect can never come out narrower than the text it was sized for.

The first commit adds the updater `checking...` and `downloading...` states to the UI replay script, so they are covered by the UI report and the `downloading...` case will catch a regression here.

**Verification**
Software panel while the updater is downloading, before (frame from the UI report artifact):
<img width="2160" height="1080" alt="before_downloadin" src="https://github.com/user-attachments/assets/d2e591a0-4eb9-49a0-ab55-904db3e98a47" />

after:
<img width="2160" height="1080" alt="after_downloading" src="https://github.com/user-attachments/assets/9043444b-6e26-46ae-8a57-9cb7b975a86f" />

