### PR TITLE
probe chestnut before compiling big model

### DIFF
--- a/openpilot/selfdrive/modeld/SConscript
+++ b/openpilot/selfdrive/modeld/SConscript
@@ -50,18 +50,6 @@ if USBGPU:
   # the USB+AMD GPU takes an exclusive flock; serialize all targets that touch it
   usbgpu_lock = File("models/.usb_gpu.lock").abspath
 
-  probe_env = {**env['ENV'], 'DEV': 'USB+AMD'}
-  try:
-    for i in range(3):
-      if i: time.sleep(1)
-      USBGPU = subprocess.run([sys.executable, '-c', 'from tinygrad import Device; Device[Device.DEFAULT]'], env=probe_env,
-                              stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, timeout=5).returncode == 0
-      if USBGPU: break
-  except subprocess.TimeoutExpired:
-    USBGPU = False
-  if not USBGPU:
-    print("Chestnut not ready, skipping big model build")
-
 def write_tg_devices(target, source, env):
   with open(str(target[0]), "w") as f:
     json.dump(tg_devices, f)
@@ -99,12 +87,29 @@ for usbgpu in [False, True] if USBGPU else [False]:
         f'--output {target_pkl_path} --frame-skip {frame_skip}')
   onnx_sizes_sum = sum(os.path.getsize(f) for f in driving_onnx_deps)
   chunk_targets = get_chunk_targets(target_pkl_path, estimate_pickle_max_size(onnx_sizes_sum))
-  def do_chunk(target, source, env, pkl=target_pkl_path, chunks=chunk_targets):
+  def do_compile(target, source, env, command=cmd):
+    probe_env = {**env['ENV'], 'DEV': 'USB+AMD'}
+    try:
+      for attempt in range(3):
+        if attempt: time.sleep(1)
+        ready = subprocess.run([sys.executable, '-c', 'from tinygrad import Device; Device[Device.DEFAULT]'], env=probe_env,
+                               stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, timeout=5).returncode == 0
+        if ready: break
+    except subprocess.TimeoutExpired:
+      ready = False
+    if not ready:
+      print("Chestnut not ready, skipping big model build")
+      return None
+    return env.Execute(command)
+  def do_chunk(target, source, env, pkl=target_pkl_path, chunks=chunk_targets, optional=usbgpu):
+    if optional and not os.path.isfile(pkl):
+      return
     chunk_file(pkl, chunks)
+  actions = [Action(do_compile, "  [USBGPU] $TARGET") if usbgpu else cmd, Action(do_chunk, "  [CHUNK] $TARGET")]
   node = lenv.Command(
     chunk_targets,
     tinygrad_files + compile_modeld_script + driving_onnx_deps + [Value(chunk_targets), chunker_file],
-    [cmd, Action(do_chunk, "  [CHUNK] $TARGET")],
+    actions,
   )
   if usbgpu:
     lenv.SideEffect(usbgpu_lock, node)

--- a/openpilot/selfdrive/modeld/SConscript
+++ b/openpilot/selfdrive/modeld/SConscript
@@ -2,6 +2,7 @@ import glob
 import json
 import os
 import sys, subprocess
+import time
 from SCons.Script import Action, Value
 from openpilot.common.file_chunker import chunk_file, get_chunk_targets, get_existing_chunks
 from openpilot.common.transformations.camera import _ar_ox_fisheye, _os_fisheye
@@ -48,6 +49,18 @@ if USBGPU:
   usbgpu_tg_flags = f'DEBUG=2 DEV=USB+AMD:LLVM WARP_DEV={tg_backend} FLOAT16=1 JIT_BATCH_SIZE=0 GMMU=0 TC_OPT=2'
   # the USB+AMD GPU takes an exclusive flock; serialize all targets that touch it
   usbgpu_lock = File("models/.usb_gpu.lock").abspath
+
+  probe_env = {**env['ENV'], 'DEV': 'USB+AMD'}
+  try:
+    for i in range(3):
+      if i: time.sleep(1)
+      USBGPU = subprocess.run([sys.executable, '-c', 'from tinygrad import Device; Device[Device.DEFAULT]'], env=probe_env,
+                              stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, timeout=5).returncode == 0
+      if USBGPU: break
+  except subprocess.TimeoutExpired:
+    USBGPU = False
+  if not USBGPU:
+    print("Chestnut not ready, skipping big model build")
 
 def write_tg_devices(target, source, env):
   with open(str(target[0]), "w") as f:

--- a/openpilot/selfdrive/modeld/SConscript
+++ b/openpilot/selfdrive/modeld/SConscript
@@ -93,7 +93,7 @@ for usbgpu in [False, True] if USBGPU else [False]:
     try:
       for attempt in range(3):
         if attempt: time.sleep(1)
-        ready = subprocess.run(probe_cmd, env=probe_env, capture_output=True, timeout=5).returncode == 0
+        ready = subprocess.run(probe_cmd, env=probe_env, capture_output=True, timeout=10).returncode == 0
         if ready: break
     except subprocess.TimeoutExpired:
       ready = False

--- a/openpilot/selfdrive/modeld/SConscript
+++ b/openpilot/selfdrive/modeld/SConscript
@@ -88,6 +88,7 @@ for usbgpu in [False, True] if USBGPU else [False]:
   onnx_sizes_sum = sum(os.path.getsize(f) for f in driving_onnx_deps)
   chunk_targets = get_chunk_targets(target_pkl_path, estimate_pickle_max_size(onnx_sizes_sum))
   def do_compile(target, source, env, command=cmd, pkl=target_pkl_path, chunks=chunk_targets):
