### PR TITLE
sim: make the MetaDrive bridge work on macOS

### DIFF
--- a/openpilot/tools/sim/README.md
+++ b/openpilot/tools/sim/README.md
@@ -43,8 +43,25 @@ options:
 
 ## MetaDrive
 
+### Installing MetaDrive
+MetaDrive isn't part of the default dependencies yet, so install it into the openpilot venv:
+``` bash
+uv pip install "metadrive-simulator @ git+https://github.com/commaai/metadrive.git@minimal"
+```
+
 ### Launching Metadrive
 Start bridge processes located in openpilot/tools/sim:
 ``` bash
 ./run_bridge.py
 ```
+
+### macOS
+The bridge runs on Apple silicon. Two things to know:
+
+* Apple's OpenGL driver only exposes 4.1 through a core profile, so the bridge asks panda3d
+  for `gl-version 4 1 core` with the `pandagl` display. MetaDrive's shaders have to compile
+  under GLSL 3.30+ for the camera feeds to render; if you get black frames, make sure you're
+  on a MetaDrive revision with the macOS shader fixes.
+* The simulator processes are started with the `spawn` start method everywhere, since an
+  OpenGL context can't be inherited through `fork()`. Anything you add that's shared with a
+  sim process must be created from `openpilot.tools.sim.lib.common.SIM_MP_CTX`.

--- a/openpilot/tools/sim/bridge/common.py
+++ b/openpilot/tools/sim/bridge/common.py
@@ -5,13 +5,13 @@ import numpy as np
 
 from collections import namedtuple
 from enum import Enum
-from multiprocessing import Process, Queue, Value
+from multiprocessing import Queue
 from abc import ABC, abstractmethod
 from opendbc.car.honda.values import CruiseButtons
 from openpilot.common.params import Params
 from openpilot.common.realtime import Ratekeeper
 from openpilot.selfdrive.test.helpers import set_params_enabled
-from openpilot.tools.sim.lib.common import SimulatorState, World
+from openpilot.tools.sim.lib.common import SIM_MP_CTX, SimulatorState, World
 from openpilot.tools.sim.lib.simulated_car import SimulatedCar
 from openpilot.tools.sim.lib.simulated_sensors import SimulatedSensors
 
@@ -49,8 +49,7 @@ class SimulatorBridge(ABC):
     self._exit_event: threading.Event | None = None
     self._threads = []
     self._keep_alive = True
-    self.started = Value('i', False)
-    signal.signal(signal.SIGTERM, self._on_shutdown)
+    self.started = SIM_MP_CTX.Value('i', False)
     self.simulator_state = SimulatorState()
 
     self.world: World | None = None
@@ -60,6 +59,18 @@ class SimulatorBridge(ABC):
 
     self.test_run = False
 
+  def __getstate__(self):
+    # the bridge is pickled to reach the spawned bridge process, and these are either
+    # unpicklable or owned by whichever process runs the bridge loop
+    return {k: v for k, v in self.__dict__.items() if k not in ("params", "world", "_exit_event", "_threads")}
+
+  def __setstate__(self, state):
+    self.__dict__.update(state)
+    self.params = Params()
+    self.world = None
+    self._exit_event = None
+    self._threads = []
+
   def _on_shutdown(self, signal, frame):
     self.shutdown()
 
@@ -67,6 +78,7 @@ class SimulatorBridge(ABC):
     self._keep_alive = False
 
   def bridge_keep_alive(self, q: Queue, retries: int):
+    signal.signal(signal.SIGTERM, self._on_shutdown)
     try:
       self._run(q)
     finally:
@@ -82,7 +94,7 @@ class SimulatorBridge(ABC):
       self.world.close(reason)
 
   def run(self, queue, retries=-1):
-    bridge_p = Process(name="bridge", target=self.bridge_keep_alive, args=(queue, retries))
+    bridge_p = SIM_MP_CTX.Process(name="bridge", target=self.bridge_keep_alive, args=(queue, retries))
     bridge_p.start()
     return bridge_p
 

--- a/openpilot/tools/sim/bridge/metadrive/metadrive_process.py
+++ b/openpilot/tools/sim/bridge/metadrive/metadrive_process.py
@@ -1,9 +1,10 @@
 import math
+import sys
 import time
 import numpy as np
 
 from collections import namedtuple
-from panda3d.core import Vec3
+from panda3d.core import Vec3, loadPrcFileData
 from multiprocessing.connection import Connection
 
 from metadrive.engine.core.engine_core import EngineCore
@@ -48,10 +49,22 @@ def apply_metadrive_patches(arrive_dest_done=True):
   if not arrive_dest_done:
     MetaDriveEnv._is_arrive_destination = arrive_destination_patch
 
