### PR TITLE
lfs: exclude big driving model in master clones

### DIFF
--- a/.lfsconfig
+++ b/.lfsconfig
@@ -1,4 +1,5 @@
 [lfs]
 	url = https://gitlab.com/commaai/openpilot-lfs.git/info/lfs
 	pushurl = ssh://git@gitlab.com/commaai/openpilot-lfs.git
+	fetchexclude = "openpilot/selfdrive/modeld/models/big_driving_supercombo.onnx"
 	locksverify = false

--- a/openpilot/selfdrive/ui/installer/installer.cc
+++ b/openpilot/selfdrive/ui/installer/installer.cc
@@ -195,6 +195,7 @@ void cloneFinished(int exitCode) {
   run(("git checkout " + migrated_branch).c_str());
   run(("git reset --hard origin/" + migrated_branch).c_str());
   run("git submodule update --init");
+  run("git lfs pull --exclude=\"\"");
 
   // move into place
   run(("rm -f " + VALID_CACHE_PATH).c_str());

--- a/openpilot/selfdrive/ui/installer/installer.cc
+++ b/openpilot/selfdrive/ui/installer/installer.cc
@@ -195,7 +195,6 @@ void cloneFinished(int exitCode) {
   run(("git checkout " + migrated_branch).c_str());
   run(("git reset --hard origin/" + migrated_branch).c_str());
   run("git submodule update --init");
-  run("git lfs pull --exclude=\"\"");
 
   // move into place
   run(("rm -f " + VALID_CACHE_PATH).c_str());


### PR DESCRIPTION
to undo this after clone, `git lfs pull --exclude=""`