+    # if chestnut enumerates, check power and PCIe link before building the big model
     probe_cmd = [sys.executable, '-c', 'from openpilot.selfdrive.modeld.compile_modeld import Device; Device[Device.DEFAULT]']
     probe_env = {**env['ENV'], 'DEV': 'USB+AMD'}
     ready = False

--- a/openpilot/selfdrive/modeld/SConscript
+++ b/openpilot/selfdrive/modeld/SConscript
@@ -88,7 +88,7 @@ for usbgpu in [False, True] if USBGPU else [False]:
   onnx_sizes_sum = sum(os.path.getsize(f) for f in driving_onnx_deps)
   chunk_targets = get_chunk_targets(target_pkl_path, estimate_pickle_max_size(onnx_sizes_sum))
   def do_compile(target, source, env, command=cmd, pkl=target_pkl_path, chunks=chunk_targets):
-    # if chestnut enumerates, check power and PCIe link before building the big model
+    # chestnut can enumerate before its PCIe link is up due to varying 12V power behavior across cars
     probe_cmd = [sys.executable, '-c', 'from openpilot.selfdrive.modeld.compile_modeld import Device; Device[Device.DEFAULT]']
     probe_env = {**env['ENV'], 'DEV': 'USB+AMD'}
     ready = False

--- a/openpilot/selfdrive/modeld/SConscript
+++ b/openpilot/selfdrive/modeld/SConscript
@@ -90,13 +90,14 @@ for usbgpu in [False, True] if USBGPU else [False]:
   def do_compile(target, source, env, command=cmd, pkl=target_pkl_path, chunks=chunk_targets):
     probe_cmd = [sys.executable, '-c', 'from openpilot.selfdrive.modeld.compile_modeld import Device; Device[Device.DEFAULT]']
     probe_env = {**env['ENV'], 'DEV': 'USB+AMD'}
-    try:
-      for attempt in range(3):
-        if attempt: time.sleep(1)
+    ready = False
+    for attempt in range(3):
+      if attempt: time.sleep(1)
+      try:
         ready = subprocess.run(probe_cmd, env=probe_env, capture_output=True, timeout=10).returncode == 0
-        if ready: break
-    except subprocess.TimeoutExpired:
-      ready = False
+      except subprocess.TimeoutExpired:
+        pass
+      if ready: break
     if not ready:
       print("Chestnut not ready, skipping big model build")
       return
@@ -105,9 +106,7 @@ for usbgpu in [False, True] if USBGPU else [False]:
     chunk_file(pkl, chunks)
   def do_chunk(target, source, env, pkl=target_pkl_path, chunks=chunk_targets):
     chunk_file(pkl, chunks)
-  actions = [cmd, Action(do_chunk, "  [CHUNK] $TARGET")]
-  if usbgpu:
-    actions = Action(do_compile, "  [USBGPU] $TARGET")
+  actions = Action(do_compile, "  [USBGPU] $TARGET") if usbgpu else [cmd, Action(do_chunk, "  [CHUNK] $TARGET")]
   node = lenv.Command(
     chunk_targets,
     tinygrad_files + compile_modeld_script + driving_onnx_deps + [Value(chunk_targets), chunker_file],

--- a/openpilot/selfdrive/modeld/SConscript
+++ b/openpilot/selfdrive/modeld/SConscript
@@ -87,25 +87,27 @@ for usbgpu in [False, True] if USBGPU else [False]:
         f'--output {target_pkl_path} --frame-skip {frame_skip}')
   onnx_sizes_sum = sum(os.path.getsize(f) for f in driving_onnx_deps)
   chunk_targets = get_chunk_targets(target_pkl_path, estimate_pickle_max_size(onnx_sizes_sum))
-  def do_compile(target, source, env, command=cmd):
+  def do_compile(target, source, env, command=cmd, pkl=target_pkl_path, chunks=chunk_targets):
+    probe_cmd = [sys.executable, '-c', 'from openpilot.selfdrive.modeld.compile_modeld import Device; Device[Device.DEFAULT]']
     probe_env = {**env['ENV'], 'DEV': 'USB+AMD'}
     try:
       for attempt in range(3):
         if attempt: time.sleep(1)
-        ready = subprocess.run([sys.executable, '-c', 'from tinygrad import Device; Device[Device.DEFAULT]'], env=probe_env,
-                               stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, timeout=5).returncode == 0
+        ready = subprocess.run(probe_cmd, env=probe_env, capture_output=True, timeout=5).returncode == 0
         if ready: break
     except subprocess.TimeoutExpired:
       ready = False
     if not ready:
       print("Chestnut not ready, skipping big model build")
-      return None
-    return env.Execute(command)
-  def do_chunk(target, source, env, pkl=target_pkl_path, chunks=chunk_targets, optional=usbgpu):
-    if optional and not os.path.isfile(pkl):
       return
+    if ret := env.Execute(command):
+      return ret
     chunk_file(pkl, chunks)
-  actions = [Action(do_compile, "  [USBGPU] $TARGET") if usbgpu else cmd, Action(do_chunk, "  [CHUNK] $TARGET")]
+  def do_chunk(target, source, env, pkl=target_pkl_path, chunks=chunk_targets):
+    chunk_file(pkl, chunks)
+  actions = [cmd, Action(do_chunk, "  [CHUNK] $TARGET")]
+  if usbgpu:
+    actions = Action(do_compile, "  [USBGPU] $TARGET")
   node = lenv.Command(
     chunk_targets,
     tinygrad_files + compile_modeld_script + driving_onnx_deps + [Value(chunk_targets), chunker_file],


### PR DESCRIPTION
Check if chestnut PCIe link is up before compiling the big model.
Replicates the effects of reverted commit in tinygrad: https://github.com/tinygrad/tinygrad/pull/17380

This makes it more robust to cars with differing 12V startup behaviors.