### PR TITLE
hardwared: handle failed thermal reads

### DIFF
--- a/openpilot/common/hardware/base.py
+++ b/openpilot/common/hardware/base.py
@@ -1,3 +1,4 @@
+import math
 import os
 from abc import abstractmethod, ABC
 from dataclasses import dataclass, fields
@@ -16,20 +17,20 @@ class ThermalZone:
   zone_number = -1
 
   def read(self) -> float:
-    if self.zone_number < 0:
-      for n in os.listdir("/sys/devices/virtual/thermal"):
-        if not n.startswith("thermal_zone"):
-          continue
-        with open(os.path.join("/sys/devices/virtual/thermal", n, "type")) as f:
-          if f.read().strip() == self.name:
-            self.zone_number = int(n.removeprefix("thermal_zone"))
-            break
-
     try:
+      if self.zone_number < 0:
+        for n in os.listdir("/sys/devices/virtual/thermal"):
+          if not n.startswith("thermal_zone"):
+            continue
+          with open(os.path.join("/sys/devices/virtual/thermal", n, "type")) as f:
+            if f.read().strip() == self.name:
+              self.zone_number = int(n.removeprefix("thermal_zone"))
+              break
+
       with open(f"/sys/devices/virtual/thermal/thermal_zone{self.zone_number}/temp") as f:
         return int(f.read()) / self.scale
-    except FileNotFoundError:
-      return 0
+    except (OSError, ValueError):
+      return math.nan
 
 @dataclass
 class ThermalConfig:

--- a/openpilot/system/hardware/hardwared.py
+++ b/openpilot/system/hardware/hardwared.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import fcntl
+import math
 import os
 import queue
 import struct
@@ -100,6 +101,9 @@ OFFROAD_DANGER_TEMP = 85 if HARDWARE.get_device_type() == "mici" else 75
 
 prev_offroad_states: dict[str, tuple[bool, str | None]] = {}
 
+
+def max_valid_temperature(temperatures: list[float]) -> float:
+  return max((t for t in temperatures if math.isfinite(t)), default=0.)
 
 
 def set_offroad_alert_if_changed(offroad_alert: str, show_alert: bool, extra_text: str | None=None):
@@ -303,16 +307,12 @@ def hardware_thread(end_event, hw_queue) -> None:
     set_offroad_alert_if_changed("Offroad_ChestnutBranch", msg.deviceState.chestnutPresent and not big_model_available)
 
     # this subset is only used for offroad
-    temp_sources = [
-      msg.deviceState.memoryTempC,
-      max(msg.deviceState.cpuTempC, default=0.),
-      max(msg.deviceState.gpuTempC, default=0.),
-    ]
-    offroad_comp_temp = offroad_temp_filter.update(max(temp_sources))
+    temp_sources = [msg.deviceState.memoryTempC, *msg.deviceState.cpuTempC, *msg.deviceState.gpuTempC]
+    offroad_comp_temp = offroad_temp_filter.update(max_valid_temperature(temp_sources))
 
     # this drives the thermal status while onroad
-    temp_sources.append(max(msg.deviceState.pmicTempC, default=0.))
-    all_comp_temp = all_temp_filter.update(max(temp_sources))
+    temp_sources.extend(msg.deviceState.pmicTempC)
+    all_comp_temp = all_temp_filter.update(max_valid_temperature(temp_sources))
     msg.deviceState.maxTempC = all_comp_temp
 
     msg.deviceState.fanSpeedPercentDesired = fan_controller.update(all_comp_temp, onroad_conditions["ignition"])

--- a/openpilot/system/hardware/tests/test_hardwared.py
+++ b/openpilot/system/hardware/tests/test_hardwared.py
@@ -1,40 +1,37 @@
 import errno
 import math
+import unittest
 from unittest.mock import mock_open, patch
-
-import pytest
 
 from openpilot.common.hardware.base import ThermalZone
 from openpilot.system.hardware.hardwared import max_valid_temperature
 
 
