### PR TITLE
modem.py: accept hex chars in ICCID

### DIFF
--- a/openpilot/common/hardware/comma/modem.py
+++ b/openpilot/common/hardware/comma/modem.py
@@ -5,6 +5,7 @@ import logging
 import os
 import select
 import signal
+import string
 import struct
 import subprocess
 import tempfile
@@ -354,7 +355,7 @@ class Modem:
       imei = ""
 
     iccid = (self._atv("AT+QCCID", "+QCCID:") or "").rstrip("F")
-    if not iccid.isdigit():
+    if not all(c in string.hexdigits for c in iccid):
       iccid = ""
 
     imsi = first_line("AT+CIMI")


### PR DESCRIPTION
**Bug:** `_read_identity()` validates the ICCID with `isdigit()`. ITU-T E.118 does specify decimal digits, but plenty of real-world SIMs carry hex characters in EF_ICCID — e.g. China Mobile's `898600B5...` range, plus some MVNO/IoT SIMs and eSIM profiles. `AT+QCCID` returns them verbatim, the check blanks the ICCID, and the daemon retries `identity read incomplete` forever: it never reaches SEARCHING, never dials, and cellular is completely dead on these SIMs.

Reading EF_ICCID directly (`AT+CRSM=176,12258,0,0,10`) confirms the hex nibble is really on the card, not a modem parsing artifact. ModemManager treats ICCID as hex for the same reason, which is why these SIMs worked before the switch to modem.py (https://github.com/commaai/openpilot/pull/37811). Same spirit as the trailing-`F` padding normalization in https://github.com/commaai/openpilot/pull/38021.

**Fix:** accept hex digits in the ICCID check. Empty string still falls through to the existing `if not identity["iccid"]` retry.

This affects all comma hardware — `_read_identity()` is shared by the EG25 (comma 3/3X) and EG916Q (comma four) paths.

**Verified** on a comma four (EG916Q-GL) with a China Mobile SIM (ICCID `898600B5...`): before, stuck in INITIALIZING logging `identity read incomplete: {'imei': '8685...', 'iccid': '', 'mcc_mnc': '460078', ...}`; after, registers, dials PPP, and passes traffic normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
