### PR TITLE
AGNOS 19.6

### DIFF
--- a/launch_env.sh
+++ b/launch_env.sh
@@ -16,7 +16,7 @@ export VECLIB_MAXIMUM_THREADS=1
 export QCOM_PRIORITY=12
 
 if [ -z "$AGNOS_VERSION" ]; then
-  export AGNOS_VERSION="19.5"
+  export AGNOS_VERSION="19.6"
 fi
 
 export STAGING_ROOT="/data/safe_staging"

--- a/openpilot/common/hardware/comma/agnos.json
+++ b/openpilot/common/hardware/comma/agnos.json
@@ -23,14 +23,14 @@
   },
   {
     "name": "abl",
-    "url": "https://commadist.azureedge.net/agnosupdate/abl-b6fba807b9bcd66a31f2afb0eba5163ec239693ad32e2e4200f6c356adfe098c.img.xz",
-    "hash": "b6fba807b9bcd66a31f2afb0eba5163ec239693ad32e2e4200f6c356adfe098c",
-    "hash_raw": "b6fba807b9bcd66a31f2afb0eba5163ec239693ad32e2e4200f6c356adfe098c",
+    "url": "https://commadist.azureedge.net/agnosupdate/abl-29fd7ed1c012e599420764840f9f11286d34dbff4adaf102a447f06d8c5e0b35.img.xz",
+    "hash": "29fd7ed1c012e599420764840f9f11286d34dbff4adaf102a447f06d8c5e0b35",
+    "hash_raw": "29fd7ed1c012e599420764840f9f11286d34dbff4adaf102a447f06d8c5e0b35",
     "size": 274432,
     "sparse": false,
     "full_check": true,
     "has_ab": true,
-    "ondevice_hash": "b6fba807b9bcd66a31f2afb0eba5163ec239693ad32e2e4200f6c356adfe098c"
+    "ondevice_hash": "29fd7ed1c012e599420764840f9f11286d34dbff4adaf102a447f06d8c5e0b35"
   },
   {
     "name": "aop",
@@ -56,28 +56,28 @@
   },
   {
     "name": "boot",
-    "url": "https://commadist.azureedge.net/agnosupdate/boot-f716b81d557c274be707abc200276ba9e8320ad0386586f36f9065dd563fee94.img.xz",
-    "hash": "f716b81d557c274be707abc200276ba9e8320ad0386586f36f9065dd563fee94",
-    "hash_raw": "f716b81d557c274be707abc200276ba9e8320ad0386586f36f9065dd563fee94",
+    "url": "https://commadist.azureedge.net/agnosupdate/boot-b30f5eef65ec3878f3aa3dcaf2cc95c09e2c1e661cd3a38e94da37dee76f68bd.img.xz",
+    "hash": "b30f5eef65ec3878f3aa3dcaf2cc95c09e2c1e661cd3a38e94da37dee76f68bd",
+    "hash_raw": "b30f5eef65ec3878f3aa3dcaf2cc95c09e2c1e661cd3a38e94da37dee76f68bd",
     "size": 46897152,
     "sparse": false,
     "full_check": true,
     "has_ab": true,
-    "ondevice_hash": "269bc216189c4532a3e796ef2f4d47d0a03e774c883203be93feb8a8ed3c3adb"
+    "ondevice_hash": "6650e4c46df99ae6dfd6ee895a34b8a2a3cc490a8ce18e16cc3c451c3f822b6e"
   },
   {
     "name": "system",
-    "url": "https://commadist.azureedge.net/agnosupdate/system-7b3da36853ee71f7f43ff9eb0f59ca8c4e80a2ba96a9a4911731641a5d008ae2.img.xz",
-    "hash": "414a9145d6ba13bc04760b31545507109e9a2509958dd44782dd1912b1cb96e9",
-    "hash_raw": "7b3da36853ee71f7f43ff9eb0f59ca8c4e80a2ba96a9a4911731641a5d008ae2",
+    "url": "https://commadist.azureedge.net/agnosupdate/system-5b6ce7965904a157fd3a134ccfcb854f9ca5c1cc2a26b7cb80a4fa4e1cc4aaa3.img.xz",
+    "hash": "b134fd04e9da27fa1d359ea0f2742c216fa21a08b5c47e9be22ab3b0563d9b9b",
+    "hash_raw": "5b6ce7965904a157fd3a134ccfcb854f9ca5c1cc2a26b7cb80a4fa4e1cc4aaa3",
     "size": 4718592000,
     "sparse": true,
     "full_check": false,
     "has_ab": true,
-    "ondevice_hash": "d4fadd9dfb4e20875650e60e37b9f8ccf2dc6c0fdc4f9a15912bee5ab8440a13",
+    "ondevice_hash": "91242772af771ae96fe2eebc105f2b80a7e1dbaaf6003c2574b62d51b806f468",
     "alt": {
-      "hash": "7b3da36853ee71f7f43ff9eb0f59ca8c4e80a2ba96a9a4911731641a5d008ae2",
-      "url": "https://commadist.azureedge.net/agnosupdate/system-7b3da36853ee71f7f43ff9eb0f59ca8c4e80a2ba96a9a4911731641a5d008ae2.img",
+      "hash": "5b6ce7965904a157fd3a134ccfcb854f9ca5c1cc2a26b7cb80a4fa4e1cc4aaa3",
+      "url": "https://commadist.azureedge.net/agnosupdate/system-5b6ce7965904a157fd3a134ccfcb854f9ca5c1cc2a26b7cb80a4fa4e1cc4aaa3.img",
       "size": 4718592000
     }
   }


