### PR TITLE
selfdrived: prioritize process failure alerts

### DIFF
--- a/openpilot/selfdrive/selfdrived/events.py
+++ b/openpilot/selfdrive/selfdrived/events.py
@@ -287,7 +287,7 @@ def posenet_invalid_alert(CP: car.CarParams, CS: car.CarState, sm: messaging.Sub
 def process_not_running_alert(CP: car.CarParams, CS: car.CarState, sm: messaging.SubMaster, metric: bool, soft_disable_time: int, personality) -> Alert:
   not_running = [p.name for p in sm['managerState'].processes if not p.running and p.shouldBeRunning]
   msg = ', '.join(not_running)
-  return NoEntryAlert(msg, alert_text_1="Process Not Running")
+  return NoEntryAlert(msg, alert_text_1="Process Not Running", priority=Priority.HIGH)
 
 
 def comm_issue_alert(CP: car.CarParams, CS: car.CarState, sm: messaging.SubMaster, metric: bool, soft_disable_time: int, personality) -> Alert:

--- a/openpilot/selfdrive/selfdrived/tests/test_alerts.py
+++ b/openpilot/selfdrive/selfdrived/tests/test_alerts.py
@@ -70,6 +70,14 @@ class TestAlerts(OpenpilotTestCase):
         if event_type not in (ET.WARNING, ET.PERMANENT, ET.PRE_ENABLE):
           assert a.creation_delay == 0.
 
+  def test_process_not_running_alert_has_priority(self):
+    process_alert = EVENTS[log.OnroadEvent.EventName.processNotRunning][ET.NO_ENTRY](
+      self.CP, self.CS, self.sm, False, 0, None,
+    )
+    steer_alert = EVENTS[log.OnroadEvent.EventName.steerUnavailable][ET.NO_ENTRY]
+
+    assert process_alert.priority > steer_alert.priority
+
   def test_offroad_alerts(self):
     params = Params()
     for a in self.offroad_alerts:

--- a/openpilot/selfdrive/selfdrived/tests/test_alerts.py
+++ b/openpilot/selfdrive/selfdrived/tests/test_alerts.py
@@ -9,7 +9,7 @@ from opendbc.car.structs import car
 from openpilot.cereal.messaging import SubMaster
 from openpilot.common.basedir import BASEDIR
 from openpilot.common.params import Params
-from openpilot.selfdrive.selfdrived.events import Alert, EVENTS, ET
+from openpilot.selfdrive.selfdrived.events import Alert, EVENTS, ET, process_not_running_alert
 from openpilot.selfdrive.selfdrived.alertmanager import set_offroad_alert
 from openpilot.selfdrive.test.process_replay.process_replay import CONFIGS
 
@@ -71,9 +71,7 @@ class TestAlerts(OpenpilotTestCase):
           assert a.creation_delay == 0.
 
   def test_process_not_running_alert_has_priority(self):
-    process_alert = EVENTS[log.OnroadEvent.EventName.processNotRunning][ET.NO_ENTRY](
-      self.CP, self.CS, self.sm, False, 0, None,
-    )
+    process_alert = process_not_running_alert(self.CP, self.CS, self.sm, False, 0, None)
     steer_alert = EVENTS[log.OnroadEvent.EventName.steerUnavailable][ET.NO_ENTRY]
 
     assert process_alert.priority > steer_alert.priority


### PR DESCRIPTION
## Summary

- raise the process-not-running no-entry alert priority so a root process failure is not hidden by secondary vehicle faults
- add regression coverage ensuring it outranks the LKAS unavailable alert

Fixes #34751

## Test plan

- `pytest -q openpilot/selfdrive/selfdrived/tests/test_alerts.py::TestAlerts::test_process_not_running_alert_has_priority openpilot/selfdrive/selfdrived/tests/test_alertmanager.py` (2 passed)
- `ruff check openpilot/selfdrive/selfdrived/events.py openpilot/selfdrive/selfdrived/tests/test_alerts.py`

