### PR TITLE
release: speedup builds

### DIFF
--- a/openpilot/selfdrive/controls/lib/longitudinal_mpc_lib/SConscript
+++ b/openpilot/selfdrive/controls/lib/longitudinal_mpc_lib/SConscript
@@ -35,6 +35,7 @@ build_files = [f'{gen}/acados_solver_long.c'] + casadi_model + casadi_cost_y + c
 
 # extra generated files used to trigger a rebuild
 generated_files = [
+  'acados_ocp_long.json',
   f'{gen}/Makefile',
 
   f'{gen}/main_long.c',

--- a/tools/release/build_release.sh
+++ b/tools/release/build_release.sh
@@ -2,14 +2,13 @@
 set -e
 set -x
 
-# git diff --name-status origin/release3-staging | grep "^A" | less
-
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
-
 cd $DIR
 
 BUILD_DIR=/data/openpilot
 SOURCE_DIR="$(git rev-parse --show-toplevel)"
+
+export PYTHONPATH="$BUILD_DIR:$BUILD_DIR/msgq_repo:$BUILD_DIR/opendbc_repo:$BUILD_DIR/rednose_repo:$BUILD_DIR/teleoprtc_repo:$BUILD_DIR/tinygrad_repo"
 
 if [ -z "$RELEASE_BRANCH" ]; then
   echo "RELEASE_BRANCH is not set"
@@ -33,15 +32,10 @@ git checkout --orphan $BUILD_BRANCH
 # do the files copy
 echo "[-] copying files T=$SECONDS"
 cd $SOURCE_DIR
-cp -pR --parents $(./tools/release/release_files.py) $BUILD_DIR/
+./tools/release/release_files.py | xargs -0 cp -pR --parents -t "$BUILD_DIR" --
 
 # in the directory
 cd $BUILD_DIR
-
-rm -f panda/board/obj/panda.bin.signed
-rm -f panda/board/obj/panda_h7.bin.signed
-
-VERSION=$(cat openpilot/common/version.h | awk -F[\"-]  '{print $2}')
 
 # use the full CPU available for speeding up the build.
 # openpilot resets the CPU frequencies when test_onroad.py runs below.
@@ -51,9 +45,6 @@ for policy in /sys/devices/system/cpu/cpufreq/policy*; do
   echo "$hardware_max" | sudo tee "$policy/scaling_max_freq" >/dev/null
 done
 
-# Build and test before launch_chffrplus.sh creates the on-device package
-# symlinks. SConstruct uses the same package roots for build subprocesses.
-export PYTHONPATH="$BUILD_DIR:$BUILD_DIR/msgq_repo:$BUILD_DIR/opendbc_repo:$BUILD_DIR/rednose_repo:$BUILD_DIR/teleoprtc_repo:$BUILD_DIR/tinygrad_repo"
 scons
 if [ -n "$INCLUDE_BIG_MODEL" ]; then
   test -f openpilot/selfdrive/modeld/models/big_driving_tinygrad.pkl.chunkmanifest
@@ -80,7 +71,6 @@ find . -name '*.a' -delete
 find . -name '*.o' -delete
 find . -name '*.os' -delete
 find . -name '*.pyc' -delete
-find . -name 'moc_*' -delete
 find . -name '__pycache__' -delete
 rm -rf .sconsign.dblite Jenkinsfile tools/release/
 rm -f openpilot/selfdrive/modeld/models/*.onnx*
@@ -88,6 +78,7 @@ rm -f openpilot/selfdrive/modeld/models/*.onnx*
 # Mark as prebuilt release
 touch prebuilt
 
+VERSION=$(cat openpilot/common/version.h | awk -F[\"-]  '{print $2}')
 # Add built files to git
 git add -f .
 git commit -m "openpilot v$VERSION"

--- a/tools/release/build_release.sh
+++ b/tools/release/build_release.sh
@@ -40,11 +40,6 @@ cd $SOURCE_DIR
 # in the directory
 cd $BUILD_DIR
 
-GIT_HASH=$(git -C "$SOURCE_DIR" rev-parse HEAD)
-GIT_COMMIT_DATE=$(git -C "$SOURCE_DIR" show --no-patch --format='%ct %ci' HEAD)
-echo -n "$GIT_HASH" > git_src_commit
-echo -n "$GIT_COMMIT_DATE" > git_src_commit_date
-
 # use the full CPU available for speeding up the build.
 # openpilot resets the CPU frequencies when test_onroad.py runs below.
 for policy in /sys/devices/system/cpu/cpufreq/policy*; do

--- a/tools/release/build_release.sh
+++ b/tools/release/build_release.sh
@@ -40,8 +40,10 @@ cd $SOURCE_DIR
 # in the directory
 cd $BUILD_DIR
 
-printf '%s' "$(git -C "$SOURCE_DIR" rev-parse HEAD)" > git_src_commit
-printf '%s' "$(git -C "$SOURCE_DIR" show --no-patch --format='%ct %ci' HEAD)" > git_src_commit_date
+GIT_HASH=$(git -C "$SOURCE_DIR" rev-parse HEAD)
+GIT_COMMIT_DATE=$(git -C "$SOURCE_DIR" show --no-patch --format='%ct %ci' HEAD)
+echo -n "$GIT_HASH" > git_src_commit
+echo -n "$GIT_COMMIT_DATE" > git_src_commit_date
 
 # use the full CPU available for speeding up the build.
 # openpilot resets the CPU frequencies when test_onroad.py runs below.

--- a/tools/release/build_release.sh
+++ b/tools/release/build_release.sh
@@ -42,9 +42,6 @@ rm -f panda/board/obj/panda.bin.signed
 rm -f panda/board/obj/panda_h7.bin.signed
 
 VERSION=$(cat openpilot/common/version.h | awk -F[\"-]  '{print $2}')
-echo "[-] committing version $VERSION T=$SECONDS"
-git add -f .
-git commit -a -m "openpilot v$VERSION release"
 
 # use the full CPU available for speeding up the build.
 # openpilot resets the CPU frequencies when test_onroad.py runs below.
@@ -93,7 +90,7 @@ touch prebuilt
 
 # Add built files to git
 git add -f .
-git commit --amend -m "openpilot v$VERSION"
+git commit -m "openpilot v$VERSION"
 
 # Run tests
 cd $BUILD_DIR

--- a/tools/release/build_release.sh
+++ b/tools/release/build_release.sh
@@ -26,6 +26,8 @@ rm -rf $BUILD_DIR
 mkdir -p $BUILD_DIR
 cd $BUILD_DIR
 git init
+# writing larger objects is faster than compressing them on-device
+git config core.compression 0
 git remote add origin git@github.com:commaai/openpilot.git
 git checkout --orphan $BUILD_BRANCH
 

--- a/tools/release/build_release.sh
+++ b/tools/release/build_release.sh
@@ -22,17 +22,12 @@ BUILD_BRANCH=release-mici-staging
 source $DIR/identity.sh
 
 echo "[-] Setting up repo T=$SECONDS"
-if [ -d "$BUILD_DIR/.git" ]; then
-  git -C "$BUILD_DIR" rm -r -f --ignore-unmatch .
-  git -C "$BUILD_DIR" clean -dffx
-else
+if ! git -C "$SOURCE_DIR" worktree remove --force "$BUILD_DIR" 2>/dev/null; then
   rm -rf $BUILD_DIR
-  mkdir -p $BUILD_DIR
-  git -C "$BUILD_DIR" init
-  git -C "$BUILD_DIR" remote add origin git@github.com:commaai/openpilot.git
 fi
+git -C "$SOURCE_DIR" worktree prune
+git -C "$SOURCE_DIR" worktree add --detach --no-checkout "$BUILD_DIR"
 cd $BUILD_DIR
-git config gc.auto 0
 git update-ref -d "refs/heads/$BUILD_BRANCH"
 git symbolic-ref HEAD "refs/heads/$BUILD_BRANCH"
 git read-tree --empty
@@ -90,7 +85,7 @@ VERSION=$(cat openpilot/common/version.h | awk -F[\"-]  '{print $2}')
 # Add built files to git
 # writing larger objects is faster than compressing them on-device
 git -c core.compression=0 add -f .
-git -c core.compression=0 commit -m "openpilot v$VERSION"
+git -c core.compression=0 -c gc.auto=0 commit -m "openpilot v$VERSION"
 
 # Run tests
 cd $BUILD_DIR

--- a/tools/release/build_release.sh
+++ b/tools/release/build_release.sh
@@ -40,6 +40,9 @@ cd $SOURCE_DIR
 # in the directory
 cd $BUILD_DIR
 
+printf '%s' "$(git -C "$SOURCE_DIR" rev-parse HEAD)" > git_src_commit
+printf '%s' "$(git -C "$SOURCE_DIR" show --no-patch --format='%ct %ci' HEAD)" > git_src_commit_date
+
 # use the full CPU available for speeding up the build.
 # openpilot resets the CPU frequencies when test_onroad.py runs below.
 for policy in /sys/devices/system/cpu/cpufreq/policy*; do

--- a/tools/release/build_release.sh
+++ b/tools/release/build_release.sh
@@ -33,8 +33,6 @@ else
   git -C "$BUILD_DIR" remote add origin git@github.com:commaai/openpilot.git
 fi
 cd $BUILD_DIR
-# writing larger objects is faster than compressing them on-device
-git config core.compression 0
 git config gc.auto 0
 git update-ref -d "refs/heads/$BUILD_BRANCH"
 git symbolic-ref HEAD "refs/heads/$BUILD_BRANCH"
@@ -91,8 +89,9 @@ touch prebuilt
 
 VERSION=$(cat openpilot/common/version.h | awk -F[\"-]  '{print $2}')
 # Add built files to git
-git add -f .
-git commit -m "openpilot v$VERSION"
+# writing larger objects is faster than compressing them on-device
+git -c core.compression=0 add -f .
+git -c core.compression=0 commit -m "openpilot v$VERSION"
 
 # Run tests
 cd $BUILD_DIR

--- a/tools/release/build_release.sh
+++ b/tools/release/build_release.sh
@@ -22,14 +22,23 @@ BUILD_BRANCH=release-mici-staging
 source $DIR/identity.sh
 
 echo "[-] Setting up repo T=$SECONDS"
-rm -rf $BUILD_DIR
-mkdir -p $BUILD_DIR
+if [ "$(git -C "$BUILD_DIR" config --bool release.buildRepo 2>/dev/null)" = "true" ]; then
+  git -C "$BUILD_DIR" rm -r -f --ignore-unmatch .
+  git -C "$BUILD_DIR" clean -dffx
+else
+  rm -rf $BUILD_DIR
+  mkdir -p $BUILD_DIR
+  git -C "$BUILD_DIR" init
+  git -C "$BUILD_DIR" config release.buildRepo true
+  git -C "$BUILD_DIR" remote add origin git@github.com:commaai/openpilot.git
+fi
 cd $BUILD_DIR
-git init
 # writing larger objects is faster than compressing them on-device
 git config core.compression 0
-git remote add origin git@github.com:commaai/openpilot.git
-git checkout --orphan $BUILD_BRANCH
+git config gc.auto 0
+git update-ref -d "refs/heads/$BUILD_BRANCH"
+git symbolic-ref HEAD "refs/heads/$BUILD_BRANCH"
+git read-tree --empty
 
 # do the files copy
 echo "[-] copying files T=$SECONDS"

--- a/tools/release/build_release.sh
+++ b/tools/release/build_release.sh
@@ -22,14 +22,13 @@ BUILD_BRANCH=release-mici-staging
 source $DIR/identity.sh
 
 echo "[-] Setting up repo T=$SECONDS"
-if [ "$(git -C "$BUILD_DIR" config --bool release.buildRepo 2>/dev/null)" = "true" ]; then
+if [ -d "$BUILD_DIR/.git" ]; then
   git -C "$BUILD_DIR" rm -r -f --ignore-unmatch .
   git -C "$BUILD_DIR" clean -dffx
 else
   rm -rf $BUILD_DIR
   mkdir -p $BUILD_DIR
   git -C "$BUILD_DIR" init
-  git -C "$BUILD_DIR" config release.buildRepo true
   git -C "$BUILD_DIR" remote add origin git@github.com:commaai/openpilot.git
 fi
 cd $BUILD_DIR

--- a/tools/release/build_stripped.sh
+++ b/tools/release/build_stripped.sh
@@ -38,12 +38,11 @@ git submodule foreach --recursive git clean -xdff
 # do the files copy
 echo "[-] copying files T=$SECONDS"
 cd $SOURCE_DIR
-./tools/release/release_files.py | xargs -d '\n' cp -pR --parents -t "$TARGET_DIR"
+./tools/release/release_files.py | xargs -0 cp -pR --parents -t "$TARGET_DIR" --
 
 # in the directory
 cd $TARGET_DIR
 rm -rf .git/modules/
-rm -f panda/board/obj/panda.bin.signed
 
 find openpilot/selfdrive/modeld/models -name '*.onnx' -size +95M -exec ./openpilot/common/file_chunker.py {} \;
 

--- a/tools/release/build_stripped.sh
+++ b/tools/release/build_stripped.sh
@@ -20,8 +20,6 @@ cp -r $SOURCE_DIR/.git $TARGET_DIR
 
 echo "[-] setting up stripped branch sync T=$SECONDS"
 cd $TARGET_DIR
-# writing larger objects is faster than compressing them on-device
-git config core.compression 0
 
 # tmp branch
 git checkout --orphan tmp
@@ -53,9 +51,10 @@ echo -n "$GIT_HASH" > git_src_commit
 echo -n "$GIT_COMMIT_DATE" > git_src_commit_date
 
 echo "[-] committing version $VERSION T=$SECONDS"
-git add -f .
+# writing larger objects is faster than compressing them on-device
+git -c core.compression=0 add -f .
 git status
-git commit -a -m "openpilot v$VERSION release
+git -c core.compression=0 commit -a -m "openpilot v$VERSION release
 
 date: $DATETIME
 master commit: $GIT_HASH

--- a/tools/release/build_stripped.sh
+++ b/tools/release/build_stripped.sh
@@ -20,6 +20,8 @@ cp -r $SOURCE_DIR/.git $TARGET_DIR
 
 echo "[-] setting up stripped branch sync T=$SECONDS"
 cd $TARGET_DIR
+# writing larger objects is faster than compressing them on-device
+git config core.compression 0
 
 # tmp branch
 git checkout --orphan tmp
@@ -29,11 +31,6 @@ echo "[-] erasing old openpilot T=$SECONDS"
 git submodule deinit -f --all
 git rm -rf --cached .
 find . -maxdepth 1 -not -path './.git' -not -name '.' -not -name '..' -exec rm -rf '{}' \;
-
-# cleanup before the copy
-cd $SOURCE_DIR
-git clean -xdff
-git submodule foreach --recursive git clean -xdff
 
 # do the files copy
 echo "[-] copying files T=$SECONDS"

--- a/tools/release/release_files.py
+++ b/tools/release/release_files.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 import os
 import re
-from pathlib import Path
+import subprocess
+import sys
 
 HERE = os.path.abspath(os.path.dirname(__file__))
 ROOT = os.path.abspath(os.path.join(HERE, "../.."))
@@ -25,11 +26,12 @@ whitelist: list[str] = [
 ]
 
 if __name__ == "__main__":
-  for f in Path(ROOT).rglob("**/*"):
-    if not (f.is_file() or f.is_symlink()):
+  tracked_files = subprocess.check_output(["git", "ls-files", "-z", "--recurse-submodules"], cwd=ROOT).split(b"\0")
+  for tracked_file in tracked_files:
+    if not tracked_file:
       continue
 
-    rf = str(f.relative_to(ROOT))
+    rf = os.fsdecode(tracked_file)
     if not os.getenv("INCLUDE_BIG_MODEL") and rf.startswith("openpilot/selfdrive/modeld/models/big_driving_supercombo.onnx"):
       continue
     blacklisted = any(re.search(p, rf) for p in blacklist)
@@ -37,4 +39,4 @@ if __name__ == "__main__":
     if blacklisted and not whitelisted:
       continue
 
-    print(rf)
+    sys.stdout.buffer.write(tracked_file + b"\0")


### PR DESCRIPTION
| Build | Before | After | Speedup |
|---|---:|---:|---:|
| Normal release | 196.62s | 188.65s | 4.1% |
| Chestnut release | 362s | 204s | 43.6% |
| Chestnut Git staging + commit | 129.91s | 40.25s | 69.0% |
| Chestnut Git staging + commit (reuse objects) | 40.25s | 16.79s | 58.3% |