### PR TITLE
ui: don't spam logs when NetworkManager is not available

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -102,6 +102,7 @@ jobs:
     steps:
     - uses: actions/checkout@v7
     - run: ./tools/op.sh setup
+    - run: sudo apt-get install -y --no-install-recommends libegl1 libgles2
     - name: Build openpilot
       run: scons
     - name: Run unit tests
@@ -212,6 +213,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - run: ./tools/op.sh setup
+      - run: sudo apt-get install -y --no-install-recommends libegl1 libgles2
       - name: Build openpilot
         run: scons
       - name: Create UI Report

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -102,7 +102,6 @@ jobs:
     steps:
     - uses: actions/checkout@v7
     - run: ./tools/op.sh setup
-    - run: sudo apt-get install -y --no-install-recommends libegl1 libgles2
     - name: Build openpilot
       run: scons
     - name: Run unit tests
@@ -213,7 +212,6 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - run: ./tools/op.sh setup
-      - run: sudo apt-get install -y --no-install-recommends libegl1 libgles2
       - name: Build openpilot
         run: scons
       - name: Create UI Report

--- a/openpilot/system/ui/lib/wifi_manager.py
+++ b/openpilot/system/ui/lib/wifi_manager.py
@@ -515,8 +515,11 @@ class WifiManager:
   def _get_adapter(self, adapter_type: int) -> str | None:
     # Return the first NetworkManager device path matching adapter_type
     try:
-      device_paths = self._router_main.send_and_get_reply(new_method_call(self._nm, 'GetDevices')).body[0]
-      for device_path in device_paths:
+      reply = self._router_main.send_and_get_reply(new_method_call(self._nm, 'GetDevices'))
+      if reply.header.message_type == MessageType.error:
+        # NetworkManager is not available, body holds an error string instead of device paths
+        return None
+      for device_path in reply.body[0]:
         dev_addr = DBusAddress(device_path, bus_name=NM, interface=NM_DEVICE_IFACE)
         dev_type = self._router_main.send_and_get_reply(Properties(dev_addr).get('DeviceType')).body[0][1]
         if dev_type == adapter_type:


### PR DESCRIPTION
> [!NOTE]
> This branch temporarily includes the CI fix from #38514 so the `Create UI Report` job can run on fork PRs

**Description**
While working on #38502, I noticed the `Create UI Report` job logs are full of repeated tracebacks from `wifi_manager.py` (426 occurrences in the job linked below):

```
ValueError: Object path ('T') must start with /
Error getting adapter type 2: Object path ('T') must start with /
```

`_get_adapter` treats the reply body of `GetDevices` as a list of device paths without checking whether the reply is a D-Bus error. On hosts where D-Bus is up but NetworkManager is not on the bus (like the GitHub runners), the body is the error string `"The name org.freedesktop.NetworkManager was not provided by any .service files"`, so the loop iterates the string character by character, throws `DBusAddress('T')` on the first one, and the 1 second retry loop in `_wait_for_wifi_device` logs a traceback every second, forever. This affects any PC running the UI without NetworkManager, not just CI.

The fix checks the reply type before using the body, matching how error replies are already handled elsewhere in the file.

**Verification**
Reproduced the error reply with plain jeepney against a bus without NetworkManager: the reply has `message_type == MessageType.error`, `body[0]` is the error string, and iterating it yields `'T'`. The added guard catches exactly this case.

Log with tracebacks (426 occurrences during Create UI Report step):
[#38502 UI Report](https://github.com/commaai/openpilot/actions/runs/30609876451/job/91090079013?pr=38502)

Clean log on this branch:
[#38504 UI Report](https://github.com/commaai/openpilot/actions/runs/30612421731/job/91097984826?pr=38504)

