### PR TITLE
paramsd: don't learn in reverse gear

### DIFF
--- a/openpilot/selfdrive/locationd/paramsd.py
+++ b/openpilot/selfdrive/locationd/paramsd.py
@@ -121,7 +121,7 @@ class VehicleParamsLearner:
 
       in_linear_region = abs(steering_angle) < 45
       self.observed_speed = msg.vEgo
-      self.active = self.observed_speed > MIN_ACTIVE_SPEED and in_linear_region
+      self.active = self.observed_speed > MIN_ACTIVE_SPEED and in_linear_region and msg.gearShifter != car.CarState.GearShifter.reverse
 
       if self.active:
         self.kf.predict_and_observe(t, ObservationKind.STEER_ANGLE, np.array([[np.radians(steering_angle)]]))


### PR DESCRIPTION
Fixes #37458

Scanned 252,815 raw segments: 959 contained reverse and 195 met the paramsd learning conditions in reverse. 101 had four continuous rlogs available; these contained 27 relevant reverse instances.

| four-segment window | car | max relative deviation |
| --- | --- | ---: |
| aa50dcda8b10d0c4\|00000002--ccfb29c78e/16 | Hyundai Palisade | 0.3469% |
| 23ab5267243bdaab\|0000002c--9964d9f1c4/155 | Rivian R1 | 0.1955% |

Across the 27 four-segment instances, stiffness recovered in 12/27 and steering ratio in 26/27. Both recovered in 12/27, with a median recovery time of 0.044 s. Unrecovered stiffness cases had 222 s median observed follow-up.

![Hyundai Palisade replay](https://raw.githubusercontent.com/adeebshihadeh/openpilot/paramsd-reverse-report-assets/paramsd-reverse-report/aa50dcda8b10d0c4.png)

![Rivian R1 replay](https://raw.githubusercontent.com/adeebshihadeh/openpilot/paramsd-reverse-report-assets/paramsd-reverse-report/23ab5267243bdaab.png)