### PR DESCRIPTION
- USB VGA tuning
- Revert power blip
- Add power counters
- fix tap to factory reset


## Release Checklist

- [x] [`test_onroad`](https://github.com/commaai/openpilot/blob/master/selfdrive/test/test_onroad.py) passes
- [x] Wi-Fi: lists networks and connects
- [x] Modem: connects to cell network
- [ ] Image sizes haven't increased
- [ ] Sounds work: `pkill -f manager ; /data/openpilot/scripts/disable-powersave.py && aplay /data/openpilot/selfdrive/assets/sounds/engage.wav`
- [x] Clean openpilot build: `scons -c && scons -j8`
- [x] Factory reset
  - [x] from openpilot menu
  - [x] tapping on boot
  - [ ] corrupt userdata: `dd if=/dev/zero of=/dev/disk/by-partlabel/userdata count=10 bs=1M`
- [x] Clean setup: factory reset -> install openpilot -> openpilot works
- [x] Color calibration works from `/persist/comma/`
  - [ ] tizi: `journalctl -u magic | grep 'Successfully setup color correction'`
  - [x] mici: `journalctl -u screen_calibration | grep -i 'Successfully setup screen calibration'`
- [x] AGNOS update works on warm boot
  - [x] previous -> new
  - [ ] new -> previous
- [ ] Display works at 60FPS: `SHOW_FPS=1 /data/openpilot/selfdrive/ui/ui.py`

### ABL

- [ ] A/B slot fallback works
- [ ] Boot time hasn't regressed (1s)

### XBL

- [ ] Display init works in cold and hot temperatures
- [ ] Display works at 60FPS
- [ ] Boot time hasn't regressed (2.4s)

### Setup

- (a) Not a real URL (e.g. `comma`, `abc123`, `...`)
  - [ ] "Ensure the entered URL is valid"
  - [ ] Start over
  - [ ] Reboot device
- (b) Website but not an installer URL (e.g. `github.com`, `comma.ai`, `installer.comma.ai`)
  - [ ] "No custom software found at this URL."
- (c) Valid installer URL (e.g. `openpilot.comma.ai`)
  - [ ] Download successful (comma logo or installer appears)
  - [ ] `/tmp/installer_url` should contain the installer URL
  - [ ] Boots into openpilot


