### PR TITLE
fix tap to factory reset

### DIFF
--- a/openpilot/common/hardware/comma/hardware.py
+++ b/openpilot/common/hardware/comma/hardware.py
@@ -12,7 +12,6 @@ from openpilot.common.utils import sudo_read, sudo_write
 from openpilot.common.gpio import gpio_set, gpio_init, get_irqs_for_action
 from openpilot.common.esim.base import LPABase
 from openpilot.common.hardware.base import HardwareBase, ThermalConfig, ThermalZone
-from openpilot.common.esim.lpa import LPA
 from openpilot.common.hardware.comma.pins import GPIO
 from openpilot.common.hardware.comma.amplifier import Amplifier
 
@@ -155,6 +154,7 @@ class HardwareComma(HardwareBase):
     }
 
   def get_sim_lpa(self) -> LPABase:
+    from openpilot.common.esim.lpa import LPA
     return LPA()
 
   def get_imei(self):


### PR DESCRIPTION
missing pyserial from agnos broke the factory reset workflow when importing LPA globally.