### PR TITLE
timed: set the clock from GPS in UTC, not local time

### DIFF
--- a/openpilot/system/timed.py
+++ b/openpilot/system/timed.py
@@ -12,7 +12,7 @@ from openpilot.common.gps import get_gps_location_service
 
 
 def set_time(new_time):
-  diff = datetime.datetime.now() - new_time
+  diff = datetime.datetime.now(datetime.UTC).replace(tzinfo=None) - new_time
   if abs(diff) < datetime.timedelta(seconds=10):
     cloudlog.debug(f"Time diff too small: {diff}")
     return
@@ -47,7 +47,7 @@ def main() -> NoReturn:
     pm.send('clocks', msg)
 
     gps = sm[gps_location_service]
-    gps_time = datetime.datetime.fromtimestamp(gps.unixTimestampMillis / 1000.)
+    gps_time = datetime.datetime.fromtimestamp(gps.unixTimestampMillis / 1000., datetime.UTC).replace(tzinfo=None)
     if not sm.updated[gps_location_service] or (time.monotonic() - sm.logMonoTime[gps_location_service] / 1e9) > 2.0:
       continue
     if not gps.hasFix:


### PR DESCRIPTION
**Description**

`openpilot/system/timed.py` reads the GPS timestamp as **local** time and writes it back as **UTC**:

```python
gps_time = datetime.datetime.fromtimestamp(gps.unixTimestampMillis / 1000.)   # line 50, local
subprocess.run(f"TZ=UTC date -s '{new_time}'", shell=True, check=True)        # line 22, as UTC
```

The system clock ends up off by exactly the local UTC offset. It never converges: `set_time` compares `datetime.datetime.now()`, the local reading of the already-wrong clock, against the same local-derived `gps_time`, so the difference stays one UTC offset — well past the 10 s guard on line 16 — and the same wrong value is rewritten every 10 s for as long as GPS is the time source.

Only a zero offset hides it, and NTP repairs the clock whenever the device has connectivity, so what survives is every route recorded while driving out of range. Nothing flags it either: `system_time_valid()` only bounds the year, so `clocks.valid` stays true.

The fix builds `gps_time` in UTC. Keeping it naive leaves both the `date -s` string form and the `min_date()`/`MAX_DATE` comparison on line 55 unchanged, so `common/time_helpers.py` and its ~10 callers are untouched.

**Verification**

The conversion, run standalone under a few zones:

```python
import datetime, os, time

T = 1785737634.099  # a gpsLocation.unixTimestampMillis / 1000

for tz in ["UTC", "Asia/Shanghai", "America/Los_Angeles", "Asia/Kathmandu"]:
  os.environ["TZ"] = tz; time.tzset()
  s = f"{datetime.datetime.fromtimestamp(T)}"          # what timed.py hands to date -s
  os.environ["TZ"] = "UTC"; time.tzset()               # what TZ=UTC date -s reads it as
  got = time.mktime(time.strptime(s.split('.')[0], "%Y-%m-%d %H:%M:%S"))
  print(f"{tz:<22}{got - int(T):+8.0f} s")
```

```
UTC                         +0 s
Asia/Shanghai           +28800 s
America/Los_Angeles     -25200 s
Asia/Kathmandu          +20700 s
```

After the change all four produce the same instant, and the string handed to `date -s` is byte-identical across them.

On a device set to `Asia/Shanghai`, this shows up as `clocks.wallTimeNanos` running +28800 s ahead of `gpsLocation.unixTimestampMillis` on every route recorded while driving, and +0/+1 s on routes recorded parked in WiFi range where NTP had already corrected the clock. Segment mtimes inherit the offset, so a 14:00 drive is stored under directories stamped 22:00.
