### PR TITLE
Test big model lfs

### DIFF
--- a/openpilot/selfdrive/modeld/models/big_driving_supercombo.onnx
+++ b/openpilot/selfdrive/modeld/models/big_driving_supercombo.onnx
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:aede9044745c3310ccebd1f37f8bb5784f6bf78ff097cd29983be89f37f2ba32
-size 37
+oid sha256:a90bd2ff9d26657ddff4d626298f3e2f1d5f73aaa7a88a1d5c76512d195120d1
+size 94

--- a/openpilot/selfdrive/modeld/models/big_driving_supercombo.onnx
+++ b/openpilot/selfdrive/modeld/models/big_driving_supercombo.onnx
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a501760a9d1d5fef0eab2b8c5d122d06124fc26dc8e0782e0aa94b82a208f0ff
-size 1757355221
+oid sha256:aede9044745c3310ccebd1f37f8bb5784f6bf78ff097cd29983be89f37f2ba32
+size 37


### PR DESCRIPTION
Tested with temp branch https://github.com/commaai/openpilot/commits/test-big-model-lfs by pushing a fake lfs model file. Setting this option during clone persistency alters git .config to always fetch the big model on master.

Tested with updater flow:

```
git fetch origin test-big-model-lfs
git checkout --force --no-recurse-submodules -B test-big-model-lfs FETCH_HEAD
git branch --set-upstream-to origin/test-big-model-lfs
git reset --hard
```