### PR TITLE
log chestnut ASM at 10Hz

### DIFF
--- a/openpilot/cereal/services.py
+++ b/openpilot/cereal/services.py
@@ -25,7 +25,7 @@ _services: dict[str, tuple] = {
   "accelerometer": (True, 104., 104),
   "temperatureSensor": (True, 2., 200),
   "deviceState": (True, 2., 1),
-  "chestnutState": (True, 0.1, 1),
+  "chestnutState": (True, 10., 10),
   "touch": (True, 20., 1),
   "can": (True, 100., 2053, QueueSize.BIG),  # decimation gives ~3 msgs in a full segment
   "controlsState": (True, 100., 10, QueueSize.MEDIUM),

--- a/openpilot/selfdrive/modeld/modeld.py
+++ b/openpilot/selfdrive/modeld/modeld.py
@@ -73,6 +73,7 @@ class ChestnutState:
   # only modeld can access chestnut
   def __init__(self, pm: PubMaster):
     self.pm = pm
+    self.params = Params()
     self.valid = True
 
   @cached_property
@@ -84,7 +85,7 @@ class ChestnutState:
     msg = messaging.new_message('chestnutState')
     state = msg.chestnutState
     valid = False
-    if "AMD" in Device._opened_devices:
+    if self.params.get_bool("UsbGpuActive") and "AMD" in Device._opened_devices:
       try:
         smu = Device["AMD"].iface.dev_impl.smu
         smu._send_msg(smu.smu_mod.PPSMC_MSG_TransferTableSmu2Dram, smu.smu_mod.TABLE_SMU_METRICS, timeout=100)
@@ -100,6 +101,7 @@ class ChestnutState:
       except Exception:
         if self.valid:
           cloudlog.exception("chestnut state read failed")
+    if "AMD" in Device._opened_devices:
       try:
         # ASM runs on USB-C power, these still read without a gpu
         asm = Device["AMD"].iface.pci_dev.usb

--- a/openpilot/selfdrive/modeld/modeld.py
+++ b/openpilot/selfdrive/modeld/modeld.py
@@ -75,6 +75,8 @@ class ChestnutState:
     self.pm = pm
     self.params = Params()
     self.valid = True
+    self.sends = 0
+    self.metrics = {}
 
   @cached_property
   def power_limit(self) -> int:
@@ -84,23 +86,28 @@ class ChestnutState:
   def send(self) -> None:
     msg = messaging.new_message('chestnutState')
     state = msg.chestnutState
-    valid = False
-    if self.params.get_bool("UsbGpuActive") and "AMD" in Device._opened_devices:
+    big = self.params.get_bool("UsbGpuActive")
+    self.sends += 1
+    if big and "AMD" in Device._opened_devices and self.sends % 10 == 1:
       try:
         smu = Device["AMD"].iface.dev_impl.smu
         smu._send_msg(smu.smu_mod.PPSMC_MSG_TransferTableSmu2Dram, smu.smu_mod.TABLE_SMU_METRICS, timeout=100)
         metrics = smu.read_table(smu.smu_mod.SmuMetricsExternal_t, smu.smu_mod.TABLE_SMU_METRICS).SmuMetrics
-        state.tempC = metrics.AvgTemperature[smu.smu_mod.TEMP_HOTSPOT]
-        state.memoryTempC = metrics.AvgTemperature[smu.smu_mod.TEMP_MEM]
-        state.powerDrawW = metrics.AverageSocketPower
-        state.powerLimitW = self.power_limit
-        state.gpuUsagePercent = metrics.AverageGfxActivity
-        state.gpuClockMhz = metrics.AverageGfxclkFrequencyPostDs
-        state.fanSpeedRpm = metrics.AvgFanRpm
-        valid = True
+        self.metrics = {'tempC': metrics.AvgTemperature[smu.smu_mod.TEMP_HOTSPOT],
+                        'memoryTempC': metrics.AvgTemperature[smu.smu_mod.TEMP_MEM],
+                        'powerDrawW': metrics.AverageSocketPower,
+                        'powerLimitW': self.power_limit,
+                        'gpuUsagePercent': metrics.AverageGfxActivity,
+                        'gpuClockMhz': metrics.AverageGfxclkFrequencyPostDs,
+                        'fanSpeedRpm': metrics.AvgFanRpm}
+        self.valid = True
       except Exception:
         if self.valid:
           cloudlog.exception("chestnut state read failed")
+        self.valid = False
+    if big:
+      for k, v in self.metrics.items():
+        setattr(state, k, v)
     if "AMD" in Device._opened_devices:
       try:
         # ASM runs on USB-C power, these still read without a gpu
@@ -110,8 +117,7 @@ class ChestnutState:
       except Exception:
         pass
 
-    self.valid = valid
-    msg.valid = valid
+    msg.valid = big and self.valid
     self.pm.send('chestnutState', msg)
 
 

--- a/openpilot/selfdrive/modeld/modeld.py
+++ b/openpilot/selfdrive/modeld/modeld.py
@@ -71,9 +71,9 @@ def get_action_from_model(model_output: dict[str, np.ndarray], prev_action: log.
 
 class ChestnutState:
   # only modeld can access chestnut
-  def __init__(self, pm: PubMaster):
+  def __init__(self, pm: PubMaster, big: bool):
     self.pm = pm
-    self.params = Params()
+    self.big = big
     self.valid = True
     self.sends = 0
     self.metrics = {}
@@ -86,9 +86,8 @@ class ChestnutState:
   def send(self) -> None:
     msg = messaging.new_message('chestnutState')
     state = msg.chestnutState
-    big = self.params.get_bool("UsbGpuActive")
     self.sends += 1
-    if big and "AMD" in Device._opened_devices and self.sends % 10 == 1:
+    if self.big and "AMD" in Device._opened_devices and self.sends % 100 == 1:
       try:
         smu = Device["AMD"].iface.dev_impl.smu
         smu._send_msg(smu.smu_mod.PPSMC_MSG_TransferTableSmu2Dram, smu.smu_mod.TABLE_SMU_METRICS, timeout=100)
@@ -105,19 +104,23 @@ class ChestnutState:
         if self.valid:
           cloudlog.exception("chestnut state read failed")
         self.valid = False
-    if big:
+        self.metrics.clear()
+    if self.big:
       for k, v in self.metrics.items():
         setattr(state, k, v)
+
+    asm_valid = False
     if "AMD" in Device._opened_devices:
       try:
         # ASM runs on USB-C power, these still read without a gpu
         asm = Device["AMD"].iface.pci_dev.usb
         state.pcieLtssm = asm.read(0xB450, 1)[0]
         state.supplyVoltage, state.supplyCurrent = struct.unpack('<Hh', bytes(asm.usb.control_read(0xC0, 5))[:4])
+        asm_valid = True
       except Exception:
         pass
 
-    msg.valid = big and self.valid
+    msg.valid = asm_valid and (not self.big or self.valid)
     self.pm.send('chestnutState', msg)
 
 
@@ -274,7 +277,7 @@ def main(demo=False):
 
   publish_state = PublishState()
   params = Params()
-  chestnut_state = ChestnutState(pm) if USBGPU else None
+  chestnut_state = ChestnutState(pm, model.usbgpu) if USBGPU else None
 
   # setup filter to track dropped frames
   frame_dropped_filter = FirstOrderFilter(0., 10., 1. / ModelConstants.MODEL_RUN_FREQ)
@@ -390,6 +393,8 @@ def main(demo=False):
       cloudlog.exception("big model failed, fall back to small")
       params.put_bool("UsbGpuActive", False)
       model = small_model
+      if chestnut_state is not None:
+        chestnut_state.big = False
       run_count = 0
       model_output = None
     mt2 = time.perf_counter()


### PR DESCRIPTION
GPU state is expensive in modeld so keep at 0.1Hz
ASM reads are fast so bumped to 10Hz.

Keep logging chestnutState if big model fails.