### PR TITLE
ci: install Raylib headless runtime

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -103,7 +103,7 @@ jobs:
     - uses: actions/checkout@v7
     - run: ./tools/op.sh setup
     - name: Install Raylib headless runtime
-      run: sudo apt-get update && sudo apt-get install -y libgles2
+      run: sudo apt-get update && sudo apt-get install -y libegl1 libgles2
     - name: Build openpilot
       run: scons
     - name: Run unit tests
@@ -209,7 +209,7 @@ jobs:
       - uses: actions/checkout@v7
       - run: ./tools/op.sh setup
       - name: Install Raylib headless runtime
-        run: sudo apt-get update && sudo apt-get install -y libgles2
+        run: sudo apt-get update && sudo apt-get install -y libegl1 libgles2
       - name: Build openpilot
         run: scons
       - name: Create UI Report

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -102,6 +102,8 @@ jobs:
     steps:
     - uses: actions/checkout@v7
     - run: ./tools/op.sh setup
+    - name: Install Raylib headless runtime
+      run: sudo apt-get update && sudo apt-get install -y libgles2
     - name: Build openpilot
       run: scons
     - name: Run unit tests
@@ -206,6 +208,8 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - run: ./tools/op.sh setup
+      - name: Install Raylib headless runtime
+        run: sudo apt-get update && sudo apt-get install -y libgles2
       - name: Build openpilot
         run: scons
       - name: Create UI Report


### PR DESCRIPTION
## Summary

Installs the Linux EGL and GLES runtimes needed by Raylib's headless backend in the two CI jobs that use it.

## Justification

The `unit tests` and `Create UI Report` jobs currently fail before project code runs because Raylib cannot load its runtime graphics libraries. Ubuntu's `libegl1` and `libgles2` packages provide `libEGL.so.1` and `libGLESv2.so.2`.

## Changes

- Install `libegl1` and `libgles2` before the `unit tests` job.
- Install `libegl1` and `libgles2` before the `Create UI Report` job.

## Validation

- `git diff --check`
- The previous CI run confirmed `libgles2` resolves the initial GLES error and exposed the remaining EGL dependency.
- The new PR CI run verifies both affected jobs with both runtime libraries installed.
