### PR TITLE
esim: workaround eUICC automatic profile fallback

### DIFF
--- a/openpilot/common/esim/esim.py
+++ b/openpilot/common/esim/esim.py
@@ -1,14 +1,52 @@
 #!/usr/bin/env python3
 
 import argparse
+import os
 import sys
 import time
 from openpilot.common.hardware import HARDWARE
 from openpilot.common.esim.base import LPABase, Profile
+from openpilot.common.esim import sim_pin
 
 
 def sorted_profiles(lpa: LPABase) -> list[Profile]:
   return sorted(lpa.list_profiles(), key=lambda p: p.iccid)
+
+
+PINNED_ICCID_PATH = '/data/params/d/GsmPinnedIccid'
+
+
+def write_pinned_param(iccid: str) -> None:
+  try:
+    os.makedirs(os.path.dirname(PINNED_ICCID_PATH), exist_ok=True)
+    if iccid:
+      with open(PINNED_ICCID_PATH, 'w') as f:
+        f.write(iccid)
+    else:
+      os.remove(PINNED_ICCID_PATH)
+  except (FileNotFoundError, OSError) as e:
+    print(f'warning: failed to write pinned iccid param: {e}', file=sys.stderr)
+
+
+def set_pin(lpa: LPABase, iccid: str) -> None:
+  """Pin (or unpin, if iccid="") the active profile so modemd reverts autonomous switchbacks.
+
+  The pin is stored in the SIM's SMS storage on the eUICC itself, so it survives a
+  factory reset; the param is just a cache of it. Note the SMS copy lands in the
+  *currently active* profile's storage - if that's not the comma/webbing profile,
+  modemd re-seeds it the next time a switchback activates the webbing profile.
+  """
+  profiles = lpa.list_profiles()
+  anchor = next((p for p in profiles if p.is_comma), None)
+
+  # pinning the comma profile itself is pointless; autonomous switching already favors it
+  if anchor is not None and anchor.iccid == iccid:
+    iccid = ""
+
+  write_pinned_param(iccid)
+  if not sim_pin.write_pin(iccid):
+    print('warning: failed to store pin in SIM storage; pin will not survive a factory reset', file=sys.stderr)
+  print(f'pinned profile: {iccid or "<none>"}')
 
 
 def resolve_iccid(lpa: LPABase, ref: str) -> str:
@@ -46,8 +84,10 @@ if __name__ == '__main__':
 
   sub.add_parser('list', help='list profiles')
 
-  p_switch = sub.add_parser('switch', help='switch to profile')
+  p_switch = sub.add_parser('switch', help='switch to profile (and pin it against autonomous switchbacks)')
   p_switch.add_argument('profile', help='iccid or 1-based index from `list`')
+
+  sub.add_parser('unpin', help='clear the pinned profile (stop auto-reverting switchbacks)')
 
   p_delete = sub.add_parser('delete', help='delete profile (warning: this cannot be undone)')
   p_delete.add_argument('profile', help='iccid or 1-based index from `list`')
@@ -68,6 +108,9 @@ if __name__ == '__main__':
   if args.cmd == 'switch':
     iccid = resolve_iccid(lpa, args.profile)
     execute_and_process_notifications(lpa, lambda: lpa.switch_profile(iccid))
+    set_pin(lpa, iccid)
+  elif args.cmd == 'unpin':
+    set_pin(lpa, '')
   elif args.cmd == 'delete':
     iccid = resolve_iccid(lpa, args.profile)
     confirm = input(f'are you sure you want to delete profile {iccid}? (y/N) ')

