### PR TITLE
updated: add fallback mechanism for `agnos.json` path resolution

### DIFF
--- a/openpilot/system/hardware/tici/agnos.json
+++ b/openpilot/system/hardware/tici/agnos.json
@@ -1,0 +1,1 @@
+../comma/agnos.json

--- a/openpilot/system/updated/updated.py
+++ b/openpilot/system/updated/updated.py
@@ -219,19 +219,7 @@ def handle_agnos_update() -> None:
   cloudlog.info(f"Beginning background installation for AGNOS {updated_version}")
   set_offroad_alert("Offroad_NeosUpdate", True)
 
-  manifest_path = None
-  for candidate in [
-    "openpilot/system/hardware/comma/agnos.json",
-    "system/hardware/tici/agnos.json",
-  ]:
-    p = os.path.join(OVERLAY_MERGED, candidate)
-    if os.path.exists(p):
-      manifest_path = p
-      break
-
-  if manifest_path is None:
-    raise FileNotFoundError(f"agnos.json not found in {OVERLAY_MERGED}")
-
+  manifest_path = os.path.join(OVERLAY_MERGED, "openpilot/system/hardware/comma/agnos.json")
   target_slot_number = get_target_slot_number()
   flash_agnos_update(manifest_path, target_slot_number, cloudlog)
   set_offroad_alert("Offroad_NeosUpdate", False)

--- a/openpilot/system/updated/updated.py
+++ b/openpilot/system/updated/updated.py
@@ -219,7 +219,19 @@ def handle_agnos_update() -> None:
   cloudlog.info(f"Beginning background installation for AGNOS {updated_version}")
   set_offroad_alert("Offroad_NeosUpdate", True)
 
-  manifest_path = os.path.join(OVERLAY_MERGED, "openpilot/system/hardware/comma/agnos.json")
+  manifest_path = None
+  for candidate in [
+    "openpilot/system/hardware/comma/agnos.json",
+    "system/hardware/tici/agnos.json",
+  ]:
+    p = os.path.join(OVERLAY_MERGED, candidate)
+    if os.path.exists(p):
+      manifest_path = p
+      break
+
+  if manifest_path is None:
+    raise FileNotFoundError(f"agnos.json not found in {OVERLAY_MERGED}")
+
   target_slot_number = get_target_slot_number()
   flash_agnos_update(manifest_path, target_slot_number, cloudlog)
   set_offroad_alert("Offroad_NeosUpdate", False)

--- a/system/hardware/tici/agnos.json
+++ b/system/hardware/tici/agnos.json
@@ -1,0 +1,1 @@
+../../../openpilot/system/hardware/comma/agnos.json


### PR DESCRIPTION
- Fixes https://github.com/sunnypilot/sunnypilot/issues/1890
- Old updater hardcodes `system/hardware/tici/agnos.json`. That path no longer exists after the directory restructure from https://github.com/commaai/openpilot/pull/38219 and the `hardware/tici/` to `hardware/comma/` rename, so OTA updates from pre-restructure versions fail.
- The updater retries every 5 min on failure, re-fetching the full tree over cellular each time, which may rack up unintended data usage.