### PR TITLE
log chestnut metrics

### DIFF
--- a/openpilot/cereal/log.capnp
+++ b/openpilot/cereal/log.capnp
@@ -709,7 +709,12 @@ struct UsbState {
 
 struct ChestnutState {
   tempC @0 :Float32;
+  memoryTempC @3 :Float32;
+  powerW @2 :Float32;
   powerTargetW @1 :Float32;
+  gpuUsagePercent @4 :UInt8;
+  gpuClockMhz @5 :UInt16;
+  fanRpm @6 :UInt16;
 }
 
 struct RadarState @0x9a185389d6fdd05f {

--- a/openpilot/cereal/log.capnp
+++ b/openpilot/cereal/log.capnp
@@ -707,6 +707,11 @@ struct UsbState {
   }
 }
 
+struct ChestnutState {
+  tempC @0 :Float32;
+  powerTargetW @1 :Float32;
+}
+
 struct RadarState @0x9a185389d6fdd05f {
   mdMonoTime @6 :UInt64;  # for debugging
   radarErrors @13 :Car.RadarData.Error;
@@ -2570,6 +2575,7 @@ struct Event {
     procLog @33 :ProcLog;
     clocks @35 :Clocks;
     deviceState @6 :DeviceState;
+    chestnutState @152 :ChestnutState;
     logMessage @18 :Text;
     errorLogMessage @85 :Text;
 

--- a/openpilot/cereal/log.capnp
+++ b/openpilot/cereal/log.capnp
@@ -710,11 +710,11 @@ struct UsbState {
 struct ChestnutState {
   tempC @0 :Float32;
   memoryTempC @3 :Float32;
-  powerW @2 :Float32;
-  powerTargetW @1 :Float32;
+  powerDrawW @2 :Float32;
+  powerLimitW @1 :Float32;
   gpuUsagePercent @4 :UInt8;
   gpuClockMhz @5 :UInt16;
-  fanRpm @6 :UInt16;
+  fanSpeedRpm @6 :UInt16;
 }
 
 struct RadarState @0x9a185389d6fdd05f {

--- a/openpilot/cereal/log.capnp
+++ b/openpilot/cereal/log.capnp
@@ -709,9 +709,9 @@ struct UsbState {
 
 struct ChestnutState {
   tempC @0 :Float32;
-  memoryTempC @3 :Float32;
+  memoryTempC @1 :Float32;
   powerDrawW @2 :Float32;
-  powerLimitW @1 :Float32;
+  powerLimitW @3 :Float32;
   gpuUsagePercent @4 :UInt8;
   gpuClockMhz @5 :UInt16;
   fanSpeedRpm @6 :UInt16;

--- a/openpilot/cereal/services.py
+++ b/openpilot/cereal/services.py
@@ -25,6 +25,7 @@ _services: dict[str, tuple] = {
   "accelerometer": (True, 104., 104),
   "temperatureSensor": (True, 2., 200),
   "deviceState": (True, 2., 1),
+  "chestnutState": (True, 0.1, 1),
   "touch": (True, 20., 1),
   "can": (True, 100., 2053, QueueSize.BIG),  # decimation gives ~3 msgs in a full segment
   "controlsState": (True, 100., 10, QueueSize.MEDIUM),

--- a/openpilot/selfdrive/modeld/modeld.py
+++ b/openpilot/selfdrive/modeld/modeld.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-from functools import cache
+from functools import cached_property
 import os
 os.environ['GMMU'] = '0' # for usbgpu fast loading, noop for qcom
 from tinygrad.tensor import Tensor
@@ -67,17 +67,16 @@ def get_action_from_model(model_output: dict[str, np.ndarray], prev_action: log.
                                 shouldStop=bool(stop))
 
 
-@cache
-def get_chestnut_power_limit() -> int:
-  smu = Device["AMD"].iface.dev_impl.smu
-  return smu._send_msg(smu.smu_mod.PPSMC_MSG_GetPptLimit, 0, read_back_arg=True)
-
-
 class ChestnutState:
   # only modeld can access chestnut
   def __init__(self, pm: PubMaster):
     self.pm = pm
     self.valid = True
+
+  @cached_property
+  def power_limit(self) -> int:
+    smu = Device["AMD"].iface.dev_impl.smu
+    return smu._send_msg(smu.smu_mod.PPSMC_MSG_GetPptLimit, 0, read_back_arg=True)
 
   def send(self) -> None:
     msg = messaging.new_message('chestnutState')
@@ -88,7 +87,7 @@ class ChestnutState:
       state.tempC = metrics.AvgTemperature[smu.smu_mod.TEMP_HOTSPOT]
       state.memoryTempC = metrics.AvgTemperature[smu.smu_mod.TEMP_MEM]
       state.powerDrawW = metrics.AverageSocketPower
-      state.powerLimitW = get_chestnut_power_limit()
+      state.powerLimitW = self.power_limit
       state.gpuUsagePercent = metrics.AverageGfxActivity
       state.gpuClockMhz = metrics.AverageGfxclkFrequencyPostDs
       state.fanSpeedRpm = metrics.AvgFanRpm

--- a/openpilot/selfdrive/modeld/modeld.py
+++ b/openpilot/selfdrive/modeld/modeld.py
@@ -67,34 +67,40 @@ def get_action_from_model(model_output: dict[str, np.ndarray], prev_action: log.
 
 
 class ChestnutState:
-  # only modeld has access to chestnut
+  # only modeld can access chestnut
   def __init__(self, pm: PubMaster):
     self.pm = pm
     self.interval = 1. / SERVICE_LIST['chestnutState'].frequency
     self.last_read = 0.
-    self.logged = False
+    self.error_logged = False
 
   def update(self) -> None:
-    if time.monotonic() - self.last_read < self.interval:
+    now = time.monotonic()
+    if now - self.last_read < self.interval:
       return
+    self.last_read = now
 
-    self.last_read = time.monotonic()
-    temp, power = 0., 0.
+    cs = log.ChestnutState.new_message()
+    valid = False
     try:
-      dev = Device["AMD"]
-      smu = dev.iface.dev_impl.smu
-      power = float(smu._send_msg(smu.smu_mod.PPSMC_MSG_GetPptLimit, 0, read_back_arg=True))
-      if dev.arch == "gfx1200":
-        metrics = smu.read_table(smu.smu_mod.SmuMetricsExternal_t, smu.smu_mod.SMU_TABLE_SMU_METRICS)
-        temp = float(metrics.SmuMetrics.MovingAverageVclk0Frequency)
+      smu = Device["AMD"].iface.dev_impl.smu
+      metrics = smu.read_table(smu.smu_mod.SmuMetricsExternal_t, smu.smu_mod.TABLE_SMU_METRICS).SmuMetrics
+      cs.tempC = max(metrics.AvgTemperature[:smu.smu_mod.TEMP_COUNT])
+      cs.memoryTempC = metrics.AvgTemperature[smu.smu_mod.TEMP_MEM]
+      cs.powerW = metrics.AverageSocketPower
+      cs.powerTargetW = smu._send_msg(smu.smu_mod.PPSMC_MSG_GetPptLimit, 0, read_back_arg=True)
+      cs.gpuUsagePercent = metrics.AverageGfxActivity
+      cs.gpuClockMhz = metrics.CurrClock[smu.smu_mod.PPCLK_GFXCLK]
+      cs.fanRpm = metrics.AvgFanRpm
+      valid = True
+      self.error_logged = False
     except Exception:
-      if not self.logged:
-        cloudlog.exception("chestnut state read failed")
-        self.logged = True
+      if not self.error_logged:
+        cloudlog.exception("Chestnut metrics read failed")
+        self.error_logged = True
 
-    msg = messaging.new_message('chestnutState', valid=temp > 0.)
-    msg.chestnutState.tempC = temp
-    msg.chestnutState.powerTargetW = power
+    msg = messaging.new_message('chestnutState', valid=valid)
+    msg.chestnutState = cs
     self.pm.send('chestnutState', msg)
 
 

--- a/openpilot/selfdrive/modeld/modeld.py
+++ b/openpilot/selfdrive/modeld/modeld.py
@@ -73,12 +73,12 @@ def send_chestnut_state(pm: PubMaster) -> None:
   try:
     smu = Device["AMD"].iface.dev_impl.smu
     metrics = smu.read_table(smu.smu_mod.SmuMetricsExternal_t, smu.smu_mod.TABLE_SMU_METRICS).SmuMetrics
-    state.tempC = max(metrics.AvgTemperature[:smu.smu_mod.TEMP_COUNT])
+    state.tempC = metrics.AvgTemperature[smu.smu_mod.TEMP_HOTSPOT]
     state.memoryTempC = metrics.AvgTemperature[smu.smu_mod.TEMP_MEM]
     state.powerDrawW = metrics.AverageSocketPower
     state.powerLimitW = smu._send_msg(smu.smu_mod.PPSMC_MSG_GetPptLimit, 0, read_back_arg=True)
     state.gpuUsagePercent = metrics.AverageGfxActivity
-    state.gpuClockMhz = metrics.CurrClock[smu.smu_mod.PPCLK_GFXCLK]
+    state.gpuClockMhz = metrics.AverageGfxclkFrequencyPostDs
     state.fanSpeedRpm = metrics.AvgFanRpm
   except Exception:
     msg.valid = False

--- a/openpilot/selfdrive/modeld/modeld.py
+++ b/openpilot/selfdrive/modeld/modeld.py
@@ -2,6 +2,7 @@
 import os
 os.environ['GMMU'] = '0' # for usbgpu fast loading, noop for qcom
 from tinygrad.tensor import Tensor
+from tinygrad.device import Device
 import threading
 import time
 import numpy as np
@@ -9,6 +10,7 @@ import openpilot.cereal.messaging as messaging
 from openpilot.cereal import log
 from opendbc.car.structs import car
 from openpilot.cereal.messaging import PubMaster, SubMaster
+from openpilot.cereal.services import SERVICE_LIST
 from msgq.visionipc import VisionIpcClient, VisionStreamType, VisionBuf
 from opendbc.car.car_helpers import get_demo_car_params
 from openpilot.common.swaglog import cloudlog
@@ -62,6 +64,38 @@ def get_action_from_model(model_output: dict[str, np.ndarray], prev_action: log.
   return log.ModelDataV2.Action(desiredCurvature=float(desired_curvature),
                                 desiredAcceleration=float(desired_accel),
                                 shouldStop=bool(stop))
+
+
+class ChestnutState:
+  # only modeld has access to chestnut
+  def __init__(self, pm: PubMaster):
+    self.pm = pm
+    self.interval = 1. / SERVICE_LIST['chestnutState'].frequency
+    self.last_read = 0.
+    self.logged = False
+
+  def update(self) -> None:
+    if time.monotonic() - self.last_read < self.interval:
+      return
+
+    self.last_read = time.monotonic()
+    temp, power = 0., 0.
+    try:
+      dev = Device["AMD"]
+      smu = dev.iface.dev_impl.smu
+      power = float(smu._send_msg(smu.smu_mod.PPSMC_MSG_GetPptLimit, 0, read_back_arg=True))
+      if dev.arch == "gfx1200":
+        metrics = smu.read_table(smu.smu_mod.SmuMetricsExternal_t, smu.smu_mod.SMU_TABLE_SMU_METRICS)
+        temp = float(metrics.SmuMetrics.MovingAverageVclk0Frequency)
+    except Exception:
+      if not self.logged:
+        cloudlog.exception("chestnut state read failed")
+        self.logged = True
+
+    msg = messaging.new_message('chestnutState', valid=temp > 0.)
+    msg.chestnutState.tempC = temp
+    msg.chestnutState.powerTargetW = power
+    self.pm.send('chestnutState', msg)
 
 
 class FrameMeta:
@@ -204,11 +238,13 @@ def main(demo=False):
   cloudlog.warning(f"models loaded in {time.monotonic() - st:.1f}s, modeld starting")
 
   # messaging
-  pm = PubMaster(["modelV2", "drivingModelData", "cameraOdometry"])
+  pub_socks = ["modelV2", "drivingModelData", "cameraOdometry"] + (["chestnutState"] if USBGPU else [])
+  pm = PubMaster(pub_socks)
   sm = SubMaster(["deviceState", "carState", "roadCameraState", "liveCalibration", "driverMonitoringState", "carControl", "liveDelay"])
 
   publish_state = PublishState()
   params = Params()
+  chestnut_state = ChestnutState(pm) if USBGPU else None
 
   # setup filter to track dropped frames
   frame_dropped_filter = FirstOrderFilter(0., 10., 1. / ModelConstants.MODEL_RUN_FREQ)
@@ -326,6 +362,9 @@ def main(demo=False):
       model_output = None
     mt2 = time.perf_counter()
     model_execution_time = mt2 - mt1
+
+    if chestnut_state is not None:
+      chestnut_state.update()
 
     if model_output is not None:
       modelv2_send = messaging.new_message('modelV2')

--- a/openpilot/selfdrive/modeld/modeld.py
+++ b/openpilot/selfdrive/modeld/modeld.py
@@ -66,42 +66,25 @@ def get_action_from_model(model_output: dict[str, np.ndarray], prev_action: log.
                                 shouldStop=bool(stop))
 
 
-class ChestnutState:
+def send_chestnut_state(pm: PubMaster) -> None:
   # only modeld can access chestnut
-  def __init__(self, pm: PubMaster):
-    self.pm = pm
-    self.interval = 1. / SERVICE_LIST['chestnutState'].frequency
-    self.last_read = 0.
-    self.error_logged = False
+  msg = messaging.new_message('chestnutState', valid=True)
+  state = msg.chestnutState
+  try:
+    smu = Device["AMD"].iface.dev_impl.smu
+    metrics = smu.read_table(smu.smu_mod.SmuMetricsExternal_t, smu.smu_mod.TABLE_SMU_METRICS).SmuMetrics
+    state.tempC = max(metrics.AvgTemperature[:smu.smu_mod.TEMP_COUNT])
+    state.memoryTempC = metrics.AvgTemperature[smu.smu_mod.TEMP_MEM]
+    state.powerDrawW = metrics.AverageSocketPower
+    state.powerLimitW = smu._send_msg(smu.smu_mod.PPSMC_MSG_GetPptLimit, 0, read_back_arg=True)
+    state.gpuUsagePercent = metrics.AverageGfxActivity
+    state.gpuClockMhz = metrics.CurrClock[smu.smu_mod.PPCLK_GFXCLK]
+    state.fanSpeedRpm = metrics.AvgFanRpm
+  except Exception:
+    msg.valid = False
+    cloudlog.exception("chestnut state read failed")
 
-  def update(self) -> None:
-    now = time.monotonic()
-    if now - self.last_read < self.interval:
-      return
-    self.last_read = now
-
-    cs = log.ChestnutState.new_message()
-    valid = False
-    try:
-      smu = Device["AMD"].iface.dev_impl.smu
-      metrics = smu.read_table(smu.smu_mod.SmuMetricsExternal_t, smu.smu_mod.TABLE_SMU_METRICS).SmuMetrics
-      cs.tempC = max(metrics.AvgTemperature[:smu.smu_mod.TEMP_COUNT])
-      cs.memoryTempC = metrics.AvgTemperature[smu.smu_mod.TEMP_MEM]
-      cs.powerW = metrics.AverageSocketPower
-      cs.powerTargetW = smu._send_msg(smu.smu_mod.PPSMC_MSG_GetPptLimit, 0, read_back_arg=True)
-      cs.gpuUsagePercent = metrics.AverageGfxActivity
-      cs.gpuClockMhz = metrics.CurrClock[smu.smu_mod.PPCLK_GFXCLK]
-      cs.fanRpm = metrics.AvgFanRpm
-      valid = True
-      self.error_logged = False
-    except Exception:
-      if not self.error_logged:
-        cloudlog.exception("Chestnut metrics read failed")
-        self.error_logged = True
-
-    msg = messaging.new_message('chestnutState', valid=valid)
-    msg.chestnutState = cs
-    self.pm.send('chestnutState', msg)
+  pm.send('chestnutState', msg)
 
 
 class FrameMeta:
@@ -250,7 +233,6 @@ def main(demo=False):
 
   publish_state = PublishState()
   params = Params()
-  chestnut_state = ChestnutState(pm) if USBGPU else None
 
   # setup filter to track dropped frames
   frame_dropped_filter = FirstOrderFilter(0., 10., 1. / ModelConstants.MODEL_RUN_FREQ)
@@ -369,9 +351,6 @@ def main(demo=False):
     mt2 = time.perf_counter()
     model_execution_time = mt2 - mt1
 
-    if chestnut_state is not None:
-      chestnut_state.update()
-
     if model_output is not None:
       modelv2_send = messaging.new_message('modelV2')
       drivingdata_send = messaging.new_message('drivingModelData')
@@ -397,6 +376,9 @@ def main(demo=False):
       pm.send('drivingModelData', drivingdata_send)
       pm.send('cameraOdometry', posenet_send)
     last_vipc_frame_id = meta_main.frame_id
+
+    if USBGPU and run_count % round(ModelConstants.MODEL_RUN_FREQ / SERVICE_LIST['chestnutState'].frequency) == 0:
+      send_chestnut_state(pm)
 
 
 if __name__ == "__main__":

--- a/openpilot/selfdrive/modeld/modeld.py
+++ b/openpilot/selfdrive/modeld/modeld.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+from functools import cache
 import os
 os.environ['GMMU'] = '0' # for usbgpu fast loading, noop for qcom
 from tinygrad.tensor import Tensor
@@ -66,6 +67,12 @@ def get_action_from_model(model_output: dict[str, np.ndarray], prev_action: log.
                                 shouldStop=bool(stop))
 
 
+@cache
+def get_chestnut_power_limit() -> int:
+  smu = Device["AMD"].iface.dev_impl.smu
+  return smu._send_msg(smu.smu_mod.PPSMC_MSG_GetPptLimit, 0, read_back_arg=True)
+
+
 def send_chestnut_state(pm: PubMaster) -> None:
   # only modeld can access chestnut
   msg = messaging.new_message('chestnutState', valid=True)
@@ -76,7 +83,7 @@ def send_chestnut_state(pm: PubMaster) -> None:
     state.tempC = metrics.AvgTemperature[smu.smu_mod.TEMP_HOTSPOT]
     state.memoryTempC = metrics.AvgTemperature[smu.smu_mod.TEMP_MEM]
     state.powerDrawW = metrics.AverageSocketPower
-    state.powerLimitW = smu._send_msg(smu.smu_mod.PPSMC_MSG_GetPptLimit, 0, read_back_arg=True)
+    state.powerLimitW = get_chestnut_power_limit()
     state.gpuUsagePercent = metrics.AverageGfxActivity
     state.gpuClockMhz = metrics.AverageGfxclkFrequencyPostDs
     state.fanSpeedRpm = metrics.AvgFanRpm

--- a/openpilot/selfdrive/modeld/modeld.py
+++ b/openpilot/selfdrive/modeld/modeld.py
@@ -73,25 +73,33 @@ def get_chestnut_power_limit() -> int:
   return smu._send_msg(smu.smu_mod.PPSMC_MSG_GetPptLimit, 0, read_back_arg=True)
 
 
-def send_chestnut_state(pm: PubMaster) -> None:
+class ChestnutState:
   # only modeld can access chestnut
-  msg = messaging.new_message('chestnutState', valid=True)
-  state = msg.chestnutState
-  try:
-    smu = Device["AMD"].iface.dev_impl.smu
-    metrics = smu.read_table(smu.smu_mod.SmuMetricsExternal_t, smu.smu_mod.TABLE_SMU_METRICS).SmuMetrics
-    state.tempC = metrics.AvgTemperature[smu.smu_mod.TEMP_HOTSPOT]
-    state.memoryTempC = metrics.AvgTemperature[smu.smu_mod.TEMP_MEM]
-    state.powerDrawW = metrics.AverageSocketPower
-    state.powerLimitW = get_chestnut_power_limit()
-    state.gpuUsagePercent = metrics.AverageGfxActivity
-    state.gpuClockMhz = metrics.AverageGfxclkFrequencyPostDs
-    state.fanSpeedRpm = metrics.AvgFanRpm
-  except Exception:
-    msg.valid = False
-    cloudlog.exception("chestnut state read failed")
+  def __init__(self, pm: PubMaster):
+    self.pm = pm
+    self.valid = True
 
-  pm.send('chestnutState', msg)
+  def send(self) -> None:
+    msg = messaging.new_message('chestnutState')
+    state = msg.chestnutState
+    try:
+      smu = Device["AMD"].iface.dev_impl.smu
+      metrics = smu.read_table(smu.smu_mod.SmuMetricsExternal_t, smu.smu_mod.TABLE_SMU_METRICS).SmuMetrics
+      state.tempC = metrics.AvgTemperature[smu.smu_mod.TEMP_HOTSPOT]
+      state.memoryTempC = metrics.AvgTemperature[smu.smu_mod.TEMP_MEM]
+      state.powerDrawW = metrics.AverageSocketPower
+      state.powerLimitW = get_chestnut_power_limit()
+      state.gpuUsagePercent = metrics.AverageGfxActivity
+      state.gpuClockMhz = metrics.AverageGfxclkFrequencyPostDs
+      state.fanSpeedRpm = metrics.AvgFanRpm
+      self.valid = True
+    except Exception:
+      if self.valid:
+        cloudlog.exception("chestnut state read failed")
+      self.valid = False
+
+    msg.valid = self.valid
+    self.pm.send('chestnutState', msg)
 
 
 class FrameMeta:
@@ -240,6 +248,7 @@ def main(demo=False):
 
   publish_state = PublishState()
   params = Params()
+  chestnut_state = ChestnutState(pm) if USBGPU else None
 
   # setup filter to track dropped frames
   frame_dropped_filter = FirstOrderFilter(0., 10., 1. / ModelConstants.MODEL_RUN_FREQ)
@@ -384,8 +393,8 @@ def main(demo=False):
       pm.send('cameraOdometry', posenet_send)
     last_vipc_frame_id = meta_main.frame_id
 
-    if USBGPU and run_count % round(ModelConstants.MODEL_RUN_FREQ / SERVICE_LIST['chestnutState'].frequency) == 0:
-      send_chestnut_state(pm)
+    if chestnut_state is not None and run_count % round(ModelConstants.MODEL_RUN_FREQ / SERVICE_LIST['chestnutState'].frequency) == 0:
+      chestnut_state.send()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Adds chestnut metrics at 0.1Hz:
```
  tempC @0 :Float32;
  memoryTempC @1 :Float32;
  powerDrawW @2 :Float32;
  powerLimitW @3 :Float32;
  gpuUsagePercent @4 :UInt8;
  gpuClockMhz @5 :UInt16;
  fanSpeedRpm @6 :UInt16;
```
Logged in modeld process as it owns the GPU lock.

logging takes ~3ms every 10s
power limit is cached as it takes an extra ~2ms