### PR TITLE
Re-open agnos updater UI if crash

### DIFF
--- a/launch_chffrplus.sh
+++ b/launch_chffrplus.sh
@@ -24,7 +24,9 @@ function agnos_init {
     if $AGNOS_PY --verify $MANIFEST; then
       sudo reboot
     fi
-    $DIR/openpilot/common/hardware/comma/updater $AGNOS_PY $MANIFEST
+    while true; do
+      $DIR/openpilot/common/hardware/comma/updater $AGNOS_PY $MANIFEST
+    done
   fi
 }
 


### PR DESCRIPTION
For https://github.com/commaai/openpilot/issues/38668. Tested a crash, re-opened without issue. Tested successful flash, no flicker