### PR TITLE
webrtcd/athenad: we don't have to fail on no car params

### DIFF
--- a/openpilot/system/athena/athenad.py
+++ b/openpilot/system/athena/athenad.py
@@ -800,8 +800,6 @@ def startStream(sdp: str, enabled: bool) -> dict:
     with car.CarParams.from_bytes(cp_bytes) as CP:
       if CP.notCar:
         bridge_services_in.append("testJoystick")
-  else:
-    raise Exception("failed to get CarParamsPersistent")
 
   if params.get_bool("IsOffroad"):
     # manager owns camerad/stream_encoderd/webrtcd; flip the param and let it bring them up.


### PR DESCRIPTION
we don't have to fail when no car params are found, we just have to not give testJoystick.

this was causing livestream to fail on fresh install that hadn't had 1 route yet.