### PR TITLE
Fix UI label eliding

### DIFF
--- a/openpilot/selfdrive/ui/mici/layouts/settings/settings.py
+++ b/openpilot/selfdrive/ui/mici/layouts/settings/settings.py
@@ -21,7 +21,7 @@ class SettingsLayout(NavScroller):
     self._params = Params()
 
     toggles_panel = TogglesLayoutMici()
-    toggles_btn = SettingsBigButton("toggles", "", gui_app.texture("icons_mici/settings.png", 64, 64))
+    toggles_btn = SettingsBigButton("toggles12", "", gui_app.texture("icons_mici/settings.png", 64, 64))
     toggles_btn.set_click_callback(lambda: gui_app.push_widget(toggles_panel))
 
     network_panel = NetworkLayoutMici()

--- a/openpilot/selfdrive/ui/mici/layouts/settings/software.py
+++ b/openpilot/selfdrive/ui/mici/layouts/settings/software.py
@@ -184,7 +184,7 @@ class CheckUpdateButton(BigButton):
 
 class InstallUpdateButton(BigButton):
   def __init__(self):
-    super().__init__("", "updater failed to respond yes it did hehe", gui_app.texture("icons_mici/settings/device/reboot.png", 64, 70))
+    super().__init__("", "updater failed to respond", gui_app.texture("icons_mici/settings/device/reboot.png", 64, 70))
     # self.set_visible(lambda: ui_state.is_offroad() and ui_state.params.get_bool("UpdateAvailable"))
 
   # def _update_state(self):

--- a/openpilot/selfdrive/ui/mici/layouts/settings/software.py
+++ b/openpilot/selfdrive/ui/mici/layouts/settings/software.py
@@ -184,16 +184,17 @@ class CheckUpdateButton(BigButton):
 
 class InstallUpdateButton(BigButton):
   def __init__(self):
-    super().__init__("install update", "", gui_app.texture("icons_mici/settings/device/reboot.png", 64, 70))
-    self.set_visible(lambda: ui_state.is_offroad() and ui_state.params.get_bool("UpdateAvailable"))
+    super().__init__("", "updater failed to respond yes it did hehe", gui_app.texture("icons_mici/settings/device/reboot.png", 64, 70))
+    # self.set_visible(lambda: ui_state.is_offroad() and ui_state.params.get_bool("UpdateAvailable"))
 
-  def _update_state(self):
-    super()._update_state()
-
-    desc = _split_description(ui_state.params.get("UpdaterNewDescription") or "")
-    value = f"{desc[0]} ({desc[1]})" if desc is not None else ""
-    if self.get_value() != value:
-      self.set_value(value)
+  # def _update_state(self):
+  #   super()._update_state()
+  #
+  #   desc = _split_description(ui_state.params.get("UpdaterNewDescription") or "")
+  #   value = f"{desc[0]} ({desc[1]})" if desc is not None else ""
+  #   value = 'some value'
+  #   if self.get_value() != value:
+  #     self.set_value(value)
 
   def _handle_mouse_release(self, mouse_pos: MousePos):
     super()._handle_mouse_release(mouse_pos)

--- a/openpilot/selfdrive/ui/mici/layouts/settings/software.py
+++ b/openpilot/selfdrive/ui/mici/layouts/settings/software.py
@@ -184,7 +184,7 @@ class CheckUpdateButton(BigButton):
 
 class InstallUpdateButton(BigButton):
   def __init__(self):
-    super().__init__("", "updater failed to respond", gui_app.texture("icons_mici/settings/device/reboot.png", 64, 70))
+    super().__init__("install update", "updater failed to respond yes it did", gui_app.texture("icons_mici/settings/device/reboot.png", 64, 70))
     # self.set_visible(lambda: ui_state.is_offroad() and ui_state.params.get_bool("UpdateAvailable"))
 
   # def _update_state(self):

--- a/openpilot/selfdrive/ui/mici/widgets/button.py
+++ b/openpilot/selfdrive/ui/mici/widgets/button.py
@@ -155,9 +155,10 @@ class BigButton(Widget):
     return int(self._rect.width - self.LABEL_HORIZONTAL_PADDING * 2 - icon_size)
 
   def _subtitle_width_hint(self) -> int:
-    # Bottom aligned, so it sits below the icon
+    # Single line if scrolling, so hide behind icon if exists
     # TODO: detect when value wraps with icon to reduce width
