### PR TITLE
webrtc: fix message handler race

### DIFF
--- a/openpilot/system/webrtc/webrtcd.py
+++ b/openpilot/system/webrtc/webrtcd.py
@@ -335,9 +335,12 @@ class StreamSession:
   async def run(self):
     try:
       self.params.put("LivestreamRequestKeyframe", True)
+
+      # avoid datachannel race by adding messange_handler immediately
+      self.stream.set_message_handler(self.message_handler)
+
       await asyncio.wait_for(self.stream.wait_for_connection(), timeout=15)
       if self.stream.has_messaging_channel():
-        self.stream.set_message_handler(self.message_handler)
         if self.incoming_bridge is not None:
           await self.shared_pub_master.add_services_if_needed(self.incoming_bridge_services)
         if self.outgoing_bridge is not None:


### PR DESCRIPTION
there are messages exchanged immediately after connection which can lead to them being missed by the message handler.

this very rarely could lead to a black screen when opening the livestream on a cold start. this was tested with a modified webrtc latency test in connect that would wait 10 seconds for the device to go back to hibernation state and then cold connect again.