### PR TITLE
fix kj PWD warnings

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -16,6 +16,9 @@ SCons.Warnings.warningAsException(True)
 
 Decider('MD5-timestamp')
 
+# SCons chdirs while reading SConscripts, which makes kj warn about a stale PWD when capnp schemas are loaded
+os.environ.pop('PWD', None)
+
 SetOption('num_jobs', max(1, int(os.cpu_count()/(1 if "CI" in os.environ else 2))))
 
 AddOption('--ccflags', action='store', type='string', default='', help='pass arbitrary flags over the command line')

--- a/openpilot/common/spinner.py
+++ b/openpilot/common/spinner.py
@@ -5,10 +5,12 @@ from openpilot.common.basedir import BASEDIR
 
 class Spinner:
   def __init__(self):
+    ui_dir = os.path.join(BASEDIR, "openpilot/system", "ui")
     try:
       self.spinner_proc = subprocess.Popen(["./spinner.py"],
                                            stdin=subprocess.PIPE,
-                                           cwd=os.path.join(BASEDIR, "openpilot/system", "ui"),
+                                           cwd=ui_dir,
+                                           env={**os.environ, "PWD": ui_dir},
                                            close_fds=True)
     except OSError:
       self.spinner_proc = None

--- a/openpilot/common/text_window.py
+++ b/openpilot/common/text_window.py
@@ -7,10 +7,12 @@ from openpilot.common.basedir import BASEDIR
 
 class TextWindow:
   def __init__(self, text):
+    ui_dir = os.path.join(BASEDIR, "openpilot/system", "ui")
     try:
       self.text_proc = subprocess.Popen(["./text.py", text],
                                         stdin=subprocess.PIPE,
-                                        cwd=os.path.join(BASEDIR, "openpilot/system", "ui"),
+                                        cwd=ui_dir,
+                                        env={**os.environ, "PWD": ui_dir},
                                         close_fds=True)
     except OSError:
       self.text_proc = None

--- a/openpilot/tools/cabana/ui/main.cc
+++ b/openpilot/tools/cabana/ui/main.cc
@@ -1,4 +1,5 @@
 #include <cstdio>
+#include <cstdlib>
 #include <cstring>
 #include <filesystem>
 #include <memory>
@@ -142,6 +143,7 @@ int main(int argc, char *argv[]) {
   // ensure the current dir matches the executable's directory
   std::error_code ec;
   std::filesystem::current_path(executableDir(), ec);
+  setenv("PWD", executableDir().c_str(), 1);
 
   CabanaArgs args;
   if (auto code = parseArgs(argc, argv, args)) return *code;

--- a/tools/test_runner.py
+++ b/tools/test_runner.py
@@ -270,6 +270,7 @@ def main():
 
   capture_output = not args.no_capture
   os.chdir(ROOT)
+  os.environ["PWD"] = str(ROOT)
   warnings.simplefilter(args.warnings)
   started = time.monotonic()
   tests, errors = collect(args.targets, args.k)


### PR DESCRIPTION
every site in openpilot that changes the working directory without updating `PWD` and then loads capnp schemas (directly or in a child python process). kj compares `PWD` against the real cwd and warns on mismatch.

### SConstruct

`tools/op.sh build`

Before:
```
kj/filesystem-disk-unix.c++:1734: warning: PWD environment variable doesn't match current directory; pwd = /home/trey/openpilot
scons: done reading SConscript files.
scons: done building targets.
```
After:
```
scons: done reading SConscript files.
scons: done building targets.
```

### cabana

`openpilot/tools/cabana/_cabana_ui --demo` for 30s, stderr piped through `sort | uniq -c`

Before:
```
1 
1 exiting...
49 kj/filesystem-disk-unix.c++:1734: warning: PWD environment variable doesn't match current directory; pwd = /home/trey/openpilot
1 shutdown: done
1 shutdown: in progress...
```
After:
```
1 
1 exiting...
1 shutdown: done
1 shutdown: in progress...
```

### spinner / text window

```
python3 -c "
import time
from openpilot.common.spinner import Spinner
from openpilot.common.text_window import TextWindow
with Spinner() as s:
  s.update('hi'); time.sleep(3)
with TextWindow('hello') as t:
  time.sleep(3)
"
```

Before:
```
kj/filesystem-disk-unix.c++:1734: warning: PWD environment variable doesn't match current directory; pwd = /home/trey/openpilot
kj/filesystem-disk-unix.c++:1734: warning: PWD environment variable doesn't match current directory; pwd = /home/trey/openpilot
exit=0
```
After:
```
exit=0
```

### test runner

`cd openpilot/tools && python3 ../../tools/test_runner.py -j2 ../../openpilot/system/loggerd/tests/test_encoder.py`

Before:
```
kj/filesystem-disk-unix.c++:1734: warning: PWD environment variable doesn't match current directory; pwd = /home/trey/openpilot/openpilot/tools
collected 1 test in 0.17s • 1 worker
s

1 skipped in 0.17s
```
After:
```
collected 1 test in 0.17s • 1 worker
s

1 skipped in 0.17s
```


### from non-standard directories

Same commands re-run with the fix, launched from other directories:

- `tools/op.sh build` from `openpilot/tools/cabana/ui`
- `_cabana_ui --demo` for 20s from `/tmp` (absolute path)
- `tools/test_runner.py` from `/tmp` (absolute path)