### PR TITLE
sync after a build

### DIFF
--- a/openpilot/system/manager/build.py
+++ b/openpilot/system/manager/build.py
@@ -48,8 +48,9 @@ def build() -> None:
           compile_output.append(line)
 
     if scons.returncode == 0:
-      os.sync()
       break
+
+  os.sync()
 
   if scons.returncode != 0:
     # Build failed log errors

--- a/openpilot/system/manager/build.py
+++ b/openpilot/system/manager/build.py
@@ -48,6 +48,7 @@ def build() -> None:
           compile_output.append(line)
 
     if scons.returncode == 0:
+      os.sync()
       break
 
   if scons.returncode != 0:


### PR DESCRIPTION
scons doesn't fsync build artifacts.
If power is cut shortly after a build, an artifact can be corrupted while sconsign still marks it valid.
Reproduced by cutting power after a build.