### PR TITLE
fix spinner crash 

### DIFF
--- a/openpilot/system/ui/widgets/__init__.py
+++ b/openpilot/system/ui/widgets/__init__.py
@@ -16,7 +16,7 @@ def _get_device() -> DeviceLike:
   try:
     from openpilot.selfdrive.ui.ui_state import device
     return device
-  except ImportError:
+  except (ImportError, OSError):
     class Device:
       awake = True
     return Device()


### PR DESCRIPTION
failed loading build artifacts before building them can crash the spinner due to uncaught exception.