### PR TITLE
cabana: keep $PWD in sync when chdir'ing to the executable dir

### DIFF
--- a/openpilot/tools/cabana/utils/qtutil.cc
+++ b/openpilot/tools/cabana/utils/qtutil.cc
@@ -222,8 +222,7 @@ void initApp(int argc, char *argv[], bool disable_hidpi) {
 
   qputenv("QT_DBL_CLICK_DIST", "150");
   // ensure the current dir matches the exectuable's directory
-  std::error_code ec;
-  std::filesystem::current_path(executableDir(), ec);
+  chdirToExecutableDir();
 }
 
 QPixmap bootstrapPixmap(const QString &id) {

--- a/openpilot/tools/cabana/utils/util.cc
+++ b/openpilot/tools/cabana/utils/util.cc
@@ -322,3 +322,10 @@ std::filesystem::path executableDir() {
   return std::filesystem::path(util::readlink("/proc/self/exe")).parent_path();
 #endif
 }
+
+void chdirToExecutableDir() {
+  const auto dir = executableDir();
+  std::error_code ec;
+  std::filesystem::current_path(dir, ec);
+  if (!ec) setenv("PWD", dir.c_str(), 1);
+}

--- a/openpilot/tools/cabana/utils/util.h
+++ b/openpilot/tools/cabana/utils/util.h
@@ -108,3 +108,4 @@ private:
 
 int num_decimals(double num);
 std::filesystem::path executableDir();
+void chdirToExecutableDir();


### PR DESCRIPTION
cabana chdirs to its executable's directory on startup (`initApp`), but leaves `$PWD` pointing at the shell's original directory. The python `file_downloader` subprocesses forked by `tools/replay/py_downloader.cc` inherit that stale environment, and pycapnp's `kj` disk-filesystem init then warns on every download.