### PR TITLE
cabana: run moc explicitly, scons 4.11 removed the qt3 tool

### DIFF
--- a/openpilot/tools/cabana/SConscript
+++ b/openpilot/tools/cabana/SConscript
@@ -47,8 +47,10 @@ else:
   qt_dirs += [f"{qt_install_headers}/Qt{m}" for m in qt_modules]
 
   qt_libs = [f"Qt5{m}" for m in qt_modules]
-qt_env['QT3DIR'] = qt_env['QTDIR']
-qt_env.Tool('qt3')
+if arch == "Darwin":
+  moc_bin = os.path.join(qt_env['QTDIR'], "bin", "moc")
+else:
+  moc_bin = os.path.join(subprocess.check_output(['qmake', '-query', 'QT_INSTALL_BINS'], encoding='utf8').strip(), "moc")
 
 qt_env['CPPPATH'] += qt_dirs
 qt_flags = [
@@ -106,6 +108,14 @@ cabana_srcs = ['mainwin.cc', 'streams/pandastream.cc', 'streams/devicestream.cc'
                'cameraview.cc', 'detailwidget.cc', 'tools/findsimilarbits.cc', 'tools/findsignal.cc', 'tools/routeinfo.cc']
 if arch != "Darwin":
   cabana_srcs += ['streams/socketcanstream.cc']
+
+# run moc on Q_OBJECT headers
+for src in list(cabana_srcs):
+  header = cabana_env.File(os.path.splitext(src)[0] + '.h').srcnode()
+  if os.path.exists(header.abspath) and 'Q_OBJECT' in header.get_text_contents():
+    moc_cc = os.path.join(os.path.dirname(src), 'moc_' + os.path.basename(src))
+    cabana_srcs += cabana_env.Command(moc_cc, header, f'{moc_bin} $SOURCE -o $TARGET')
+
 cabana_lib = cabana_env.Library("cabana_lib", cabana_srcs + [bootstrap_icons_src], LIBS=cabana_libs, FRAMEWORKS=base_frameworks)
 cabana_env.Program('_cabana', ['cabana.cc', cabana_lib, assets], LIBS=cabana_libs, FRAMEWORKS=base_frameworks)
 


### PR DESCRIPTION
SCons 4.11.0 (pulled in by the bot bump in #38650) deleted its long-deprecated `qt3` tool, so cabana's SConscript now fails to read with:

```
scons: *** No tool module 'qt3' found in ... SCons/Tool
File ".../openpilot/tools/cabana/SConscript", line 51
```

CI didn't catch it because it has no Qt installed, and the SConscript silently `Return()`s in that case — the break only hits people building cabana locally (macOS with brew `qt@5`, Linux with `qmake` on PATH).

**Fix:** the only thing cabana used from that tool was automoc, so run moc explicitly. moc comes from the Qt discovery the SConscript already does — `$QTDIR/bin/moc` from brew on macOS, `qmake -query QT_INSTALL_BINS` on Linux (same qmake we already query, so the moc always matches the Qt5 being built against). Each entry in `cabana_srcs` whose paired header contains `Q_OBJECT` gets a `Command` generating `moc_<name>.cc` into the sources. Deriving candidates from `cabana_srcs` rather than a header glob reproduces automoc's pairing behavior exactly and keeps the macOS `socketcanstream` exclusion working for free.

**Considered instead:** pinning `scons<4.11`. Rejected because the de-Qt migration still has a long way to go, so Qt (and moc) are around for a while — the pin would hold the whole repo's scons back for months and fight the dependency bot, to protect a tool cabana barely used. This is ~10 lines, self-contained to cabana, adds no Qt usage, and drops a deprecated-tool dependency, so it also reads as a small de-Qt step.

**Verified** on Linux with scons 4.11.0: from a clean slate (cache disabled, all cabana objects deleted) all 27 moc commands run and generate the same set of moc files the old automoc produced, `_cabana` links, and runs (`--help` under `QT_QPA_PLATFORM=offscreen`). Caveat: the macOS branch of the moc lookup is untested here — it points at brew `qt@5`'s `bin/moc`, whose bin dir the SConscript already puts on PATH.

---

*Disclosure: this fix was researched, written, and verified by Claude Code working in my checkout. The failure was reproduced on a fresh master clone before anything was changed, the root cause traced to the scons bump in #38650, and the replacement validated from scratch — cache disabled, all outputs deleted — with the generated moc set compared file-for-file against what the old automoc tool produced. macOS is the one path it couldn't test, flagged above. We went through the diff and this PR together before I raised it.*