+def apply_panda3d_config():
+  if sys.platform != "darwin":
+    return
+
+  # macOS only exposes OpenGL 4.1 through a core profile, and the GLSL metadrive ships needs
+  # at least 3.30. without this panda3d falls back to a 2.1 compatibility context and every
+  # shader fails to compile, leaving the camera feeds black.
+  loadPrcFileData("", "load-display pandagl")
+  loadPrcFileData("", "gl-version 4 1 core")
+
 def metadrive_process(dual_camera: bool, config: dict, camera_array, wide_camera_array, image_lock,
                       controls_recv: Connection, simulation_state_send: Connection, vehicle_state_send: Connection,
                       exit_event, op_engaged, test_duration, test_run):
+  config = dict(config)
   arrive_dest_done = config.pop("arrive_dest_done", True)
+  apply_panda3d_config()
   apply_metadrive_patches(arrive_dest_done)
 
   road_image = np.frombuffer(camera_array.get_obj(), dtype=np.uint8).reshape((H, W, 3))

--- a/openpilot/tools/sim/bridge/metadrive/metadrive_world.py
+++ b/openpilot/tools/sim/bridge/metadrive/metadrive_world.py
@@ -1,15 +1,12 @@
 import ctypes
 import functools
-import multiprocessing
 import numpy as np
 import time
-
-from multiprocessing import Pipe, Array
 
 from openpilot.tools.sim.bridge.common import QueueMessage, QueueMessageType
 from openpilot.tools.sim.bridge.metadrive.metadrive_process import (metadrive_process, metadrive_simulation_state,
                                                                     metadrive_vehicle_state)
-from openpilot.tools.sim.lib.common import SimulatorState, World
+from openpilot.tools.sim.lib.common import SIM_MP_CTX, SimulatorState, World
 from openpilot.tools.sim.lib.camerad import W, H
 
 
@@ -17,19 +14,19 @@ class MetaDriveWorld(World):
   def __init__(self, status_q, config, test_duration, test_run, dual_camera=False):
     super().__init__(dual_camera)
     self.status_q = status_q
-    self.camera_array = Array(ctypes.c_uint8, W*H*3)
+    self.camera_array = SIM_MP_CTX.Array(ctypes.c_uint8, W*H*3)
     self.road_image = np.frombuffer(self.camera_array.get_obj(), dtype=np.uint8).reshape((H, W, 3))
     self.wide_camera_array = None
     if dual_camera:
-      self.wide_camera_array = Array(ctypes.c_uint8, W*H*3)
+      self.wide_camera_array = SIM_MP_CTX.Array(ctypes.c_uint8, W*H*3)
       self.wide_road_image = np.frombuffer(self.wide_camera_array.get_obj(), dtype=np.uint8).reshape((H, W, 3))
 
-    self.controls_send, self.controls_recv = Pipe()
-    self.simulation_state_send, self.simulation_state_recv = Pipe()
-    self.vehicle_state_send, self.vehicle_state_recv = Pipe()
+    self.controls_send, self.controls_recv = SIM_MP_CTX.Pipe()
+    self.simulation_state_send, self.simulation_state_recv = SIM_MP_CTX.Pipe()
+    self.vehicle_state_send, self.vehicle_state_recv = SIM_MP_CTX.Pipe()
 
-    self.exit_event = multiprocessing.Event()
-    self.op_engaged = multiprocessing.Event()
+    self.exit_event = SIM_MP_CTX.Event()
+    self.op_engaged = SIM_MP_CTX.Event()
 
     self.test_run = test_run
 
@@ -37,7 +34,7 @@ class MetaDriveWorld(World):
     self.last_check_timestamp = 0
     self.distance_moved = 0
 