-    return int(self._rect.width - self.LABEL_HORIZONTAL_PADDING * 2)
+    icon_size = self._txt_icon.width if self._txt_icon and self._scroll and self.value else 0
+    return int(self._rect.width - self.LABEL_HORIZONTAL_PADDING * 2 - icon_size)
 
   def _get_label_font_size(self):
     if len(self.text) <= 18:
@@ -321,7 +322,6 @@ class BigMultiToggle(BigToggle):
     return int(self._rect.width - self.LABEL_HORIZONTAL_PADDING * 2 - self._txt_enabled_toggle.width)
 
   def _subtitle_width_hint(self) -> int:
-    # Pills stack down the right side, so the value has to make room for them too
     return self._title_width_hint()
 
   def _handle_mouse_release(self, mouse_pos: MousePos):
@@ -371,6 +371,12 @@ class GreyBigButton(BigButton):
   @property
   def LABEL_VERTICAL_PADDING(self):
     return BigButton.LABEL_VERTICAL_PADDING if self._label.text else 18
+
+  def _title_width_hint(self) -> int:
+    return int(self._rect.width - self.LABEL_HORIZONTAL_PADDING * 2)
+
+  def _subtitle_width_hint(self) -> int:
+    return self._title_width_hint()
 
   def _get_label_font_size(self):
     return 36

--- a/openpilot/selfdrive/ui/mici/widgets/button.py
+++ b/openpilot/selfdrive/ui/mici/widgets/button.py
@@ -106,6 +106,7 @@ class BigCircleToggle(BigCircleButton):
 class BigButton(Widget):
   LABEL_HORIZONTAL_PADDING = 40
   LABEL_VERTICAL_PADDING = 23  # visually matches 30 in figma
+  ICON_PADDING = 30
 
   """A lightweight stand-in for the Qt BigButton, drawn & updated each frame."""
 
@@ -160,8 +161,20 @@ class BigButton(Widget):
     return int(self._rect.width - self.LABEL_HORIZONTAL_PADDING * 2 - icon_size)
 
   def _subtitle_width_hint(self) -> int:
-    # Bottom aligned and the title takes the icon's row, so it never needs to make room for the icon
-    return int(self._rect.width - self.LABEL_HORIZONTAL_PADDING * 2)
+    # Bottom aligned, so it usually sits below the icon and can use the full width
+    width = int(self._rect.width - self.LABEL_HORIZONTAL_PADDING * 2)
+    if not self._txt_icon:
+      return width
+
+    # A tall enough value grows up into the icon, so keep it out of the icon's column instead
+    title_height = self._label.get_content_height(self._title_width_hint())
+    available_height = self._rect.height - self.LABEL_VERTICAL_PADDING * 2 - title_height
+    value_height = min(self._sub_label.get_content_height(width), available_height)
+    value_top = self._rect.height - self.LABEL_VERTICAL_PADDING - value_height
+    if value_top >= self.ICON_PADDING + self._txt_icon.height:
+      return width
+
+    return width - self._txt_icon.width
 
   def _get_label_font_size(self):
     if len(self.text) <= 18:
@@ -253,9 +266,9 @@ class BigButton(Widget):
       if self._rotate_icon_t is not None:
         rotation = (rl.get_time() - self._rotate_icon_t) * 180
 
-      # draw top right with 30px padding
-      x = self._rect.x + self._rect.width - 30 - self._txt_icon.width / 2
-      y = btn_y + 30 + self._txt_icon.height / 2
+      # draw top right
+      x = self._rect.x + self._rect.width - self.ICON_PADDING - self._txt_icon.width / 2
+      y = btn_y + self.ICON_PADDING + self._txt_icon.height / 2
       source_rec = rl.Rectangle(0, 0, self._txt_icon.width, self._txt_icon.height)
       dest_rec = rl.Rectangle(x, y, self._txt_icon.width, self._txt_icon.height)
       origin = rl.Vector2(self._txt_icon.width / 2, self._txt_icon.height / 2)

--- a/openpilot/selfdrive/ui/mici/widgets/button.py
+++ b/openpilot/selfdrive/ui/mici/widgets/button.py
@@ -106,7 +106,6 @@ class BigCircleToggle(BigCircleButton):
 class BigButton(Widget):
   LABEL_HORIZONTAL_PADDING = 40
   LABEL_VERTICAL_PADDING = 23  # visually matches 30 in figma
-  ICON_PADDING = 30
 
   """A lightweight stand-in for the Qt BigButton, drawn & updated each frame."""
 
