### PR TITLE
[bot] Update Python packages

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -981,18 +981,18 @@ wheels = [
 
 [[package]]
 name = "sounddevice"
-version = "0.5.5"
+version = "0.5.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cffi" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2a/f9/2592608737553638fca98e21e54bfec40bf577bb98a61b2770c912aab25e/sounddevice-0.5.5.tar.gz", hash = "sha256:22487b65198cb5bf2208755105b524f78ad173e5ab6b445bdab1c989f6698df3", size = 143191, upload-time = "2026-01-23T18:36:43.529Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ec/db/0c890e2d9aab9ba284021efc02e1d3aebfecab1b611762d7434602209bcf/sounddevice-0.5.6.tar.gz", hash = "sha256:8ec9fbfde2e32f020b167e348f3ab3bac6625a5f15af524d790108ac7147a410", size = 1120094, upload-time = "2026-08-17T07:55:05.048Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/0a/478e441fd049002cf308520c0d62dd8333e7c6cc8d997f0dda07b9fbcc46/sounddevice-0.5.5-py3-none-any.whl", hash = "sha256:30ff99f6c107f49d25ad16a45cacd8d91c25a1bcdd3e81a206b921a3a6405b1f", size = 32807, upload-time = "2026-01-23T18:36:35.649Z" },
-    { url = "https://files.pythonhosted.org/packages/56/f9/c037c35f6d0b6bc3bc7bfb314f1d6f1f9a341328ef47cd63fc4f850a7b27/sounddevice-0.5.5-py3-none-macosx_10_6_x86_64.macosx_10_6_universal2.whl", hash = "sha256:05eb9fd6c54c38d67741441c19164c0dae8ce80453af2d8c4ad2e7823d15b722", size = 108557, upload-time = "2026-01-23T18:36:37.41Z" },
-    { url = "https://files.pythonhosted.org/packages/88/a1/d19dd9889cd4bce2e233c4fac007cd8daaf5b9fe6e6a5d432cf17be0b807/sounddevice-0.5.5-py3-none-win32.whl", hash = "sha256:1234cc9b4c9df97b6cbe748146ae0ec64dd7d6e44739e8e42eaa5b595313a103", size = 317765, upload-time = "2026-01-23T18:36:39.047Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/0e/002ed7c4c1c2ab69031f78989d3b789fee3a7fba9e586eb2b81688bf4961/sounddevice-0.5.5-py3-none-win_amd64.whl", hash = "sha256:cfc6b2c49fb7f555591c78cb8ecf48d6a637fd5b6e1db5fec6ed9365d64b3519", size = 365324, upload-time = "2026-01-23T18:36:40.496Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/39/a61d4b83a7746b70d23d9173be688c0c6bfc7173772344b7442c2c155497/sounddevice-0.5.5-py3-none-win_arm64.whl", hash = "sha256:3861901ddd8230d2e0e8ae62ac320cdd4c688d81df89da036dcb812f757bb3e6", size = 317115, upload-time = "2026-01-23T18:36:42.235Z" },
+    { url = "https://files.pythonhosted.org/packages/72/1f/62eef605172bddc1017508469a12f75bc7c4194ece35c734f822795f53b1/sounddevice-0.5.6-py3-none-any.whl", hash = "sha256:de099612311ad81e55d31ccbd83f43ea6bf4d87b48f9b6ea55a1fbcde0eee4e0", size = 32793, upload-time = "2026-08-17T07:54:57.507Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/84/85e719d49cf98b2f406d9ac9c338892286c4448eb42ef0b2625ccf159616/sounddevice-0.5.6-py3-none-macosx_10_6_x86_64.macosx_10_6_universal2.whl", hash = "sha256:e3aef00ad8b1d1740eb66d9a7671eab88a4d2b8fa4ab33498d742e63b65c309c", size = 1009647, upload-time = "2026-08-17T07:54:58.814Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/6f/6292145099f72a153a710245f46ae43e5fb6c77bec1b6086cb76c12dc280/sounddevice-0.5.6-py3-none-win32.whl", hash = "sha256:b36b807eb02abd257198bf84b2af05e4fea199a9d2f0019014169c7136d45e9c", size = 1009627, upload-time = "2026-08-17T07:55:00.401Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/3e/cbc593c31a5f0d817b3fe97e64aa8461bd0f55cb07b67ce1b776296ae336/sounddevice-0.5.6-py3-none-win_amd64.whl", hash = "sha256:7f4162f514f007b0bf25a3ccfed3f1705bc2ec311888a90232729eec4f57a4f4", size = 1009630, upload-time = "2026-08-17T07:55:02.088Z" },
+    { url = "https://files.pythonhosted.org/packages/60/a4/b0c21c9f215a6fd9606b8f8748c21212dc098e5d5a2d93068c50edcf19b4/sounddevice-0.5.6-py3-none-win_arm64.whl", hash = "sha256:c8ae19173e5f27f8c12d4b5eee2dbfe542cee125d591e663e0fb4dfb75246d45", size = 1009630, upload-time = "2026-08-17T07:55:03.689Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Automatic PR from repo-maintenance -> package_updates

```
$ du -sh .venv && du -sh .venv/lib/python*/site-packages/* | sort -rh | head -10
Total: 495M

Top 10 by size:
43M  gcc_arm_none_eabi
30M  sympy
30M  numpy
28M  numpy.libs
28M  casadi
25M  matplotlib
23M  zstandard
23M  SCons
21M  fontTools
19M  capnp
```

```
$ uv pip tree
codespell v2.4.3
comma-deps-bootstrap-icons v1.10.5.0.post98
comma-deps-imgui v1.92.7.post98
comma-deps-libusb v1.0.29.post98
comma-deps-ncurses v6.5.post98
coverage v7.15.4
cryptography v50.0.0
└── cffi v2.1.1
    └── pycparser v3.0
matplotlib v3.11.1
├── contourpy v1.3.3
│   └── numpy v2.5.2
├── cycler v0.12.1
├── fonttools v4.63.0
├── kiwisolver v1.5.0
├── numpy v2.5.2
├── packaging v26.3
├── pillow v12.3.0
├── pyparsing v3.3.2
└── python-dateutil v2.9.0.post0
    └── six v1.17.0
msgq v0.0.1
openpilot v0.1.0
├── comma-deps-acados v0.2.2.post98
│   └── numpy v2.5.2
├── comma-deps-capnproto v1.0.1.post98
├── comma-deps-ffmpeg v7.1.0.post98
├── comma-deps-gcc-arm-none-eabi v13.2.1.post98
├── comma-deps-git-lfs v3.6.1.post98
├── comma-deps-json11 v20170411.0.post98
├── comma-deps-raylib v6.0.0.1.post98
│   └── cffi v2.1.1 (*)
├── comma-deps-zeromq v4.3.5.post98
├── comma-deps-zstd v1.5.6.post98
├── inputs v0.5
├── jeepney v0.9.0
├── numpy v2.5.2
├── pycapnp v2.1.0
├── pyjwt v2.13.0
├── pyzmq v27.1.0
├── requests v2.34.2
│   ├── certifi v2026.7.22
│   ├── charset-normalizer v3.5.1
│   ├── idna v3.18
│   └── urllib3 v2.7.0
├── scons v4.11.0
├── sentry-sdk v2.68.0
│   ├── certifi v2026.7.22
│   └── urllib3 v2.7.0
├── setproctitle v1.3.7
├── sounddevice v0.5.5
│   └── cffi v2.1.1 (*)
├── tqdm v4.70.0
├── websocket-client v1.9.0
└── zstandard v0.25.0
pandacan v0.0.10
├── libusb-package v1.0.30.0
│   └── importlib-resources v7.1.0
├── libusb1 v3.4.0
├── opendbc v0.3.1
│   ├── numpy v2.5.2
│   ├── pycapnp v2.1.0
│   ├── pycryptodome v3.23.0
│   └── tqdm v4.70.0
└── spidev v3.8
rednose v0.0.1
├── cffi v2.1.1 (*)
├── comma-deps-eigen v3.4.0.post98
├── cython v3.2.9
├── numpy v2.5.2
├── scons v4.11.0
├── setuptools v84.0.0
└── sympy v1.14.0
    └── mpmath v1.3.0
ruff v0.16.3
teleoprtc v1.0.1
└── libdatachannel-py v2026.1.0.dev2
tinygrad v0.13.0
ty v0.0.72
(*) Package tree already displayed
```