### PR TITLE
cabana: add --layout CLI argument and layout restoration support

### DIFF
--- a/openpilot/tools/cabana/tests/test_cabana_ui.py
+++ b/openpilot/tools/cabana/tests/test_cabana_ui.py
@@ -11,3 +11,4 @@ class TestCabanaUi(OpenpilotTestCase):
     result = subprocess.run(["./_cabana_ui", "-h"], cwd=CABANA_DIR, capture_output=True, text=True)
     assert result.returncode == 0, result.stderr
     assert "Usage:" in result.stderr
+    assert "--layout" in result.stderr

--- a/openpilot/tools/cabana/ui/app.cc
+++ b/openpilot/tools/cabana/ui/app.cc
@@ -180,7 +180,7 @@ std::vector<KeyEvent> takeKeyEvents() {
   return std::exchange(g_key_events, {});
 }
 
-int run(std::unique_ptr<AbstractStream> stream, StreamLoader stream_loader, const std::string &dbc_file) {
+int run(std::unique_ptr<AbstractStream> stream, StreamLoader stream_loader, const std::string &dbc_file, const std::string &layout) {
   try {
     // SIGINT/SIGTERM close all windows (which may ask about unsaved changes), then exit
     UnixSignalHandler signal_handler([]() { g_signal_exit = true; });
@@ -193,7 +193,7 @@ int run(std::unique_ptr<AbstractStream> stream, StreamLoader stream_loader, cons
     inistate::load();
     inistate::applyWindowGeometry(glfw.window());
 
-    MainWindow win(glfw.window(), std::move(stream), std::move(stream_loader), dbc_file);
+    MainWindow win(glfw.window(), std::move(stream), std::move(stream_loader), dbc_file, layout);
     while (!win.exited()) {
       if (g_signal_exit.exchange(false)) {
         printf("\nexiting...\n");

--- a/openpilot/tools/cabana/ui/app.h
+++ b/openpilot/tools/cabana/ui/app.h
@@ -12,7 +12,7 @@ using StreamLoader = std::function<std::unique_ptr<AbstractStream>()>;
 
 // takes ownership of stream; a loader runs behind the window instead of before it; with neither, the
 // stream selector opens
-int run(std::unique_ptr<AbstractStream> stream, StreamLoader stream_loader, const std::string &dbc_file);
+int run(std::unique_ptr<AbstractStream> stream, StreamLoader stream_loader, const std::string &dbc_file, const std::string &layout = "");
 
 // key presses with the modifier state at event time: imgui may apply a modifier release in the same frame as
 // the key press it belongs to, which loses fast shortcut sequences. Consumed once per frame by MainWindow.

--- a/openpilot/tools/cabana/ui/chart/chartswidget.cc
+++ b/openpilot/tools/cabana/ui/chart/chartswidget.cc
@@ -330,11 +330,32 @@ void ChartsWidget::restoreChartsFromIds(const std::vector<std::string> &chart_id
     int index = 0;
     for (const auto &part : utils::split(chart_id, ',')) {
       const size_t sep = part.find('|');
-      if (sep == std::string::npos) continue;
-      MessageId msg_id = MessageId::fromString(part.substr(0, sep));
-      if (auto *msg = dbc()->msg(msg_id))
-        if (auto *sig = msg->sig(part.substr(sep + 1)))
-          showChart(msg_id, sig, true, index++ > 0);
+      if (sep != std::string::npos) {
+        MessageId msg_id = MessageId::fromString(part.substr(0, sep));
+        if (auto *msg = dbc()->msg(msg_id))
+          if (auto *sig = msg->sig(part.substr(sep + 1)))
+            showChart(msg_id, sig, true, index++ > 0);
+      } else {
+        std::string sig_name = part;
+        const size_t slash = sig_name.find_last_of('/');
+        if (slash != std::string::npos) sig_name = sig_name.substr(slash + 1);
+        bool found = false;
+        for (auto *file : dbc()->allDBCFiles()) {
+          for (const auto &[addr, msg] : file->getMessages()) {
+            if (auto *sig = const_cast<cabana::Msg &>(msg).sig(sig_name)) {
+              for (int src : dbc()->sources(file)) {
+                uint8_t source = (src < 0) ? 0 : (uint8_t)src;
+                MessageId msg_id{.source = source, .address = addr};
+                showChart(msg_id, sig, true, index++ > 0);
+                found = true;
+                break;
+              }
+            }
+            if (found) break;
+          }
+          if (found) break;
+        }
+      }
     }
   }
 }

--- a/openpilot/tools/cabana/ui/main.cc
+++ b/openpilot/tools/cabana/ui/main.cc
@@ -36,6 +36,7 @@ struct CabanaArgs {
   std::string zmq;
   std::string data_dir;
   std::string dbc;
+  std::string layout;
   std::string route;
 };
 
@@ -63,7 +64,8 @@ void printUsage(const char *argv0) {
           "  --data_dir <dir>          local directory with routes\n"
           "  --no-vipc                 do not output video\n"
           "  --no-cache                turn off the local route file cache\n"
-          "  --dbc <file>              dbc file to open\n",
+          "  --dbc <file>              dbc file to open\n"
+          "  --layout <layout>         load a predefined or custom layout\n",
           argv0);
 }
 
@@ -116,6 +118,8 @@ std::optional<int> parseArgs(int argc, char *argv[], CabanaArgs &args) {
       args.no_cache = true;
     } else if (std::strcmp(a, "--dbc") == 0) {
       if (!takeValue(argc, argv, i, args.dbc)) return 1;
+    } else if (std::strcmp(a, "--layout") == 0) {
+      if (!takeValue(argc, argv, i, args.layout)) return 1;
     } else if (a[0] == '-') {
       fprintf(stderr, "error: unknown option %s\n", a);
       printUsage(argv[0]);
@@ -198,5 +202,5 @@ int main(int argc, char *argv[]) {
     }
   }
 
-  return run(std::move(stream), std::move(stream_loader), args.dbc);
+  return run(std::move(stream), std::move(stream_loader), args.dbc, args.layout);
 }

--- a/openpilot/tools/cabana/ui/mainwin.cc
+++ b/openpilot/tools/cabana/ui/mainwin.cc
@@ -36,7 +36,7 @@ constexpr const char *CHARTS_WINDOW = "Charts###ChartsWindow";
 }  // namespace
 
 MainWindow::MainWindow(GLFWwindow *window, std::unique_ptr<AbstractStream> stream, StreamLoader stream_loader,
-                       const std::string &dbc_file) : window_(window) {
+                       const std::string &dbc_file, const std::string &layout) : window_(window), startup_layout_(layout) {
   can = &dummy_;
   video_splitter_ratio_ = inistate::main_window.video_splitter_ratio;
   messages_visible_ = inistate::main_window.messages_visible;
@@ -206,7 +206,12 @@ void MainWindow::updateWindowTitle() {
 void MainWindow::dbcFileChanged() {
   UndoStack::instance()->clear();
   updateWindowTitle();
-  nextFrame([this]() { restoreSessionState(); });
+  nextFrame([this]() {
+    restoreSessionState();
+    if (!startup_layout_.empty()) {
+      loadLayout(startup_layout_);
+    }
+  });
 }
 
 void MainWindow::selectAndOpenStream() {
@@ -366,6 +371,9 @@ void MainWindow::startStream(std::unique_ptr<AbstractStream> stream, const std::
     if (!dbc()->nonEmptyDBCCount()) {
       newFile();
     }
+    if (!startup_layout_.empty()) {
+      loadLayout(startup_layout_);
+    }
 
     stream_connections_.push_back(can->eventsMerged.connect([this](const MessageEventsMap &) { eventsMerged(); }));
 
@@ -389,7 +397,12 @@ void MainWindow::eventsMerged() {
     // Don't overwrite already loaded DBC
     auto it = fingerprint_to_dbc_.find(car_fingerprint_);
     if (!dbc()->nonEmptyDBCCount() && it != fingerprint_to_dbc_.end()) {
-      nextFrame([this, dbc_name = it->second]() { loadDBCFromOpendbc(dbc_name + ".dbc"); });
+      nextFrame([this, dbc_name = it->second]() {
+        loadDBCFromOpendbc(dbc_name + ".dbc");
+        if (!startup_layout_.empty()) {
+          loadLayout(startup_layout_);
+        }
+      });
     }
   }
 }
@@ -673,6 +686,77 @@ void MainWindow::restoreSessionState() {
 
   if (charts_widget_ != nullptr && !settings.active_charts.empty()) {
     charts_widget_->restoreChartsFromIds(settings.active_charts);
+  }
+}
+
+void MainWindow::loadLayout(const std::string &layout_name) {
+  if (layout_name.empty() || !charts_widget_) return;
+
+  std::filesystem::path path(layout_name);
+  if (!std::filesystem::exists(path)) {
+    const std::filesystem::path candidate_paths[] = {
+      executableDir() / "layouts" / (layout_name + ".json"),
+      executableDir() / "layouts" / layout_name,
+      executableDir() / "../jotpluggler/layouts" / (layout_name + ".json"),
+      executableDir() / "../jotpluggler/layouts" / layout_name,
+      executableDir() / "../plotjuggler/layouts" / layout_name,
+      executableDir() / "../../jotpluggler/layouts" / (layout_name + ".json"),
+      executableDir() / "../../jotpluggler/layouts" / layout_name,
+    };
+    for (const auto &p : candidate_paths) {
+      if (std::filesystem::exists(p)) {
+        path = p;
+        break;
+      }
+    }
+  }
+
+  if (!std::filesystem::exists(path)) {
+    showStatusMessage("Layout file not found: " + layout_name, 3000);
+    return;
+  }
+
+  std::ifstream f(path);
+  if (!f) return;
+  const std::string contents{std::istreambuf_iterator<char>(f), std::istreambuf_iterator<char>()};
+  std::string err;
+  auto doc = json11::Json::parse(contents, err);
+  if (!err.empty()) return;
+
+  std::vector<std::string> chart_ids;
+  if (doc.is_array()) {
+    for (const auto &item : doc.array_items()) {
+      if (item.is_string()) chart_ids.push_back(item.string_value());
+    }
+  } else if (doc.is_object()) {
+    std::function<void(const json11::Json &)> extract_curves = [&](const json11::Json &node) {
+      if (node.is_object()) {
+        if (node["curves"].is_array()) {
+          std::string combined;
+          for (const auto &c : node["curves"].array_items()) {
+            if (c["name"].is_string()) {
+              std::string name = c["name"].string_value();
+              if (!combined.empty()) combined += ",";
+              combined += name;
+            }
+          }
+          if (!combined.empty()) chart_ids.push_back(combined);
+        }
+        if (node["children"].is_array()) {
+          for (const auto &child : node["children"].array_items()) extract_curves(child);
+        }
+        if (node["root"].is_object()) extract_curves(node["root"]);
+        if (node["tabs"].is_array()) {
+          for (const auto &tab : node["tabs"].array_items()) extract_curves(tab);
+        }
+      }
+    };
+    extract_curves(doc);
+  }
+
+  if (!chart_ids.empty()) {
+    charts_widget_->restoreChartsFromIds(chart_ids);
+    showStatusMessage("Loaded layout: " + path.filename().string(), 2000);
   }
 }
 

--- a/openpilot/tools/cabana/ui/mainwin.h
+++ b/openpilot/tools/cabana/ui/mainwin.h
@@ -23,7 +23,7 @@ struct GLFWwindow;
 
 class MainWindow {
 public:
-  MainWindow(GLFWwindow *window, std::unique_ptr<AbstractStream> stream, StreamLoader stream_loader, const std::string &dbc_file);
+  MainWindow(GLFWwindow *window, std::unique_ptr<AbstractStream> stream, StreamLoader stream_loader, const std::string &dbc_file, const std::string &layout = "");
   ~MainWindow();
   void draw();
   void toggleChartsDocking();
@@ -31,6 +31,7 @@ public:
   bool exited() const { return exited_; }
   void showStatusMessage(const std::string &msg, int timeout_ms = 0);
   void loadFile(const std::string &fn, SourceSet s = SOURCE_ALL, std::function<void()> then = {});
+  void loadLayout(const std::string &layout_name);
 
   void selectAndOpenStream();
   void openStream(std::unique_ptr<AbstractStream> stream, const std::string &dbc_file = {});
@@ -89,6 +90,7 @@ private:
   GLFWwindow *window_;
   std::unique_ptr<AbstractStream> startup_stream_;  // opened on the first frame
   StreamLoader startup_loader_;  // run on a worker after the first frame
+  std::string startup_layout_;
   std::unique_ptr<AbstractStream> stream_;  // `can` points here, or at dummy_ when no stream is open
   DummyStream dummy_;
   std::unique_ptr<MessagesWidget> messages_widget_;

--- a/tools/op.sh
+++ b/tools/op.sh
@@ -318,6 +318,11 @@ function op_juggle() {
   op_run_command openpilot/tools/plotjuggler/juggle.py "$@"
 }
 
+function op_jotpluggler() {
+  op_before_cmd
+  op_run_command openpilot/tools/jotpluggler/jotpluggler "$@"
+}
+
 function op_lint() {
   op_before_cmd
   op_run_command scripts/lint/lint.sh "$@"
@@ -443,6 +448,7 @@ function op_default() {
   echo -e "  ${BOLD}stop${NC}         Stops openpilot"
   echo ""
   echo -e "${BOLD}${UNDERLINE}Commands [Tooling]:${NC}"
+  echo -e "  ${BOLD}jotpluggler${NC}  Run JotPluggler"
   echo -e "  ${BOLD}juggle${NC}       Run PlotJuggler"
   echo -e "  ${BOLD}replay${NC}       Run Replay"
   echo -e "  ${BOLD}cabana${NC}       Run Cabana (--legacy for the old Qt version)"
@@ -496,6 +502,7 @@ function _op() {
     esim )          shift 1; op_esim "$@" ;;
     setup )         shift 1; op_setup "$@" ;;
     build )         shift 1; op_build "$@" ;;
+    jotpluggler | jot ) shift 1; op_jotpluggler "$@" ;;
     juggle )        shift 1; op_juggle "$@" ;;
     cabana )        shift 1; op_cabana "$@" ;;
     lint )          shift 1; op_lint "$@" ;;


### PR DESCRIPTION
Resolves #38752

### Description
- Added `--layout` option to Cabana ImGui frontend CLI (`openpilot/tools/cabana/ui/main.cc`, `app.h`, `app.cc`).
- Implemented `MainWindow::loadLayout(const std::string &layout_name)` supporting both layout files and bare layout names from `layouts/`, `jotpluggler/layouts/`, and `plotjuggler/layouts/`.
- Supported both JSON chart list format and PlotJuggler / JotPluggler tab-and-curves schema.
- Added signal lookup by name fallback in `ChartsWidget::restoreChartsFromIds` for layout files specifying signal names across DBC messages without message ID prefix.
- Updated `tools/op.sh` to add `jotpluggler` / `jot` command and help entries.
- Updated `openpilot/tools/cabana/tests/test_cabana_ui.py` to verify `--layout` in CLI help.

### Verification
- Built and tested `_cabana_ui` and `jotpluggler` binaries with SCons.
- Verified `--layout` argument in `_cabana_ui -h`.
- Ran pytest across `test_cabana_ui.py`, `test_jotpluggler.py`, and `test_plotjuggler.py` with passing tests.

## Payout Routing
- **EVM (Base/Arbitrum/Polygon/ETH):** `0xF46C9F6d70C50BF81ef3588AB523a90a594a2F89`
- **Stellar:** `GCL6OXAMLD75BMTINA6EMRUDWK5THQUSHMYNLSNBCJAPZJHNYJTUNIBC`