-    self.metadrive_process = multiprocessing.Process(name="metadrive process", target=
+    self.metadrive_process = SIM_MP_CTX.Process(name="metadrive process", target=
                               functools.partial(metadrive_process, dual_camera, config,
                                                 self.camera_array, self.wide_camera_array, self.image_lock,
                                                 self.controls_recv, self.simulation_state_send,

--- a/openpilot/tools/sim/lib/common.py
+++ b/openpilot/tools/sim/lib/common.py
@@ -7,6 +7,10 @@ from collections import namedtuple
 
 W, H = 1928, 1208
 
+# panda3d/OpenGL contexts can't be inherited across fork(), so the sim always spawns. every
+# object shared with a sim process has to come from this same context.
+SIM_MP_CTX = multiprocessing.get_context("spawn")
+
 
 vec3 = namedtuple("vec3", ["x", "y", "z"])
 
@@ -65,11 +69,11 @@ class World(ABC):
   def __init__(self, dual_camera):
     self.dual_camera = dual_camera
 
-    self.image_lock = multiprocessing.Semaphore(value=0)
+    self.image_lock = SIM_MP_CTX.Semaphore(value=0)
     self.road_image = np.zeros((H, W, 3), dtype=np.uint8)
     self.wide_road_image = np.zeros((H, W, 3), dtype=np.uint8)
 
-    self.exit_event = multiprocessing.Event()
+    self.exit_event = SIM_MP_CTX.Event()
 
   @abstractmethod
   def apply_controls(self, steer_sim, throttle_out, brake_out, /):

--- a/openpilot/tools/sim/run_bridge.py
+++ b/openpilot/tools/sim/run_bridge.py
@@ -2,12 +2,12 @@
 import argparse
 
 from typing import Any
-from multiprocessing import Queue
 
 from openpilot.tools.sim.bridge.metadrive.metadrive_bridge import MetaDriveBridge
+from openpilot.tools.sim.lib.common import SIM_MP_CTX
 
 def create_bridge(dual_camera, high_quality):
-  queue: Any = Queue()
+  queue: Any = SIM_MP_CTX.Queue()
 
   simulator_bridge = MetaDriveBridge(dual_camera, high_quality)
   simulator_process = simulator_bridge.run(queue)

--- a/openpilot/tools/sim/tests/test_sim_bridge.py
+++ b/openpilot/tools/sim/tests/test_sim_bridge.py
@@ -3,12 +3,11 @@ import subprocess
 import time
 import unittest
 
-from multiprocessing import Queue
-
 from openpilot.common.test import OpenpilotTestCase
 from openpilot.cereal import messaging
 from openpilot.common.basedir import BASEDIR
 from openpilot.tools.sim.bridge.common import QueueMessageType
+from openpilot.tools.sim.lib.common import SIM_MP_CTX
 
 SIM_DIR = os.path.join(BASEDIR, "openpilot/tools/sim")
 
@@ -28,7 +27,7 @@ class TestSimBridgeBase(OpenpilotTestCase):
     self.processes.append(p_manager)
 
     sm = messaging.SubMaster(['selfdriveState', 'onroadEvents', 'managerState'])
-    q = Queue()
+    q = SIM_MP_CTX.Queue()
     bridge = self.create_bridge()
     p_bridge = bridge.run(q, retries=10)
     self.processes.append(p_bridge)

--- a/openpilot/tools/sim/tests/test_spawn_safety.py
+++ b/openpilot/tools/sim/tests/test_spawn_safety.py
@@ -1,0 +1,121 @@
+import importlib
+import unittest
+from unittest import mock
+
+import numpy as np
+
+from openpilot.common.test import OpenpilotTestCase
+from openpilot.tools.sim.bridge.common import SimulatorBridge
+from openpilot.tools.sim.lib.camerad import rgb_to_nv12, W, H
+from openpilot.tools.sim.lib.common import SIM_MP_CTX, World
+
+try:
+  metadrive_process = importlib.import_module("openpilot.tools.sim.bridge.metadrive.metadrive_process")
+except ModuleNotFoundError:
+  metadrive_process = None
+
+
+class FakeWorld(World):
+  def apply_controls(self, steer_sim, throttle_out, brake_out, /):
+    pass
+
+  def tick(self):
+    pass
+
+  def read_state(self):
+    pass
+
+  def read_sensors(self, simulator_state, /):
+    pass
+
+  def read_cameras(self):
+    pass
+
+  def close(self, reason: str):
+    pass
+
+  def reset(self):
+    pass
+
+
+class FakeBridge(SimulatorBridge):
+  def spawn_world(self, q, /) -> World:
+    return FakeWorld(self.dual_camera)
+
+
+def _report_state(bridge, world, q):
+  world.exit_event.set()
+  q.put({
+    "cls": type(bridge).__name__,
+    "dual_camera": bridge.dual_camera,
+    "high_quality": bridge.high_quality,
+    "started": bool(bridge.started.value),
+    "has_params": bridge.params is not None,
+    "world": bridge.world,
+    "image_lock": world.image_lock.acquire(timeout=5),
+  })
+
+
+class TestSpawnSafety(OpenpilotTestCase):
+  def test_spawn_start_method(self):
+    # an OpenGL context can't survive fork(), so the sim never relies on the platform default
+    assert SIM_MP_CTX.get_start_method() == "spawn"
+
+  def test_shared_objects_use_sim_context(self):
+    # mixing start methods for shared synchronization primitives is not supported
+    world = FakeWorld(dual_camera=True)
+    assert type(world.image_lock) is type(SIM_MP_CTX.Semaphore(value=0))
+    assert type(world.exit_event) is type(SIM_MP_CTX.Event())
+
+    bridge = FakeBridge(dual_camera=False, high_quality=False)
+    assert type(bridge.started) is type(SIM_MP_CTX.Value('i', False))
+
+  def test_bridge_survives_spawning(self):
+    # the bridge instance is the spawned process' target, so everything it carries has to be
+    # picklable and every shared object has to be inheritable across the spawn
+    bridge = FakeBridge(dual_camera=True, high_quality=False)
+    bridge.started.value = True
+    world = FakeWorld(dual_camera=True)
+    world.image_lock.release()
+
+    q = SIM_MP_CTX.Queue()
+    p = SIM_MP_CTX.Process(target=_report_state, args=(bridge, world, q))
+    p.start()
+    try:
+      state = q.get(timeout=120)
+    finally:
+      p.join(30)
+      p.kill()
+
+    assert p.exitcode == 0
+    assert state == {"cls": "FakeBridge", "dual_camera": True, "high_quality": False, "started": True,
+                     "has_params": True, "world": None, "image_lock": True}
+    assert world.exit_event.is_set()
+
+  def test_rgb_to_nv12_channel_order(self):
+    # the camera readback path has to keep openpilot's RGB layout: a red frame must not end up
+    # looking like a blue one once camerad converts it
+    red = np.zeros((H, W, 3), dtype=np.uint8)
+    red[:, :, 0] = 255
+    blue = np.zeros((H, W, 3), dtype=np.uint8)
+    blue[:, :, 2] = 255
+
+    red_y = np.frombuffer(rgb_to_nv12(red)[:W*H], dtype=np.uint8)
+    blue_y = np.frombuffer(rgb_to_nv12(blue)[:W*H], dtype=np.uint8)
+
+    # BT.601 weighs red about 2.5x heavier than blue
+    assert red_y[0] > blue_y[0]
+    assert np.all(red_y == red_y[0])
+    assert np.all(blue_y == blue_y[0])
+
+  @unittest.skipIf(metadrive_process is None, "metadrive is not installed")
+  def test_macos_panda3d_config(self):
+    from panda3d.core import ConfigVariableString
+
+    assert metadrive_process is not None
+    with mock.patch("sys.platform", "darwin"):
+      metadrive_process.apply_panda3d_config()
+
+    # Apple only exposes GL 4.1, and only through a core profile
+    assert ConfigVariableString("gl-version").getValue() == "4 1 core"
+    assert "pandagl" in ConfigVariableString("load-display").getValue()


### PR DESCRIPTION
## Summary

Fixes the two openpilot-side blockers that keep the MetaDrive bridge from running on macOS (#33207).

**1. Start method.** The bridge and the MetaDrive process were created with the platform default start method. On macOS that's `spawn`, and the code assumed `fork`: `SimulatorBridge` installed its `SIGTERM` handler in `__init__` (in the parent, never in the process that runs the loop) and held a `threading.Event`, thread list and `Params` handle that can't cross a spawn. Rather than special-casing macOS, the sim now always spawns — panda3d/OpenGL contexts can't be inherited across `fork()` anyway, so there's one tested path:

```python
# tools/sim/lib/common.py
SIM_MP_CTX = multiprocessing.get_context("spawn")
```

Everything shared with a sim process now comes from that one context (`Semaphore`, `Event`, `Array`, `Pipe`, `Value`, `Queue`, `Process`) — mixing contexts for synchronization primitives isn't supported. `SimulatorBridge` gained `__getstate__`/`__setstate__` dropping the process-owned attrs, and registers `SIGTERM` inside `bridge_keep_alive` where the loop actually runs. `metadrive_process` copies the config it's handed before `pop`ing from it, since it no longer implicitly gets a copy from fork's COW.

**2. GL context.** Apple's driver only exposes OpenGL 4.1 through a core profile; panda3d otherwise picks a 2.1 compatibility context in which none of MetaDrive's GLSL compiles, and the camera feeds come out black:

```python
# tools/sim/bridge/metadrive/metadrive_process.py, before the engine is created
if sys.platform == "darwin":
  loadPrcFileData("", "load-display pandagl")
  loadPrcFileData("", "gl-version 4 1 core")
```

The remaining piece is on the MetaDrive side — its terrain shader still uses `texture2D`, which isn't valid in a core profile. That's commaai/metadrive#15. This PR is intentionally the thin openpilot half and doesn't touch the (currently commented out) `metadrive-simulator` dependency; `tools/sim/README.md` documents installing it manually plus the macOS specifics.

New `tools/sim/tests/test_spawn_safety.py` covers what regressed silently before: that the context is `spawn`, that a bridge plus a `World`'s shared objects actually survive being handed to a spawned process, and that `rgb_to_nv12` still reads channel 0 as red so a fixed camera readback can't quietly swap R and B on the way to VisionIPC.

Validated on Linux (can't run macOS here): bridge comes up in ~12s under `spawn` and 20 non-blank frames arrive over VisionIPC; `scripts/lint/lint.sh` clean apart from a pre-existing `ty` diagnostic on `metadrive_process.py:50` that only appears when MetaDrive is installed locally.


Closes #33207