--- a/openpilot/common/esim/sim_pin.py
+++ b/openpilot/common/esim/sim_pin.py
@@ -1,0 +1,202 @@
+# Persistent eSIM profile pin stored in the active profile's SIM SMS storage (EF-SMS).
+#
+# Modem eSIMs (e.g. Webbing) autonomously switch the enabled profile back to their own
+# and cannot be configured out of it (see TS-PA-UP probing notes). modemd reverts such
+# switchbacks when it knows which profile is pinned. The pin param in /data is lost on
+# factory reset, but the SIM SMS storage is not - so we stash the pin in a draft SMS on
+# the SIM itself (payload: "comma-pin:<iccid>").
+#
+# Note: the pin stored in a profile's SMS storage is only readable while that profile is
+# enabled. That's exactly when we need it: a switchback makes the webbing profile active,
+# at which point modemd can read the pin back from the SIM (and modemd/esim.py re-seed
+# the marker whenever the webbing profile is active and a pin is known).
+
+import fcntl
+import os
+import time
+
+from openpilot.common.esim.lpa import AtClient, DEFAULT_DEVICE, DEFAULT_BAUD, DEFAULT_TIMEOUT, LOCK_FILE
+
+PIN_SMS_PREFIX = "comma-pin:"
+_DEST_ADDRESS = "123"  # dummy recipient for the stored draft; never sent
+
+
+# --- 7-bit GSM 03.38 packing helpers (ascii-safe subset) ---
+
+def _gsm7_pack(text: str) -> bytes:
+  out = bytearray()
+  buf = nbits = 0
+  for ch in text:
+    buf |= ord(ch) << nbits
+    nbits += 7
+    while nbits >= 8:
+      out.append(buf & 0xFF)
+      buf >>= 8
+      nbits -= 8
+  if nbits:
+    out.append(buf & 0xFF)
+  return bytes(out)
+
+
+def _gsm7_unpack(data: bytes, num_septets: int) -> str:
+  out = []
+  buf = nbits = 0
+  for b in data:
+    buf |= b << nbits
+    nbits += 8
+    while nbits >= 7:
+      out.append(chr(buf & 0x7F))
+      buf >>= 7
+      nbits -= 7
+  return "".join(out[:num_septets])
+
+
+def _tbcd(digits: str) -> bytes:
+  return bytes(int(d) | ((int(digits[i + 1]) if i + 1 < len(digits) else 0xF) << 4) for i, d in enumerate(digits) if i % 2 == 0)
+
+
+# --- SMS-PDU encode/decode (7-bit text, no VP) ---
+
+def _encode_pdu(text: str) -> tuple[bytes, int]:
+  """Returns (full pdu, tpdu length). SMS-SUBMIT, 7-bit GSM, VPF none, DCS 0."""
+  ud = _gsm7_pack(text)
+  da = _tbcd(_DEST_ADDRESS)
+  tpdu = bytes([0x11, 0x00, len(_DEST_ADDRESS), 0x81]) + da + bytes([0x00, 0x00, len(text)]) + ud
+  return b"\x00" + tpdu, len(tpdu)  # SCA length 0 = modem default SMSC
+
+
+def _decode_pdu(pdu: bytes) -> str:
+  sca_len = pdu[0] + 1
+  tpdu = pdu[sca_len:]
+  mti = tpdu[0] & 0x03
+  i = 1
+  if mti == 0x01:  # SUBMIT: skip TP-MR
+    i += 1
+  addr_digits = tpdu[i]
+  i += 2 + (addr_digits + 1) // 2  # len, toa, tbcd number
+  i += 2  # TP-PID, TP-DCS
+  if mti == 0x00:  # DELIVER: skip TP-SCTS
+    i += 7
+  udl = tpdu[i]
+  ud = tpdu[i + 1:i + 1 + (udl * 7 + 7) // 8]
+  return _gsm7_unpack(ud, udl)
+
+
+# --- SIM SMS store access over the modem AT port ---
+
+class _Store:
+  def __init__(self) -> None:
+    self._owns_client = False
+    self._client: AtClient | None = None
+
+  def __enter__(self) -> "_Store":
+    self._fd = os.open(LOCK_FILE, os.O_CREAT | os.O_RDWR)
+    fcntl.flock(self._fd, fcntl.LOCK_EX)
+    self._client = AtClient(DEFAULT_DEVICE, DEFAULT_BAUD, DEFAULT_TIMEOUT)
+    return self
+
+  def __exit__(self, *args) -> None:
+    try:
+      if self._client is not None:
+        self._client.close()
+    finally:
+      fcntl.flock(self._fd, fcntl.LOCK_UN)
+      os.close(self._fd)
+
+  def _query(self, cmd: str) -> list[str]:
+    return self._client.query(cmd)
+
+  def _select_sim_storage(self) -> None:
+    try:
+      self._query('AT+CPMS="SM","SM","SM"')
+    except (RuntimeError, TimeoutError):
+      self._query('AT+CPMS="SM"')
+
+  def _gateway_write(self, cmd: str, hc_data: str) -> list[str]:
+    """Send a prompt-mode command (e.g. +CMGW) and its ctrl-Z-terminated payload."""
+    s = self._client._serial
+    self._client._ensure_serial()
+    s.reset_input_buffer()
+    self._client._send(cmd)
+    deadline = time.monotonic() + 10
+    buf = b""
+    while time.monotonic() < deadline:
+      line = s.readline()
+      if line:
+        buf += line
+      if b">" in buf:
+        break
+      if b"ERROR" in buf:
+        raise RuntimeError(f"prompt command failed: {buf!r}")
+    else:
+      raise TimeoutError(f"no prompt for {cmd}")
+    s.write(hc_data.encode("ascii") + b"\x1a")
+    s.flush()
+    return self._client._expect()
+
+  def read_messages(self) -> list[tuple[int, str]]:
+    """Returns [(slot_index, decoded_text), ...] for all SMS currently in SIM storage."""
+    self._query("AT+CMGF=0")
+    self._select_sim_storage()
+    lines = self._query("AT+CMGL=4")
+    out: list[tuple[int, str]] = []
+    headers = [l for l in lines if l.startswith("+CMGL:")]
+    payload_candidates = [l for l in lines if not l.startswith("+CMGL:")]
+    # map each header to the following payload line in order of appearance
+    payloads = iter(payload_candidates)
+    for h in headers:
+      try:
+        idx = int(h.split(":", 1)[1].split(",", 1)[0].strip())
+        pdu_line = next(p for p in payloads if all(c in "0123456789ABCDEF" for c in p.strip()) and len(p.strip()) > 10)
+      except (ValueError, StopIteration):
+        continue
+      try:
+        text = _decode_pdu(bytes.fromhex(pdu_line.strip()))
+      except Exception:
+        continue
+      out.append((idx, text))
+    return out
+
+  def delete_slot(self, idx: int) -> None:
+    self._query(f"AT+CMGD={idx}")
+
+  def write_message(self, text: str) -> int:
+    self._query("AT+CMGF=0")
+    self._select_sim_storage()
+    pdu, tlen = _encode_pdu(text)
+    lines = self._gateway_write(f"AT+CMGW={tlen},2", pdu.hex().upper())
+    for line in lines:
+      if line.startswith("+CMGW:"):
+        return int(line.split(":", 1)[1].strip())
+    raise RuntimeError(f"CMGW failed: {lines}")
+
+
+def _markers(store: _Store) -> list[tuple[int, str]]:
+  return [(i, t[len(PIN_SMS_PREFIX):].strip()) for i, t in store.read_messages() if t.startswith(PIN_SMS_PREFIX)]
+
+
+def read_pin() -> str:
+  """Read the pinned iccid from SIM SMS storage, or '' if absent/unavailable."""
+  try:
+    with _Store() as store:
+      ms = _markers(store)
+      return ms[-1][1] if ms else ""
+  except Exception:
+    return ""
+
+
+def write_pin(iccid: str) -> bool:
+  """Persist the pin marker into the *currently active* profile's SIM SMS storage.
+
+  Deletes any stale markers first. iccid='' only deletes markers. Returns False if the
+  write wasn't possible (e.g. storage full) - callers have the /data param as backup.
+  """
+  try:
+    with _Store() as store:
+      for idx, _ in _markers(store):
+        store.delete_slot(idx)
+      if iccid:
+        store.write_message(f"{PIN_SMS_PREFIX}{iccid}")
+    return True
+  except Exception:
+    return False

--- a/openpilot/common/hardware/comma/modem.py
+++ b/openpilot/common/hardware/comma/modem.py
@@ -45,6 +45,13 @@ NETWORK_TYPE = {0: "gsm", 1: "gsm", 3: "gsm", 8: "gsm",
 DIAL_CID = 1
 WEBBING_ICCID_PREFIX = "8985235"
 
+# Some eSIMs (e.g. Webbing) autonomously switch back to their own profile when
+# in "automatic" mode, and this cannot be disabled on-card. If GsmPinnedIccid is
+# set, modemd re-enables that profile whenever the eUICC slips away from it.
+# The pinned iccid also lives in the SIM's SMS storage (see esim/sim_pin.py), so it
+# survives a factory reset; GsmPinnedIccid is just a cache of it.
+REVERT_BACKOFF_S = (0, 60, 300, 900, 3600)
+
 PPPD_CMD = [
   "sudo", "pppd", PPP_PORT, "460800", "noauth", "nodetach", "noipdefault", "usepeerdns",
   "nodefaultroute", "connect",
@@ -211,6 +218,9 @@ class Modem:
   def __init__(self):
     self._ppp = PPPSession()
     self._sim_change = False
+    self._revert_attempts = 0
+    self._last_revert = 0.0
+    self._pin_scanned = False  # whether we checked SIM storage for a pin this boot
     self._apn = ""  # blank = network-provided via PCO
     self._roaming_allowed = True
     self.running = True
@@ -333,6 +343,14 @@ class Modem:
 
     self._configure_modem(identity["modem_version"])
 
+    # eUICC may have autonomously reverted to the webbing profile while we were off;
+    # recover the pin (stored on the eUICC itself) and switch back if needed
+    if identity["iccid"].startswith(WEBBING_ICCID_PREFIX):
+      pinned = self._get_pinned_iccid()
+      if pinned and pinned != identity["iccid"] and time.monotonic() - self._last_revert >= REVERT_BACKOFF_S[self._revert_attempts]:
+        self._restore_pinned_profile(pinned)
+        return State.INITIALIZING  # re-read identity after the profile switch refresh
+
     self.S.update(identity)
     self._apn = self._read_param("GsmApn")
     self._roaming_allowed = self._is_roaming_allowed()
@@ -433,9 +451,58 @@ class Modem:
     if state in (State.INITIALIZING, State.DISCONNECTING) or not self.S["iccid"]:
       return
     iccid = (self._atv("AT+QCCID", "+QCCID:") or "").rstrip("F")
-    if iccid and iccid != self.S["iccid"]:
-      logging.warning(f"iccid changed: {self.S['iccid']} -> {iccid}")
-      self._sim_change = True
+    if not iccid or iccid == self.S["iccid"]:
+      return
+    logging.warning(f"iccid changed: {self.S['iccid']} -> {iccid}")
+    self._sim_change = True
+
+    pinned = self._get_pinned_iccid()
+    if iccid == pinned:
+      self._revert_attempts = 0  # pinned profile active again
+    elif pinned and time.monotonic() - self._last_revert >= REVERT_BACKOFF_S[self._revert_attempts]:
+      self._restore_pinned_profile(pinned)
+
+  def _get_pinned_iccid(self) -> str:
+    """Pinned profile iccid: param first, then the reset-proof copy in the SIM's SMS storage."""
+    pinned = self._read_param("GsmPinnedIccid")
+    if pinned or self._pin_scanned:
+      return pinned
+    self._pin_scanned = True  # scan at most once per boot
+    try:
+      from openpilot.common.esim import sim_pin
+      pinned = sim_pin.read_pin()
+      if pinned:
+        logging.info(f"recovered pinned profile from SIM storage: {pinned}")
+        self._write_param("GsmPinnedIccid", pinned)
+    except Exception as e:
+      logging.info(f"SIM pin scan failed: {e}")
+    return pinned
+
+  @staticmethod
+  def _write_param(key, value):
+    try:
+      with open(f"/data/params/d/{key}", "w") as f:
+        f.write(value)
+    except OSError as e:
+      logging.warning(f"failed to write param {key}: {e}")
+
+  def _restore_pinned_profile(self, iccid: str):
+    self._last_revert = time.monotonic()
+    self._revert_attempts = min(self._revert_attempts + 1, len(REVERT_BACKOFF_S) - 1)
+    logging.warning(f"re-enabling pinned profile {iccid} (attempt {self._revert_attempts})")
+    try:
+      # active profile is presumably the switching partner (e.g. webbing) right now;
+      # (re)seed the pin marker into its SIM SMS storage so it survives factory resets
+      from openpilot.common.esim import sim_pin
+      sim_pin.write_pin(iccid)
+    except Exception:
+      pass
+    try:
+      from openpilot.common.esim.lpa import TiciLPA
+      TiciLPA().switch_profile(iccid)
+      logging.info("pinned profile restored")
+    except Exception as e:
+      logging.warning(f"pinned profile restore failed: {e}")
 
   def _do_connected(self):
     if self._ppp.has_exited():

--- a/openpilot/common/params_keys.h
+++ b/openpilot/common/params_keys.h
@@ -52,6 +52,7 @@ inline static std::unordered_map<std::string, ParamKeyAttributes> keys = {
     {"GitRemote", {PERSISTENT, STRING}},
     {"GsmApn", {PERSISTENT, STRING}},
     {"GsmMetered", {PERSISTENT, BOOL, "1"}},
+    {"GsmPinnedIccid", {PERSISTENT, STRING}},
     {"GsmRoaming", {PERSISTENT, BOOL}},
     {"HardwareSerial", {PERSISTENT, STRING}},
     {"HasAcceptedTerms", {PERSISTENT, STRING, "0"}},


### PR DESCRIPTION
This avoids needing any config on the Webbing backend.