@@ -161,20 +160,8 @@ class BigButton(Widget):
     return int(self._rect.width - self.LABEL_HORIZONTAL_PADDING * 2 - icon_size)
 
   def _subtitle_width_hint(self) -> int:
-    # Bottom aligned, so it usually sits below the icon and can use the full width
-    width = int(self._rect.width - self.LABEL_HORIZONTAL_PADDING * 2)
-    if not self._txt_icon:
-      return width
-
-    # A tall enough value grows up into the icon, so keep it out of the icon's column instead
-    title_height = self._label.get_content_height(self._title_width_hint())
-    available_height = self._rect.height - self.LABEL_VERTICAL_PADDING * 2 - title_height
-    value_height = min(self._sub_label.get_content_height(width), available_height)
-    value_top = self._rect.height - self.LABEL_VERTICAL_PADDING - value_height
-    if value_top >= self.ICON_PADDING + self._txt_icon.height:
-      return width
-
-    return width - self._txt_icon.width
+    # Bottom aligned, so it sits below the icon
+    return int(self._rect.width - self.LABEL_HORIZONTAL_PADDING * 2)
 
   def _get_label_font_size(self):
     if len(self.text) <= 18:
@@ -266,9 +253,9 @@ class BigButton(Widget):
       if self._rotate_icon_t is not None:
         rotation = (rl.get_time() - self._rotate_icon_t) * 180
 
-      # draw top right
-      x = self._rect.x + self._rect.width - self.ICON_PADDING - self._txt_icon.width / 2
-      y = btn_y + self.ICON_PADDING + self._txt_icon.height / 2
+      # draw top right with 30px padding
+      x = self._rect.x + self._rect.width - 30 - self._txt_icon.width / 2
+      y = btn_y + 30 + self._txt_icon.height / 2
       source_rec = rl.Rectangle(0, 0, self._txt_icon.width, self._txt_icon.height)
       dest_rec = rl.Rectangle(x, y, self._txt_icon.width, self._txt_icon.height)
       origin = rl.Vector2(self._txt_icon.width / 2, self._txt_icon.height / 2)

--- a/openpilot/selfdrive/ui/mici/widgets/button.py
+++ b/openpilot/selfdrive/ui/mici/widgets/button.py
@@ -150,8 +150,8 @@ class BigButton(Widget):
     super().set_touch_valid_callback(lambda: touch_callback() and self._grow_animation_until is None)
 
   def _width_hint(self) -> int:
-    # A value moves the title to the top, where it shares space with the icon.
-    icon_size = self._txt_icon.width if self._txt_icon and self.value else 0
+    # Single line if scrolling, so hide behind icon if exists
+    icon_size = self._txt_icon.width if self._txt_icon and self._scroll and self.value else 0
     return int(self._rect.width - self.LABEL_HORIZONTAL_PADDING * 2 - icon_size)
 
   def _get_label_font_size(self):

--- a/openpilot/selfdrive/ui/mici/widgets/button.py
+++ b/openpilot/selfdrive/ui/mici/widgets/button.py
@@ -150,12 +150,13 @@ class BigButton(Widget):
     super().set_touch_valid_callback(lambda: touch_callback() and self._grow_animation_until is None)
 
   def _title_width_hint(self) -> int:
-    # Single line if scrolling, so hide behind icon if exists
-    icon_size = self._txt_icon.width if self._txt_icon and self._scroll and self.value else 0
+    # A value moves the title to the top, where it shares space with the icon
+    icon_size = self._txt_icon.width if self._txt_icon and self.value else 0
     return int(self._rect.width - self.LABEL_HORIZONTAL_PADDING * 2 - icon_size)
 
   def _subtitle_width_hint(self) -> int:
     # Bottom aligned, so it sits below the icon
+    # TODO: detect when value wraps with icon to reduce width
     return int(self._rect.width - self.LABEL_HORIZONTAL_PADDING * 2)
 
   def _get_label_font_size(self):

--- a/openpilot/selfdrive/ui/mici/widgets/button.py
+++ b/openpilot/selfdrive/ui/mici/widgets/button.py
@@ -149,10 +149,19 @@ class BigButton(Widget):
   def set_touch_valid_callback(self, touch_callback: Callable[[], bool]) -> None:
     super().set_touch_valid_callback(lambda: touch_callback() and self._grow_animation_until is None)
 
