### PR TITLE
common: clean up failed atomic writes

### DIFF
--- a/openpilot/common/tests/test_file_helpers.py
+++ b/openpilot/common/tests/test_file_helpers.py
@@ -18,21 +18,3 @@ class TestFileHelpers(OpenpilotTestCase):
 
   def test_atomic_write(self):
     self.run_atomic_write_func(atomic_write)
-
-  def test_atomic_write_cleans_up_after_error(self):
-    path = f"/tmp/tmp{uuid4()}"
-    tmp_path = None
-    try:
-      with self.assertRaises(RuntimeError):
-        with atomic_write(path) as f:
-          tmp_path = f.name
-          f.write("partial")
-          raise RuntimeError("write failed")
-
-      assert tmp_path is not None
-      assert not os.path.exists(tmp_path)
-      assert not os.path.exists(path)
-    finally:
-      for cleanup_path in (tmp_path, path):
-        if cleanup_path is not None and os.path.exists(cleanup_path):
-          os.remove(cleanup_path)

--- a/openpilot/common/tests/test_file_helpers.py
+++ b/openpilot/common/tests/test_file_helpers.py
@@ -18,3 +18,21 @@ class TestFileHelpers(OpenpilotTestCase):
 
   def test_atomic_write(self):
     self.run_atomic_write_func(atomic_write)
+
+  def test_atomic_write_cleans_up_after_error(self):
+    path = f"/tmp/tmp{uuid4()}"
+    tmp_path = None
+    try:
+      with self.assertRaises(RuntimeError):
+        with atomic_write(path) as f:
+          tmp_path = f.name
+          f.write("partial")
+          raise RuntimeError("write failed")
+
+      assert tmp_path is not None
+      assert not os.path.exists(tmp_path)
+      assert not os.path.exists(path)
+    finally:
+      for cleanup_path in (tmp_path, path):
+        if cleanup_path is not None and os.path.exists(cleanup_path):
+          os.remove(cleanup_path)

--- a/openpilot/common/utils.py
+++ b/openpilot/common/utils.py
@@ -108,10 +108,14 @@ def atomic_write(path: str, mode: str = 'w', buffering: int = -1, encoding: str 
   if not overwrite and os.path.exists(path):
     raise FileExistsError(f"File '{path}' already exists. To overwrite it, set 'overwrite' to True.")
 
-  with tempfile.NamedTemporaryFile(mode=mode, buffering=buffering, encoding=encoding, newline=newline, dir=dir_name, delete=False) as tmp_file:
-    yield tmp_file
-    tmp_file_name = tmp_file.name
-  os.replace(tmp_file_name, path)
+  tmp_file = tempfile.NamedTemporaryFile(mode=mode, buffering=buffering, encoding=encoding, newline=newline, dir=dir_name, delete=False)
+  try:
+    with tmp_file:
+      yield tmp_file
+    os.replace(tmp_file.name, path)
+  finally:
+    with contextlib.suppress(FileNotFoundError):
+      os.unlink(tmp_file.name)
 
 
 def get_upload_stream(filepath: str, should_compress: bool) -> tuple[io.BufferedIOBase, int]:


### PR DESCRIPTION
`atomic_write` uses `delete=False`, so an exception from the writer left the partial temp file behind. Always remove it in `finally`; successful writes still use the same `os.replace` path.

Adds a regression test for the error path.

Tested on Python 3.12.13. The focused regression, Ruff, `py_compile`, and `git diff --check` pass.
