### PR TITLE
ci: fix headless raylib jobs on default GitHub runners

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -102,6 +102,8 @@ jobs:
     steps:
     - uses: actions/checkout@v7
     - run: ./tools/op.sh setup
+    # stock GitHub runners lack the GLES/EGL libraries the headless raylib backend links against
+    - run: sudo apt-get install -y --no-install-recommends libegl1 libgles2 libegl-mesa0 libgl1-mesa-dri
     - name: Build openpilot
       run: scons
     - name: Run unit tests
@@ -212,6 +214,8 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - run: ./tools/op.sh setup
+      # stock GitHub runners lack the GLES/EGL libraries the headless raylib backend links against
+      - run: sudo apt-get install -y --no-install-recommends libegl1 libgles2 libegl-mesa0 libgl1-mesa-dri
       - name: Build openpilot
         run: scons
       - name: Create UI Report


### PR DESCRIPTION
**Description**
While working on #38502, I noticed the `Create UI Report` job fails for every PR opened from a fork, and has since #38298. That PR replaced xvfb with the headless raylib backend, which links against `libGLESv2.so.2`/`libEGL.so.1` instead of desktop OpenGL. PRs from forks run on the stock `ubuntu-24.04` runners (the `runs-on` fallback), which don't ship the GLES/EGL stack, so `unit tests` and `Create UI Report` both die at import:

```
ImportError: libGLESv2.so.2: cannot open shared object file: No such file or directory
ImportError: failed to load raylib headless backend extension _raylib_cffi_headless
```

Runs on the namespace runners have these libraries in the image, which is why master is green while fork PRs fail. This installs the GLES/EGL runtime (glvnd dispatchers plus mesa's EGL implementation and software rasterizer) in the two jobs that render with the headless backend.

**Verification**
Failing CI runs:
[#38497 UI Report](https://github.com/commaai/openpilot/actions/runs/30539381353/job/90860272367?pr=38497)
[#38497 unit tests](https://github.com/commaai/openpilot/actions/runs/30539381353/job/90860272177?pr=38497)
[#38501 UI Report](https://github.com/commaai/openpilot/actions/runs/30604637080/job/91074284542?pr=38501)

Passing CI run on this branch:
https://github.com/commaai/openpilot/actions/runs/30608815549