-  def _width_hint(self) -> int:
+  # def _width_hint(self) -> int:
+  #   # Single line if scrolling, so hide behind icon if exists
+  #   icon_size = self._txt_icon.width if self._txt_icon and self.value else 0
+  #   return int(self._rect.width - self.LABEL_HORIZONTAL_PADDING * 2 - icon_size)
+
+  def _title_width_hint(self) -> int:
     # Single line if scrolling, so hide behind icon if exists
     icon_size = self._txt_icon.width if self._txt_icon and self._scroll and self.value else 0
     return int(self._rect.width - self.LABEL_HORIZONTAL_PADDING * 2 - icon_size)
+
+  def _subtitle_width_hint(self) -> int:
+    # Bottom aligned and the title takes the icon's row, so it never needs to make room for the icon
+    return int(self._rect.width - self.LABEL_HORIZONTAL_PADDING * 2)
 
   def _get_label_font_size(self):
     if len(self.text) <= 18:
@@ -228,14 +237,14 @@ class BigButton(Widget):
 
     label_color = LABEL_COLOR if self.enabled else rl.Color(255, 255, 255, int(255 * 0.35))
     self._label.set_color(label_color)
-    label_rect = rl.Rectangle(label_x, btn_y + self.LABEL_VERTICAL_PADDING, self._width_hint(),
+    label_rect = rl.Rectangle(label_x, btn_y + self.LABEL_VERTICAL_PADDING, self._title_width_hint(),
                               self._rect.height - self.LABEL_VERTICAL_PADDING * 2)
     self._label.render(label_rect)
 
     if self.value:
-      label_y = btn_y + self.LABEL_VERTICAL_PADDING + self._label.get_content_height(self._width_hint())
+      label_y = btn_y + self.LABEL_VERTICAL_PADDING + self._label.get_content_height(self._title_width_hint())
       sub_label_height = btn_y + self._rect.height - self.LABEL_VERTICAL_PADDING - label_y
-      sub_label_rect = rl.Rectangle(label_x, label_y, self._width_hint(), sub_label_height)
+      sub_label_rect = rl.Rectangle(label_x, label_y, self._subtitle_width_hint(), sub_label_height)
       self._sub_label.render(sub_label_rect)
 
     # ICON -------------------------------------------------------------------
@@ -312,8 +321,12 @@ class BigMultiToggle(BigToggle):
 
     self.set_value(self._options[0])
 
-  def _width_hint(self) -> int:
+  def _title_width_hint(self) -> int:
     return int(self._rect.width - self.LABEL_HORIZONTAL_PADDING * 2 - self._txt_enabled_toggle.width)
+
+  def _subtitle_width_hint(self) -> int:
+    # Pills stack down the right side, so the value has to make room for them too
+    return self._title_width_hint()
 
   def _handle_mouse_release(self, mouse_pos: MousePos):
     super()._handle_mouse_release(mouse_pos)
@@ -362,9 +375,6 @@ class GreyBigButton(BigButton):
   @property
   def LABEL_VERTICAL_PADDING(self):
     return BigButton.LABEL_VERTICAL_PADDING if self._label.text else 18
-
-  def _width_hint(self) -> int:
-    return int(self._rect.width - self.LABEL_HORIZONTAL_PADDING * 2)
 
   def _get_label_font_size(self):
     return 36

--- a/openpilot/selfdrive/ui/mici/widgets/button.py
+++ b/openpilot/selfdrive/ui/mici/widgets/button.py
@@ -149,11 +149,6 @@ class BigButton(Widget):
   def set_touch_valid_callback(self, touch_callback: Callable[[], bool]) -> None:
     super().set_touch_valid_callback(lambda: touch_callback() and self._grow_animation_until is None)
 
-  # def _width_hint(self) -> int:
-  #   # Single line if scrolling, so hide behind icon if exists
-  #   icon_size = self._txt_icon.width if self._txt_icon and self.value else 0
-  #   return int(self._rect.width - self.LABEL_HORIZONTAL_PADDING * 2 - icon_size)
-
   def _title_width_hint(self) -> int:
     # Single line if scrolling, so hide behind icon if exists
     icon_size = self._txt_icon.width if self._txt_icon and self._scroll and self.value else 0


### PR DESCRIPTION
Title and subtitle need different width hint, depending on how many subtitle lines there is. https://github.com/commaai/openpilot/pull/38628

these kinds of subtitles can go past icon:

<img width="535" height="241" alt="image" src="https://github.com/user-attachments/assets/43ea626c-ab8f-479a-9b8b-f704a7324765" />
