### PR TITLE
logreader: read segments in order, not discovery order

### DIFF
--- a/openpilot/tools/lib/logreader.py
+++ b/openpilot/tools/lib/logreader.py
@@ -179,7 +179,7 @@ def auto_source(identifier: str, sources: list[Source], default_mode: ReadMode) 
 
         # We've found all files, return them
         if len(needed_seg_idxs) == 0:
-          return list(valid_files.values())
+          return [valid_files[idx] for idx in sorted(valid_files)]
         else:
           raise FileNotFoundError(f"Did not find {fn} for seg idxs {needed_seg_idxs} of {sr.route_name}")
 

--- a/openpilot/tools/lib/tests/test_logreader.py
+++ b/openpilot/tools/lib/tests/test_logreader.py
@@ -11,7 +11,7 @@ from openpilot.common.test import OpenpilotTestCase
 from openpilot.common.parameterized import parameterized
 
 from openpilot.cereal import log as capnp_log
-from openpilot.tools.lib.logreader import _LogFileReader, LogsUnavailable, LogIterable, LogReader, parse_indirect, ReadMode
+from openpilot.tools.lib.logreader import _LogFileReader, LogsUnavailable, LogIterable, LogReader, auto_source, parse_indirect, ReadMode
 from openpilot.tools.lib.file_sources import InternalUnavailableException
 from openpilot.tools.lib.route import FileName, SegmentRange
 from openpilot.tools.lib.url_file import URLFileException
@@ -250,6 +250,17 @@ class TestLogReader(OpenpilotTestCase):
       lr = LogReader(f"{TEST_ROUTE}/3/q")
       log_len = len(list(lr))
       assert qlog_len == log_len
+
+  def test_auto_source_returns_segments_in_order(self):
+    # The rlog pass skips the middle segment and the qlog fallback fills it last.
+    # The late arrival must land in segment order, not at the end of the list.
+    def rlog_missing_middle(sr, seg_idxs, fns):
+      if fns == FileName.RLOG:
+        return {idx: f"rlog{idx}" for idx in seg_idxs if idx != 2}
+      return {idx: f"qlog{idx}" for idx in seg_idxs}
+
+    files = auto_source(f"{TEST_ROUTE}/0:5", [rlog_missing_middle], ReadMode.AUTO)
+    assert files == ["rlog0", "rlog1", "qlog2", "rlog3", "rlog4"]
 
   def test_sort_by_time(self):
     msgs = list(LogReader(self.qlog_path))


### PR DESCRIPTION
**Description**

`auto_source` accumulates `valid_files: dict[int, str]` across two nested loops: filenames (rlog, then qlog) at `logreader.py:169` and sources at `:170`. Each pass prunes `needed_seg_idxs` down to the segments still missing (`:178`), so a later pass only ever adds the gaps, and those entries land at the *end* of the dict. The return handed back `.values()`, which is insertion order, not segment order:

```python
valid_files |= files                                                         # :175
needed_seg_idxs = [idx for idx in needed_seg_idxs if idx not in valid_files]  # :178
if len(needed_seg_idxs) == 0:
  return list(valid_files.values())                                          # :182
```

Whenever a lower-numbered segment is resolved *after* a higher-numbered one, the returned list is out of order. Two ways that happens in normal use:

1. AUTO mode falling back to qlogs. If a middle segment's rlog is missing, the rlog pass returns the segments around it and the qlog pass fills the hole last. This is the path that already logs `"N/M rlogs were not found, falling back to qlogs for those segments..."` (`:192`), so it is an expected case, not an exotic one.
2. Plain RLOG mode, no fallback involved. The default source list is four sources (`:249`) and each returns only the segments it has. If the first source is missing an early segment that a later source supplies, the order is wrong.

`LogReader.__iter__` (`:268`) reads the list in the order given, so segments come out shuffled and `logMonoTime` moves backwards across segment boundaries. `sort_by_time` does not cover this: it sorts `self._ents` within a single file (`:120`).

The existing tests cannot observe it. `local_source` and `local_auto_source` return the same path for every segment via `dict.fromkeys` (`test_logreader.py:84`, `:89`), so ordering is invisible, and `local_auto_source` returns `{}` for rlogs, which makes the qlog pass fill every segment in one call and therefore in order. `test_sort_by_time` (`:254`) reads a single file.

Fix: return the files ordered by segment index. `seg_idxs` is always ascending, since a descending slice always evaluates to empty (`10:0:-1` and `0:6:-2` both give `[]`), so this is exactly the requested order and can never reorder a valid request.

**Verification**

Three segments where segment 1 has no rlog, resolved through a fake source, so no network or device is needed:

```
before: ['seg0/rlog.zst', 'seg2/rlog.zst', 'seg1/qlog.zst']
after:  ['seg0/rlog.zst', 'seg1/qlog.zst', 'seg2/rlog.zst']
```

End to end, same setup with real logs written by `save_log` and read back through `LogReader(..., sort_by_time=True)`:

```
before: logMonoTime [0, 2000000000, 1000000000]   # time goes backwards 1s
after:  logMonoTime [0, 1000000000, 2000000000]
```

Also reproduced with no qlog fallback at all: two rlog-only sources, the first holding segments 1 and 2 and the second holding segment 0, returned `[seg1, seg2, seg0]` before and `[seg0, seg1, seg2]` after.

`openpilot/tools/lib/tests/test_logreader.py`: 56 tests pass (22 skipped, network). `ruff`, `ty`, and `codespell` clean.
