### PR TITLE
ui: fix inverted DM head tracking on RHD

### DIFF
--- a/openpilot/selfdrive/ui/mici/onroad/driver_state.py
+++ b/openpilot/selfdrive/ui/mici/onroad/driver_state.py
@@ -170,7 +170,8 @@ class DriverStateRenderer(Widget):
     self._face_detected = dm_state.visionPolicyState.faceDetected
     self._awareness_unfull = self.effective_active and dm_state.visionPolicyState.awarenessPercent < self.AWARENESS_UNFULL_PERCENT
     self._face_pitch = dm_state.visionPolicyState.pose.pitch + math.radians(6) # calib or DM pose is not accurate, add a fake upward pitch to bias forward
-    self._face_yaw = -dm_state.visionPolicyState.pose.yaw # undo sign flip in face_orientation_from_model to match UI convention
+    # undo sign flip in face_orientation_from_model to match UI convention, and the RHD mirroring the policy applies
+    self._face_yaw = -dm_state.visionPolicyState.pose.yaw * (-1 if self._is_rhd else 1)
 
     driverstate = sm["driverStateV2"]
     driver_data = driverstate.rightDriverData if self._is_rhd else driverstate.leftDriverData

--- a/openpilot/selfdrive/ui/mici/onroad/driver_state.py
+++ b/openpilot/selfdrive/ui/mici/onroad/driver_state.py
@@ -170,7 +170,7 @@ class DriverStateRenderer(Widget):
     self._face_detected = dm_state.visionPolicyState.faceDetected
     self._awareness_unfull = self.effective_active and dm_state.visionPolicyState.awarenessPercent < self.AWARENESS_UNFULL_PERCENT
     self._face_pitch = dm_state.visionPolicyState.pose.pitch + math.radians(6)  # calib or DM pose is not accurate, add a fake upward pitch to bias forward
-    self._face_yaw = -dm_state.visionPolicyState.pose.yaw * (-1 if self._is_rhd else 1)  # undo sign flip in face_orientation_from_model to match UI convention
+    self._face_yaw = dm_state.visionPolicyState.pose.yaw * (1 if self._is_rhd else -1)  # undo sign flip in face_orientation_from_model to match UI convention
 
     driverstate = sm["driverStateV2"]
     driver_data = driverstate.rightDriverData if self._is_rhd else driverstate.leftDriverData

--- a/openpilot/selfdrive/ui/mici/onroad/driver_state.py
+++ b/openpilot/selfdrive/ui/mici/onroad/driver_state.py
@@ -169,9 +169,8 @@ class DriverStateRenderer(Widget):
     self._is_rhd = dm_state.isRHD
     self._face_detected = dm_state.visionPolicyState.faceDetected
     self._awareness_unfull = self.effective_active and dm_state.visionPolicyState.awarenessPercent < self.AWARENESS_UNFULL_PERCENT
-    self._face_pitch = dm_state.visionPolicyState.pose.pitch + math.radians(6) # calib or DM pose is not accurate, add a fake upward pitch to bias forward
-    # undo sign flip in face_orientation_from_model to match UI convention, and the RHD mirroring the policy applies
-    self._face_yaw = -dm_state.visionPolicyState.pose.yaw * (-1 if self._is_rhd else 1)
+    self._face_pitch = dm_state.visionPolicyState.pose.pitch + math.radians(6)  # calib or DM pose is not accurate, add a fake upward pitch to bias forward
+    self._face_yaw = -dm_state.visionPolicyState.pose.yaw * (-1 if self._is_rhd else 1)  # undo sign flip in face_orientation_from_model to match UI convention
 
     driverstate = sm["driverStateV2"]
     driver_data = driverstate.rightDriverData if self._is_rhd else driverstate.leftDriverData


### PR DESCRIPTION
b29d0a17af switched the mici driver state renderer from computing pose from driverStateV2 itself to consuming driverMonitoringState.visionPolicyState.pose. That published yaw is mirrored for RHD (policy.py:269) so the asymmetric yaw offsets/thresholds can be tuned in a single frame, so the UI's unconditional sign flip left RHD head tracking backwards. LHD was unaffected, which is why the refactor looked like a no-op.

Undo the mirror on the UI side.