### PR TITLE
harden: add path validation in api.py (utils.custom.path-traversal-open)

### DIFF
--- a/openpilot/common/api.py
+++ b/openpilot/common/api.py
@@ -57,8 +57,13 @@ def api_get(endpoint, method='GET', timeout=None, access_token=None, session=Non
 
 
 def get_key_pair() -> tuple[str, str, str] | tuple[None, None, None]:
+  comma_dir = os.path.realpath(os.path.join(Paths.persist_root(), 'comma'))
   for key in KEYS:
-    if os.path.isfile(Paths.persist_root() + f'/comma/{key}') and os.path.isfile(Paths.persist_root() + f'/comma/{key}.pub'):
-      with open(Paths.persist_root() + f'/comma/{key}') as private, open(Paths.persist_root() + f'/comma/{key}.pub') as public:
+    private_path = os.path.realpath(os.path.join(comma_dir, key))
+    public_path = os.path.realpath(os.path.join(comma_dir, key + '.pub'))
+    if not private_path.startswith(comma_dir + os.sep) or not public_path.startswith(comma_dir + os.sep):
+      continue
+    if os.path.isfile(private_path) and os.path.isfile(public_path):
+      with open(private_path) as private, open(public_path) as public:
         return KEYS[key], private.read(), public.read()
   return None, None, None


### PR DESCRIPTION
## Summary
Harden input handling in `openpilot/common/api.py` (flagged by semgrep).

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | utils.custom.path-traversal-open |
| **Severity** | HIGH |
| **Scanner** | semgrep |
| **Rule** | `utils.custom.path-traversal-open` |
| **File** | `openpilot/common/api.py:62` |
| **Assessment** | Defensive hardening |

**Description**: User-controlled input used in file path for open() without sanitization. This can allow path traversal attacks to read arbitrary files.


## Threat Model Context

This is a Python library - vulnerabilities affect applications that import this code.

## Changes
- `openpilot/common/api.py`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path; it only tightens handling of untrusted input and leaves valid inputs unaffected.

---
*This patch removes an exploit primitive — a code pattern that, while not independently exploitable today, could be chained with other weaknesses by automated exploit-development tooling. Proactive removal of such primitives raises the bar against increasingly capable automated attack tools.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