-class TestThermalZone:
+class TestThermalZone(unittest.TestCase):
   def test_read(self):
     zone = ThermalZone("cpu", scale=1000.)
     zone.zone_number = 2
     with patch("builtins.open", mock_open(read_data="42500")):
       assert zone.read() == 42.5
 
-  @pytest.mark.parametrize("error", [
-    OSError(errno.EIO, "I/O error"),
-    FileNotFoundError(),
-    ValueError(),
-  ])
-  def test_read_failure(self, error):
-    zone = ThermalZone("cpu")
-    zone.zone_number = 2
-    with patch("builtins.open", side_effect=error):
-      assert math.isnan(zone.read())
+  def test_read_failure(self):
+    for error in (OSError(errno.EIO, "I/O error"), FileNotFoundError(), ValueError()):
+      with self.subTest(error=error):
+        zone = ThermalZone("cpu")
+        zone.zone_number = 2
+        with patch("builtins.open", side_effect=error):
+          assert math.isnan(zone.read())
 
   def test_discovery_failure(self):
     with patch("os.listdir", side_effect=OSError(errno.EIO, "I/O error")):
       assert math.isnan(ThermalZone("cpu").read())
 
-
-@pytest.mark.parametrize(("temperatures", "expected"), [
-  ([math.nan, 50., 42.], 50.),
-  ([math.nan, math.nan], 0.),
-  ([], 0.),
-])
-def test_max_valid_temperature(temperatures, expected):
-  assert max_valid_temperature(temperatures) == expected
+  def test_max_valid_temperature(self):
+    cases = (
+      ([math.nan, 50., 42.], 50.),
+      ([math.nan, math.nan], 0.),
+      ([], 0.),
+    )
+    for temperatures, expected in cases:
+      with self.subTest(temperatures=temperatures):
+        assert max_valid_temperature(temperatures) == expected

--- a/openpilot/system/hardware/tests/test_hardwared.py
+++ b/openpilot/system/hardware/tests/test_hardwared.py
@@ -1,0 +1,40 @@
+import errno
+import math
+from unittest.mock import mock_open, patch
+
+import pytest
+
+from openpilot.common.hardware.base import ThermalZone
+from openpilot.system.hardware.hardwared import max_valid_temperature
+
+
+class TestThermalZone:
+  def test_read(self):
+    zone = ThermalZone("cpu", scale=1000.)
+    zone.zone_number = 2
+    with patch("builtins.open", mock_open(read_data="42500")):
+      assert zone.read() == 42.5
+
+  @pytest.mark.parametrize("error", [
+    OSError(errno.EIO, "I/O error"),
+    FileNotFoundError(),
+    ValueError(),
+  ])
+  def test_read_failure(self, error):
+    zone = ThermalZone("cpu")
+    zone.zone_number = 2
+    with patch("builtins.open", side_effect=error):
+      assert math.isnan(zone.read())
+
+  def test_discovery_failure(self):
+    with patch("os.listdir", side_effect=OSError(errno.EIO, "I/O error")):
+      assert math.isnan(ThermalZone("cpu").read())
+
+
+@pytest.mark.parametrize(("temperatures", "expected"), [
+  ([math.nan, 50., 42.], 50.),
+  ([math.nan, math.nan], 0.),
+  ([], 0.),
+])
+def test_max_valid_temperature(temperatures, expected):
+  assert max_valid_temperature(temperatures) == expected


### PR DESCRIPTION
## Summary

- report failed thermal-zone reads as NaN instead of crashing hardwared
- exclude non-finite sensor values when calculating control temperatures
- add regression coverage for valid reads, I/O failures, missing files, malformed values, discovery failures, and temperature aggregation

Fixes #36690

## Test plan

- `pytest -q openpilot/system/hardware/tests/test_hardwared.py` (8 passed)
- `ruff check openpilot/common/hardware/base.py openpilot/system/hardware/hardwared.py openpilot/system/hardware/tests/test_hardwared.py`

