### PR TITLE
selfdrived: report comm issues only when engagement-relevant

### DIFF
--- a/openpilot/selfdrive/selfdrived/selfdrived.py
+++ b/openpilot/selfdrive/selfdrived/selfdrived.py
@@ -20,7 +20,7 @@ from openpilot.selfdrive.car.car_events import CarEvents
 from openpilot.selfdrive.locationd.helpers import PoseCalibrator, Pose
 from openpilot.selfdrive.selfdrived.events import Events, ET
 from openpilot.selfdrive.selfdrived.helpers import ExcessiveActuationCheck
-from openpilot.selfdrive.selfdrived.state import StateMachine
+from openpilot.selfdrive.selfdrived.state import StateMachine, should_report_comm_issue
 from openpilot.selfdrive.selfdrived.alertmanager import AlertManager, set_offroad_alert
 
 from openpilot.common.version import get_build_metadata
@@ -378,7 +378,8 @@ class SelfdriveD:
     no_system_errors = (not has_disable_events) or (len(self.events) == num_events)
     warmup_sec = 5.
     big_model_settling = self.big_model_loading or time.monotonic() < self.big_model_ready_t + warmup_sec
-    if not self.sm.all_checks() and no_system_errors and not big_model_settling:  # the load holds modelV2 and friends back on purpose
+    if (should_report_comm_issue(self.enabled, self.events) and not self.sm.all_checks() and no_system_errors and
+        not big_model_settling):  # the load holds modelV2 and friends back on purpose
       if not self.sm.all_alive():
         self.events.add(EventName.commIssue)
       elif not self.sm.all_freq_ok():

--- a/openpilot/selfdrive/selfdrived/state.py
+++ b/openpilot/selfdrive/selfdrived/state.py
@@ -8,6 +8,11 @@ SOFT_DISABLE_TIME = 3  # seconds
 ACTIVE_STATES = (State.enabled, State.softDisabling, State.overriding)
 ENABLED_STATES = (State.preEnabled, *ACTIVE_STATES)
 
+
+def should_report_comm_issue(enabled: bool, events: Events) -> bool:
+  return enabled or events.contains(ET.ENABLE)
+
+
 class StateMachine:
   def __init__(self):
     self.current_alert_types = [ET.PERMANENT]
@@ -95,4 +100,3 @@ class StateMachine:
     if active:
       self.current_alert_types.append(ET.WARNING)
     return enabled, active
-

--- a/openpilot/selfdrive/selfdrived/tests/test_state_machine.py
+++ b/openpilot/selfdrive/selfdrived/tests/test_state_machine.py
@@ -1,7 +1,7 @@
 from openpilot.common.test import OpenpilotTestCase
 from openpilot.cereal import log
 from openpilot.common.realtime import DT_CTRL
-from openpilot.selfdrive.selfdrived.state import StateMachine, SOFT_DISABLE_TIME
+from openpilot.selfdrive.selfdrived.state import StateMachine, SOFT_DISABLE_TIME, should_report_comm_issue
 from openpilot.selfdrive.selfdrived.events import Events, ET, EVENTS, NormalPermanentAlert
 
 State = log.SelfdriveState.OpenpilotState
@@ -81,6 +81,15 @@ class TestStateMachine(OpenpilotTestCase):
     self.events.add(make_event([ET.NO_ENTRY, ET.PRE_ENABLE]))
     self.state_machine.update(self.events)
     assert self.state_machine.state == State.preEnabled
+
+  def test_comm_issue_relevance(self):
+    assert not should_report_comm_issue(False, self.events)
+
+    self.events.add(make_event([ET.ENABLE]))
+    assert should_report_comm_issue(False, self.events)
+
+    self.events.clear()
+    assert should_report_comm_issue(True, self.events)
 
   def test_maintain_states(self):
     # Given current state's event type, we should maintain state


### PR DESCRIPTION
## Summary

* run the generic communication-health check only while openpilot is enabled or an engagement is being attempted
* keep the existing specific malfunction events unchanged
* add regression coverage for idle, engagement-attempt, and enabled states

This follows option 1 proposed in #35918 and avoids reporting a generic `commIssue` while the system is disabled and no engagement is being attempted.

## Testing

* `uv run pytest -q openpilot/selfdrive/selfdrived/tests/test_state_machine.py` — 8 passed
* `uv run ruff check openpilot/selfdrive/selfdrived/selfdrived.py openpilot/selfdrive/selfdrived/state.py openpilot/selfdrive/selfdrived/tests/test_state_machine.py` — passed
* Python compilation and patch-integrity checks — passed

Not run: Ford route replay; the required local Git LFS model dependency was not available.

Refs #35918
