### PR TITLE
installer: fetch big model on master clones

### DIFF
--- a/openpilot/selfdrive/ui/installer/installer.cc
+++ b/openpilot/selfdrive/ui/installer/installer.cc
@@ -144,7 +144,7 @@ int cachedFetch(const std::string &cache) {
   LOGD("Fetching with cache: %s", cache.c_str());
 
   run(util::string_format("cp -rp %s %s", cache.c_str(), TMP_INSTALL_PATH).c_str());
-  run(util::string_format("cd %s && git config --local lfs.fetchexclude ''", TMP_INSTALL_PATH).c_str());
+//   run(util::string_format("cd %s && git config --local lfs.fetchexclude ''", TMP_INSTALL_PATH).c_str());
   run(util::string_format("cd %s && git remote set-url origin %s", TMP_INSTALL_PATH, GIT_URL.c_str()).c_str());
   run(util::string_format("cd %s && git remote set-branches --add origin %s", TMP_INSTALL_PATH, migrated_branch.c_str()).c_str());
 

--- a/openpilot/selfdrive/ui/installer/installer.cc
+++ b/openpilot/selfdrive/ui/installer/installer.cc
@@ -135,7 +135,7 @@ int doInstall() {
 
 int freshClone() {
   LOGD("Doing fresh clone");
-  std::string cmd = util::string_format("git clone --progress %s -b %s --depth=1 --recurse-submodules %s 2>&1",
+  std::string cmd = util::string_format("git clone --progress -c lfs.fetchexclude='' %s -b %s --depth=1 --recurse-submodules %s 2>&1",
                                         GIT_URL.c_str(), migrated_branch.c_str(), TMP_INSTALL_PATH);
   return executeGitCommand(cmd);
 }
@@ -144,6 +144,7 @@ int cachedFetch(const std::string &cache) {
   LOGD("Fetching with cache: %s", cache.c_str());
 
   run(util::string_format("cp -rp %s %s", cache.c_str(), TMP_INSTALL_PATH).c_str());
+  run(util::string_format("cd %s && git config --local lfs.fetchexclude ''", TMP_INSTALL_PATH).c_str());
   run(util::string_format("cd %s && git remote set-url origin %s", TMP_INSTALL_PATH, GIT_URL.c_str()).c_str());
   run(util::string_format("cd %s && git remote set-branches --add origin %s", TMP_INSTALL_PATH, migrated_branch.c_str()).c_str());
 


### PR DESCRIPTION
Overrides https://github.com/commaai/openpilot/pull/38626, so big model is only excluded on PC. Tested with temp branch https://github.com/commaai/openpilot/commits/test-big-model-lfs (https://github.com/commaai/openpilot/pull/38665) by pushing a fake lfs model file. Setting this option during clone persistency alters git .config to always fetch the big model on master.

Tested with updater flow:

```
git fetch origin test-big-model-lfs
git checkout --force --no-recurse-submodules -B test-big-model-lfs FETCH_HEAD
git branch --set-upstream-to origin/test-big-model-lfs
git reset --hard
```