### PR TITLE
car: reset calibration when car changes

### DIFF
--- a/openpilot/selfdrive/car/card.py
+++ b/openpilot/selfdrive/car/card.py
@@ -58,6 +58,19 @@ def can_comm_callbacks(logcan: messaging.SubSocket, sendcan: messaging.PubSocket
   return can_recv, can_send
 
 
+def reset_calibration_if_car_changed(params: Params, prev_cp: bytes | None, CP: car.CarParams) -> None:
+  if prev_cp is None:
+    return
+
+  try:
+    with car.CarParams.from_bytes(prev_cp) as previous_CP:
+      if previous_CP.carFingerprint != CP.carFingerprint:
+        cloudlog.info(f"car changed from {previous_CP.carFingerprint} to {CP.carFingerprint}, resetting calibration")
+        params.remove("CalibrationParams")
+  except Exception:
+    cloudlog.exception("Error comparing current and previous CarParams")
+
+
 class Car:
   CI: CarInterfaceBase
   RI: RadarInterfaceBase
@@ -142,6 +155,7 @@ class Car:
     prev_cp = self.params.get("CarParamsPersistent")
     if prev_cp is not None:
       self.params.put("CarParamsPrevRoute", prev_cp, block=True)
+    reset_calibration_if_car_changed(self.params, prev_cp, self.CP)
 
     # Write CarParams for controls and radard
     cp_bytes = self.CP.to_bytes()

--- a/openpilot/selfdrive/car/tests/test_card.py
+++ b/openpilot/selfdrive/car/tests/test_card.py
@@ -1,0 +1,26 @@
+import unittest
+from unittest import mock
+
+from opendbc.car.structs import car
+
+from openpilot.selfdrive.car.card import reset_calibration_if_car_changed
+
+
+class TestCarParamsPersistence(unittest.TestCase):
+  def test_calibration_reset_when_car_changes(self):
+    params = mock.Mock()
+    previous_CP = car.CarParams(carFingerprint="HONDA CIVIC 2016")
+    current_CP = car.CarParams(carFingerprint="TOYOTA COROLLA TSS2 2019")
+
+    reset_calibration_if_car_changed(params, previous_CP.to_bytes(), current_CP)
+
+    params.remove.assert_called_once_with("CalibrationParams")
+
+  def test_calibration_preserved_for_same_car(self):
+    params = mock.Mock()
+    previous_CP = car.CarParams(carFingerprint="HONDA CIVIC 2016")
+    current_CP = car.CarParams(carFingerprint=previous_CP.carFingerprint)
+
+    reset_calibration_if_car_changed(params, previous_CP.to_bytes(), current_CP)
+
+    params.remove.assert_not_called()


### PR DESCRIPTION
## Summary

Reset the saved camera calibration when the newly fingerprinted car differs from the previous route.

Calibration is specific to the device mounting geometry. Reusing it after moving a device to a different car can start the next drive with invalid extrinsics. The comparison runs before CarParams is published, so calibrationd observes the reset before loading its cached state.

Closes #38351

## Validation

- Added regression coverage for preserving calibration on the same fingerprint.
- Added regression coverage for resetting calibration on a different fingerprint.
- 2 tests passed.
- Ruff and git diff checks passed.