### PR TITLE
hardware: don't kernel panic when a heat-soaked display stops acking frames

### DIFF
--- a/launch_chffrplus.sh
+++ b/launch_chffrplus.sh
@@ -9,6 +9,15 @@ function agnos_init {
   sudo rm -f /data/etc/NetworkManager/system-connections/*.nmmeta
   rm -f /data/scons_cache/config.lock
 
+  # The SDE display driver panics the kernel when a command-mode panel misses two
+  # consecutive pingpong-done IRQs (sde_encoder_phys_cmd.c, SDE_DBG_DUMP("panic")),
+  # which heat-soaked EA8074 panels do ~20-45s into boot - so a recoverable panel
+  # fault becomes a reboot loop. Disarming panic_on_err keeps the register dump and
+  # the PANEL_DEAD/ctl-reset recovery path; it only skips the panic() call.
+  # See commaai/openpilot#34971 and commaai/agnos-kernel-sdm845#85.
+  # Done here rather than in hardwared: this runs before any openpilot DRM client.
+  echo 0 | sudo tee /sys/kernel/debug/dri/0/debug/panic > /dev/null || true
+
   # set success flag for current boot slot
   sudo abctl --set_success
 

--- a/openpilot/system/hardware/hardwared.py
+++ b/openpilot/system/hardware/hardwared.py
@@ -10,7 +10,7 @@ from collections import OrderedDict, namedtuple
 import openpilot.cereal.messaging as messaging
 from openpilot.cereal import log
 from openpilot.cereal.services import SERVICE_LIST
-from openpilot.common.utils import strip_deprecated_keys
+from openpilot.common.utils import strip_deprecated_keys, sudo_read
 from openpilot.common.filter_simple import FirstOrderFilter
 from openpilot.common.params import Params
 from openpilot.common.realtime import DT_HW
@@ -192,6 +192,13 @@ def hardware_thread(end_event, hw_queue) -> None:
   last_uptime_ts: float = time.monotonic()
 
   HARDWARE.initialize_hardware()
+
+  if TICI:
+    # panic-on-display-error is disarmed in launch_chffrplus.sh. journald is only_onroad,
+    # so nothing else records the state during the offroad boot window where a heat-soaked
+    # panel faults - log the readback so that boot is diagnosable after the fact.
+    cloudlog.event("hardwared.sde_panic_on_err", value=sudo_read("/sys/kernel/debug/dri/0/debug/panic"))
+
   thermal_config = HARDWARE.get_thermal_config()
 
   fan_controller = FanController(int(1./DT_HW))


### PR DESCRIPTION
**Description**

On a heat-soaked comma 3X the SDE display driver panics the kernel ~20-45s into boot, offroad — on a hot day that becomes a boot loop until the device cools.

It's a debug panic, not a thermal trip: after a command-mode panel misses two consecutive pingpong-done IRQs, `_sde_encoder_phys_cmd_handle_ppdone_timeout()` hits `SDE_DBG_DUMP("panic")`, and `panic_on_err` defaults to 1. This clears that knob in `agnos_init()`.

Only the `panic()` is skipped — the register dump still runs, `PANEL_DEAD` is still delivered, and the encoder still recovers on the next kickoff. A recoverable panel fault stays recoverable.

Related: #34971, commaai/agnos-kernel-sdm845#85, #36191. The panel-jitter DT change reduced the fault rate but didn't remove it — this device is on current AGNOS and still faults above ~68 °C board.

**Verification**

- Bench: `bash -n` and `ruff` clean, no new `shellcheck` findings; no cereal change.
- Device: `/sys/kernel/debug/dri/0/debug/panic` reads `0` after reboot.
- Field, one 3X over 9 days: 6 consecutive boots, none surviving past 19s, two ramoops both ending in `Kernel panic - not syncing: _sde_encoder_phys_cmd_handle_ppdone_timeout`. After disarming: 32 boots, 0 reboots, 0 panic dumps — while the panel fault kept recurring on 4 of them, the hottest at 82.4 °C board faulting at 46s (inside the old panic window) and then running 22 min unbroken. Faults separate cleanly on board temp: every boot ≥68.3 °C faulted, every boot ≤67.5 °C did not.

Data and figures: https://github.com/jojobird6/comma3x-thermal-investigation/tree/main/display-panic

Notes: placed in `agnos_init()` rather than `Tici.initialize_hardware()` because hardwared starts after registration, later than the earliest observed panic at 20.6s — that timing is inferred from log timestamps rather than directly measured, so happy to move it to a systemd drop-in if you'd prefer. `sudo tee` rather than `sudo_write()`, whose `PermissionError` fallback would leave a root-owned debugfs knob world-writable. The hardwared hunk only logs the readback, since `journald` is `only_onroad` and nothing else records kernel state during the offroad boot window where this fires.

Evidence was gathered on a device running a fork's userspace; the fault is in the AGNOS kernel display driver and is independent of which openpilot build is running.
