### PR TITLE
handle transient sysfs read errors

### DIFF
--- a/openpilot/common/hardware/usb.py
+++ b/openpilot/common/hardware/usb.py
@@ -22,7 +22,7 @@ def read(path: Path) -> str | None:
 def read_int(path: Path, base: int = 10) -> int:
   try:
     return int(path.read_text(), base)
-  except (OSError, ValueError):
+  except (OSError, ValueError, TypeError):
     return 0
 
 


### PR DESCRIPTION
USB logger occasionally throws TypeError with a USB hub. It is robust to varying AGNOS versions.