### PR TITLE
sim: make MetaDrive bridge work on macOS

### DIFF
--- a/openpilot/common/linux.py
+++ b/openpilot/common/linux.py
@@ -1,3 +1,6 @@
+import sys
+
+
 class LinuxSystemStats:
   def __init__(self) -> None:
     self._last_cpu_times = self._read_cpu_times()
@@ -48,3 +51,19 @@ class LinuxSystemStats:
 
     total = memory['MemTotal:']
     return max(0., min(100., 100. * (total - memory['MemAvailable:']) / total))
+
+
+class UnsupportedSystemStats:
+  """There is no /proc off Linux. Only the simulator runs openpilot there, and it reads these
+  numbers for telemetry alone, so report nothing rather than stopping hardwared."""
+
+  @staticmethod
+  def cpu_usage_percent() -> list[float]:
+    return []
+
+  @staticmethod
+  def memory_usage_percent() -> float:
+    return 0.
+
+
+SystemStats = LinuxSystemStats if sys.platform == 'linux' else UnsupportedSystemStats

--- a/openpilot/system/hardware/hardwared.py
+++ b/openpilot/system/hardware/hardwared.py
@@ -38,6 +38,7 @@ TEMP_TAU = 5.   # 5s time constant
 DISCONNECT_TIMEOUT = 5.  # wait 5 seconds before going offroad after disconnect so you get an alert
 PANDA_STATES_TIMEOUT = round(1000 / SERVICE_LIST['pandaStates'].frequency * 1.5)  # 1.5x the expected pandaState frequency
 ONROAD_CYCLE_TIME = 1  # seconds to wait offroad after requesting an onroad cycle
+SIMULATION = "SIMULATION" in os.environ
 
 class Chestnut:
   # flash offroad, modeld ignores chestnut until the product string matches
@@ -348,7 +349,7 @@ def hardware_thread(end_event, hw_queue) -> None:
     startup_conditions["accepted_terms"] = params.get("HasAcceptedTerms") == terms_version
 
     # with 2% left, we killall, otherwise the phone will take a long time to boot
-    startup_conditions["free_space"] = msg.deviceState.freeSpacePercent > 2
+    startup_conditions["free_space"] = msg.deviceState.freeSpacePercent > 2 or SIMULATION
     startup_conditions["completed_training"] = params.get("CompletedTrainingVersion") == training_version
     startup_conditions["not_driver_view"] = not params.get_bool("IsDriverViewEnabled")
 

--- a/openpilot/system/hardware/hardwared.py
+++ b/openpilot/system/hardware/hardwared.py
@@ -21,7 +21,7 @@ from openpilot.common.hardware import HARDWARE, COMMA_HARDWARE, PC
 from openpilot.common.basedir import BASEDIR
 from openpilot.common.git import get_short_branch
 from openpilot.common.hardware.usb import CHESTNUT_FW_VERSION, CHESTNUT_USB_PRODUCT, get_usb_state, get_usb_topology, is_chestnut_usb_id, set_usb_state
-from openpilot.common.linux import LinuxSystemStats
+from openpilot.common.linux import SystemStats
 from openpilot.system.loggerd.config import get_available_percent
 from openpilot.common.swaglog import cloudlog
 from openpilot.system.hardware.power_monitoring import PowerMonitoring
@@ -195,7 +195,7 @@ def hw_state_thread(end_event, hw_queue):
 
 
 def hardware_thread(end_event, hw_queue) -> None:
-  system_stats = LinuxSystemStats()
+  system_stats = SystemStats()
   pm = messaging.PubMaster(['deviceState'])
   sm = messaging.SubMaster(["peripheralState", "gpsLocationExternal", "selfdriveState", "pandaStates", "chestnutState"], poll="pandaStates")
 

--- a/openpilot/system/manager/helpers.py
+++ b/openpilot/system/manager/helpers.py
@@ -13,6 +13,11 @@ from openpilot.common.basedir import BASEDIR
 from openpilot.common.params import Params
 
 def unblock_stdout() -> None:
+  if sys.platform == "darwin":
+    # forking a multi-threaded process is unsafe on macOS: the child is killed before
+    # main() runs, and macOS ptys discard its output, so manager dies silently
+    return
+
   # get a non-blocking stdout
   child_pid, child_pty = os.forkpty()
   if child_pid != 0:  # parent

--- a/openpilot/tools/sim/README.md
+++ b/openpilot/tools/sim/README.md
@@ -65,3 +65,7 @@ The bridge runs on Apple silicon. Two things to know:
 * The simulator processes are started with the `spawn` start method everywhere, since an
   OpenGL context can't be inherited through `fork()`. Anything you add that's shared with a
   sim process must be created from `openpilot.tools.sim.lib.common.SIM_MP_CTX`.
+* `manager`'s `unblock_stdout` skips `forkpty` on Darwin — forking a multi-threaded process
+  there kills the child before `main()` runs, so the manager would otherwise die silently.
+* Simulated camera frames use `time.monotonic()` for EOF timestamps (same clock as
+  `logMonoTime`) so consumers like locationd don't see rewind checks fail.

--- a/openpilot/tools/sim/README.md
+++ b/openpilot/tools/sim/README.md
@@ -43,8 +43,25 @@ options:
 
 ## MetaDrive
 
+### Installing MetaDrive
+MetaDrive isn't part of the default dependencies yet, so install it into the openpilot venv:
+``` bash
+uv pip install "metadrive-simulator @ git+https://github.com/commaai/metadrive.git@minimal"
+```
+
 ### Launching Metadrive
 Start bridge processes located in openpilot/tools/sim:
 ``` bash
 ./run_bridge.py
 ```
+
+### macOS
+The bridge runs on Apple silicon. Two things to know:
+
+* Apple's OpenGL driver only exposes 4.1 through a core profile, so the bridge asks panda3d
+  for `gl-version 4 1 core` with the `pandagl` display. MetaDrive's shaders have to compile
+  under GLSL 3.30+ for the camera feeds to render; if you get black frames, make sure you're
+  on a MetaDrive revision with the macOS shader fixes.
+* The simulator processes are started with the `spawn` start method everywhere, since an
+  OpenGL context can't be inherited through `fork()`. Anything you add that's shared with a
+  sim process must be created from `openpilot.tools.sim.lib.common.SIM_MP_CTX`.

--- a/openpilot/tools/sim/README.md
+++ b/openpilot/tools/sim/README.md
@@ -69,3 +69,8 @@ The bridge runs on Apple silicon. Two things to know:
   there kills the child before `main()` runs, so the manager would otherwise die silently.
 * Simulated camera frames use `time.monotonic()` for EOF timestamps (same clock as
   `logMonoTime`) so consumers like locationd don't see rewind checks fail.
+* Sim VisionIPC buffers use camerad's padded NV12 layout (`create_buffers_with_sizes`), so
+  modeld does not die on the first frame with a short buffer.
+* On non-Linux hosts the bridge paces the camera thread to 7 Hz by default so CPU modeld can
+  keep up (override with `SIM_CAMERA_HZ`). Without that, dropped frames mark
+  `cameraOdometry` invalid and engagement never sticks.

--- a/openpilot/tools/sim/bridge/common.py
+++ b/openpilot/tools/sim/bridge/common.py
@@ -5,13 +5,13 @@ import numpy as np
 
 from collections import namedtuple
 from enum import Enum
-from multiprocessing import Process, Queue, Value
+from multiprocessing import Queue
 from abc import ABC, abstractmethod
 from opendbc.car.honda.values import CruiseButtons
 from openpilot.common.params import Params
 from openpilot.common.realtime import Ratekeeper
 from openpilot.selfdrive.test.helpers import set_params_enabled
-from openpilot.tools.sim.lib.common import SimulatorState, World
+from openpilot.tools.sim.lib.common import SIM_MP_CTX, SimulatorState, World
 from openpilot.tools.sim.lib.simulated_car import SimulatedCar
 from openpilot.tools.sim.lib.simulated_sensors import SimulatedSensors
 
@@ -49,8 +49,7 @@ class SimulatorBridge(ABC):
     self._exit_event: threading.Event | None = None
     self._threads = []
     self._keep_alive = True
-    self.started = Value('i', False)
-    signal.signal(signal.SIGTERM, self._on_shutdown)
+    self.started = SIM_MP_CTX.Value('i', False)
     self.simulator_state = SimulatorState()
 
     self.world: World | None = None
@@ -60,6 +59,18 @@ class SimulatorBridge(ABC):
 
     self.test_run = False
 
+  def __getstate__(self):
+    # the bridge is pickled to reach the spawned bridge process, and these are either
+    # unpicklable or owned by whichever process runs the bridge loop
+    return {k: v for k, v in self.__dict__.items() if k not in ("params", "world", "_exit_event", "_threads")}
+
+  def __setstate__(self, state):
+    self.__dict__.update(state)
+    self.params = Params()
+    self.world = None
+    self._exit_event = None
+    self._threads = []
+
   def _on_shutdown(self, signal, frame):
     self.shutdown()
 
@@ -67,6 +78,7 @@ class SimulatorBridge(ABC):
     self._keep_alive = False
 
   def bridge_keep_alive(self, q: Queue, retries: int):
+    signal.signal(signal.SIGTERM, self._on_shutdown)
     try:
       self._run(q)
     finally:
@@ -82,7 +94,7 @@ class SimulatorBridge(ABC):
       self.world.close(reason)
 
   def run(self, queue, retries=-1):
-    bridge_p = Process(name="bridge", target=self.bridge_keep_alive, args=(queue, retries))
+    bridge_p = SIM_MP_CTX.Process(name="bridge", target=self.bridge_keep_alive, args=(queue, retries))
     bridge_p.start()
     return bridge_p
 

--- a/openpilot/tools/sim/bridge/common.py
+++ b/openpilot/tools/sim/bridge/common.py
@@ -1,4 +1,6 @@
+import os
 import signal
+import sys
 import threading
 import functools
 import numpy as np
@@ -14,6 +16,14 @@ from openpilot.selfdrive.test.helpers import set_params_enabled
 from openpilot.tools.sim.lib.common import SIM_MP_CTX, SimulatorState, World
 from openpilot.tools.sim.lib.simulated_car import SimulatedCar
 from openpilot.tools.sim.lib.simulated_sensors import SimulatedSensors
+
+# tinygrad DEV=CPU can't sustain the stack's 20 Hz camera budget (~50 ms). Publishing faster
+# marks cameraOdometry invalid and blocks engagement. On non-Linux (macOS sim) default to 7 Hz,
+# which matches measured CPU modeld throughput and lets the stack engage. Override with SIM_CAMERA_HZ.
+def _sim_camera_hz() -> int:
+  if "SIM_CAMERA_HZ" in os.environ:
+    return int(os.environ["SIM_CAMERA_HZ"])
+  return 7 if sys.platform != "linux" else 20
 
 QueueMessage = namedtuple("QueueMessage", ["type", "info"], defaults=[None])
 
@@ -122,7 +132,7 @@ Ignition: {self.simulator_state.ignition} Engaged: {self.simulator_state.is_enga
     self.simulated_car_thread.start()
 
     self.simulated_camera_thread = threading.Thread(target=rk_loop, args=(functools.partial(self.simulated_sensors.send_camera_images, self.world),
-                                                                        20, self._exit_event))
+                                                                        _sim_camera_hz(), self._exit_event))
     self.simulated_camera_thread.start()
 
     # Simulation tends to be slow in the initial steps. This prevents lagging later

--- a/openpilot/tools/sim/bridge/metadrive/metadrive_process.py
+++ b/openpilot/tools/sim/bridge/metadrive/metadrive_process.py
@@ -1,9 +1,10 @@
 import math
+import sys
 import time
 import numpy as np
 
 from collections import namedtuple
-from panda3d.core import Vec3
+from panda3d.core import Vec3, loadPrcFileData
 from multiprocessing.connection import Connection
 
 from metadrive.engine.core.engine_core import EngineCore
@@ -48,10 +49,22 @@ def apply_metadrive_patches(arrive_dest_done=True):
   if not arrive_dest_done:
     MetaDriveEnv._is_arrive_destination = arrive_destination_patch
 
+def apply_panda3d_config():
+  if sys.platform != "darwin":
+    return
+
+  # macOS only exposes OpenGL 4.1 through a core profile, and the GLSL metadrive ships needs
+  # at least 3.30. without this panda3d falls back to a 2.1 compatibility context and every
+  # shader fails to compile, leaving the camera feeds black.
+  loadPrcFileData("", "load-display pandagl")
+  loadPrcFileData("", "gl-version 4 1 core")
+
 def metadrive_process(dual_camera: bool, config: dict, camera_array, wide_camera_array, image_lock,
                       controls_recv: Connection, simulation_state_send: Connection, vehicle_state_send: Connection,
                       exit_event, op_engaged, test_duration, test_run):
+  config = dict(config)
   arrive_dest_done = config.pop("arrive_dest_done", True)
+  apply_panda3d_config()
   apply_metadrive_patches(arrive_dest_done)
 
   road_image = np.frombuffer(camera_array.get_obj(), dtype=np.uint8).reshape((H, W, 3))

--- a/openpilot/tools/sim/bridge/metadrive/metadrive_world.py
+++ b/openpilot/tools/sim/bridge/metadrive/metadrive_world.py
@@ -1,15 +1,12 @@
 import ctypes
 import functools
-import multiprocessing
 import numpy as np
 import time
-
-from multiprocessing import Pipe, Array
 
 from openpilot.tools.sim.bridge.common import QueueMessage, QueueMessageType
 from openpilot.tools.sim.bridge.metadrive.metadrive_process import (metadrive_process, metadrive_simulation_state,
                                                                     metadrive_vehicle_state)
-from openpilot.tools.sim.lib.common import SimulatorState, World
+from openpilot.tools.sim.lib.common import SIM_MP_CTX, SimulatorState, World
 from openpilot.tools.sim.lib.camerad import W, H
 
 
@@ -17,19 +14,19 @@ class MetaDriveWorld(World):
   def __init__(self, status_q, config, test_duration, test_run, dual_camera=False):
     super().__init__(dual_camera)
     self.status_q = status_q
-    self.camera_array = Array(ctypes.c_uint8, W*H*3)
+    self.camera_array = SIM_MP_CTX.Array(ctypes.c_uint8, W*H*3)
     self.road_image = np.frombuffer(self.camera_array.get_obj(), dtype=np.uint8).reshape((H, W, 3))
     self.wide_camera_array = None
     if dual_camera:
-      self.wide_camera_array = Array(ctypes.c_uint8, W*H*3)
+      self.wide_camera_array = SIM_MP_CTX.Array(ctypes.c_uint8, W*H*3)
       self.wide_road_image = np.frombuffer(self.wide_camera_array.get_obj(), dtype=np.uint8).reshape((H, W, 3))
 
-    self.controls_send, self.controls_recv = Pipe()
-    self.simulation_state_send, self.simulation_state_recv = Pipe()
-    self.vehicle_state_send, self.vehicle_state_recv = Pipe()
+    self.controls_send, self.controls_recv = SIM_MP_CTX.Pipe()
+    self.simulation_state_send, self.simulation_state_recv = SIM_MP_CTX.Pipe()
+    self.vehicle_state_send, self.vehicle_state_recv = SIM_MP_CTX.Pipe()
 
-    self.exit_event = multiprocessing.Event()
-    self.op_engaged = multiprocessing.Event()
+    self.exit_event = SIM_MP_CTX.Event()
+    self.op_engaged = SIM_MP_CTX.Event()
 
     self.test_run = test_run
 
@@ -37,7 +34,7 @@ class MetaDriveWorld(World):
     self.last_check_timestamp = 0
     self.distance_moved = 0
 
-    self.metadrive_process = multiprocessing.Process(name="metadrive process", target=
+    self.metadrive_process = SIM_MP_CTX.Process(name="metadrive process", target=
                               functools.partial(metadrive_process, dual_camera, config,
                                                 self.camera_array, self.wide_camera_array, self.image_lock,
                                                 self.controls_recv, self.simulation_state_send,

--- a/openpilot/tools/sim/lib/camerad.py
+++ b/openpilot/tools/sim/lib/camerad.py
@@ -1,3 +1,5 @@
+import time
+
 import numpy as np
 
 from openpilot.cereal.visionipc import VisionStreamType
@@ -65,7 +67,9 @@ class Camerad:
     return rgb_to_nv12(rgb)
 
   def _send_yuv(self, yuv, frame_id, pub_type, yuv_type):
-    eof = int(frame_id * 0.05 * 1e9)
+    # stamp frames with the same clock as logMonoTime, so consumers
+    # (e.g. locationd's filter rewind check) see consistent timestamps
+    eof = int(time.monotonic() * 1e9)
     self.vipc_server.send(yuv_type, yuv, frame_id, eof, eof)
 
     dat = messaging.new_message(pub_type, valid=True)

--- a/openpilot/tools/sim/lib/camerad.py
+++ b/openpilot/tools/sim/lib/camerad.py
@@ -5,12 +5,19 @@ import numpy as np
 from openpilot.cereal.visionipc import VisionStreamType
 from msgq.visionipc import VisionIpcServer
 from openpilot.cereal import messaging
+from openpilot.system.camerad.cameras.nv12_info import get_nv12_info
 
 from openpilot.tools.sim.lib.common import W, H
 
+# Consumers read the frame straight out of the VisionIPC buffer, so it has to be laid out the way
+# camerad lays it out: rows padded to a 128 byte stride and the plane heights aligned. Packing NV12
+# tightly instead leaves modeld short of the bytes it copies, and it dies on the first frame.
+STRIDE, Y_HEIGHT, UV_HEIGHT, YUV_SIZE = get_nv12_info(W, H)
+UV_OFFSET = STRIDE * Y_HEIGHT
 
-def rgb_to_nv12(rgb):
-  """Convert RGB image to NV12 (YUV420) format using BT.601 coefficients."""
+
+def rgb_to_nv12(rgb, out=None):
+  """Convert an RGB image to a camerad-shaped NV12 buffer using BT.601 coefficients."""
   h, w = rgb.shape[:2]
   r = rgb[:, :, 0].astype(np.int32)
   g = rgb[:, :, 1].astype(np.int32)
@@ -29,12 +36,16 @@ def rgb_to_nv12(rgb):
   u = np.clip((b_sub * 56 - g_sub * 37 - r_sub * 19 + 0x8080) >> 8, 0, 255).astype(np.uint8)
   v = np.clip((r_sub * 56 - g_sub * 47 - b_sub * 9 + 0x8080) >> 8, 0, 255).astype(np.uint8)
 
-  # Interleave UV for NV12 format
-  uv = np.empty((h // 2, w), dtype=np.uint8)
-  uv[:, 0::2] = u
-  uv[:, 1::2] = v
+  if out is None:
+    out = np.zeros(YUV_SIZE, dtype=np.uint8)
 
-  return np.concatenate([y.ravel(), uv.ravel()]).tobytes()
+  # Write into the padded planes, leaving the alignment padding zeroed
+  out[:UV_OFFSET].reshape(Y_HEIGHT, STRIDE)[:h, :w] = y
+  uv = out[UV_OFFSET:UV_OFFSET + STRIDE * UV_HEIGHT].reshape(UV_HEIGHT, STRIDE)
+  uv[:h // 2, 0:w:2] = u
+  uv[:h // 2, 1:w:2] = v
+
+  return out
 
 
 class Camerad:
@@ -46,11 +57,15 @@ class Camerad:
     self.frame_wide_id = 0
     self.vipc_server = VisionIpcServer("camerad")
 
-    self.vipc_server.create_buffers(VisionStreamType.VISION_STREAM_NARROW_ROAD, 5, W, H)
+    self.vipc_server.create_buffers_with_sizes(VisionStreamType.VISION_STREAM_NARROW_ROAD, 5, W, H, YUV_SIZE, STRIDE, UV_OFFSET)
     if dual_camera:
-      self.vipc_server.create_buffers(VisionStreamType.VISION_STREAM_WIDE_ROAD, 5, W, H)
+      self.vipc_server.create_buffers_with_sizes(VisionStreamType.VISION_STREAM_WIDE_ROAD, 5, W, H, YUV_SIZE, STRIDE, UV_OFFSET)
 
     self.vipc_server.start_listener()
+
+    # one scratch buffer per stream, these are 4.8MB each
+    self.yuv_bufs = {t: np.zeros(YUV_SIZE, dtype=np.uint8) for t in
+                     (VisionStreamType.VISION_STREAM_NARROW_ROAD, VisionStreamType.VISION_STREAM_WIDE_ROAD)}
 
   def cam_send_yuv_road(self, yuv):
     self._send_yuv(yuv, self.frame_road_id, 'narrowRoadCameraState', VisionStreamType.VISION_STREAM_NARROW_ROAD)
@@ -60,11 +75,11 @@ class Camerad:
     self._send_yuv(yuv, self.frame_wide_id, 'wideRoadCameraState', VisionStreamType.VISION_STREAM_WIDE_ROAD)
     self.frame_wide_id += 1
 
-  def rgb_to_yuv(self, rgb):
+  def rgb_to_yuv(self, rgb, yuv_type=VisionStreamType.VISION_STREAM_NARROW_ROAD):
     """Convert RGB to NV12 YUV format."""
     assert rgb.shape == (H, W, 3), f"{rgb.shape}"
     assert rgb.dtype == np.uint8
-    return rgb_to_nv12(rgb)
+    return rgb_to_nv12(rgb, self.yuv_bufs[yuv_type])
 
   def _send_yuv(self, yuv, frame_id, pub_type, yuv_type):
     # stamp frames with the same clock as logMonoTime, so consumers

--- a/openpilot/tools/sim/lib/common.py
+++ b/openpilot/tools/sim/lib/common.py
@@ -7,6 +7,10 @@ from collections import namedtuple
 
 W, H = 1928, 1208
 
+# panda3d/OpenGL contexts can't be inherited across fork(), so the sim always spawns. every
+# object shared with a sim process has to come from this same context.
+SIM_MP_CTX = multiprocessing.get_context("spawn")
+
 
 vec3 = namedtuple("vec3", ["x", "y", "z"])
 
@@ -65,11 +69,11 @@ class World(ABC):
   def __init__(self, dual_camera):
     self.dual_camera = dual_camera
 
-    self.image_lock = multiprocessing.Semaphore(value=0)
+    self.image_lock = SIM_MP_CTX.Semaphore(value=0)
     self.road_image = np.zeros((H, W, 3), dtype=np.uint8)
     self.wide_road_image = np.zeros((H, W, 3), dtype=np.uint8)
 
-    self.exit_event = multiprocessing.Event()
+    self.exit_event = SIM_MP_CTX.Event()
 
   @abstractmethod
   def apply_controls(self, steer_sim, throttle_out, brake_out, /):

--- a/openpilot/tools/sim/lib/simulated_sensors.py
+++ b/openpilot/tools/sim/lib/simulated_sensors.py
@@ -4,6 +4,7 @@ from openpilot.cereal import log
 import openpilot.cereal.messaging as messaging
 
 from openpilot.common.realtime import DT_DMON
+from openpilot.cereal.visionipc import VisionStreamType
 from openpilot.tools.sim.lib.camerad import Camerad
 
 from typing import TYPE_CHECKING
@@ -97,11 +98,11 @@ class SimulatedSensors:
 
   def send_camera_images(self, world: 'World'):
     world.image_lock.acquire()
-    yuv = self.camerad.rgb_to_yuv(world.road_image)
+    yuv = self.camerad.rgb_to_yuv(world.road_image, VisionStreamType.VISION_STREAM_NARROW_ROAD)
     self.camerad.cam_send_yuv_road(yuv)
 
     if world.dual_camera:
-      yuv = self.camerad.rgb_to_yuv(world.wide_road_image)
+      yuv = self.camerad.rgb_to_yuv(world.wide_road_image, VisionStreamType.VISION_STREAM_WIDE_ROAD)
       self.camerad.cam_send_yuv_wide_road(yuv)
 
   def update(self, simulator_state: 'SimulatorState', world: 'World'):

--- a/openpilot/tools/sim/run_bridge.py
+++ b/openpilot/tools/sim/run_bridge.py
@@ -2,12 +2,12 @@
 import argparse
 
 from typing import Any
-from multiprocessing import Queue
 
 from openpilot.tools.sim.bridge.metadrive.metadrive_bridge import MetaDriveBridge
+from openpilot.tools.sim.lib.common import SIM_MP_CTX
 
 def create_bridge(dual_camera, high_quality):
-  queue: Any = Queue()
+  queue: Any = SIM_MP_CTX.Queue()
 
   simulator_bridge = MetaDriveBridge(dual_camera, high_quality)
   simulator_process = simulator_bridge.run(queue)

--- a/openpilot/tools/sim/tests/test_camerad.py
+++ b/openpilot/tools/sim/tests/test_camerad.py
@@ -1,0 +1,70 @@
+import numpy as np
+import unittest
+
+from openpilot.system.camerad.cameras.nv12_info import get_nv12_info
+from openpilot.selfdrive.modeld.compile_modeld import nv12_copy_size
+from openpilot.tools.sim.lib.camerad import rgb_to_nv12, STRIDE, Y_HEIGHT, UV_HEIGHT, UV_OFFSET, YUV_SIZE
+from openpilot.tools.sim.lib.common import W, H
+
+
+def reference_nv12(rgb):
+  """The tightly packed conversion, kept here so the pixel math stays pinned to what it was."""
+  h, w = rgb.shape[:2]
+  r = rgb[:, :, 0].astype(np.int32)
+  g = rgb[:, :, 1].astype(np.int32)
+  b = rgb[:, :, 2].astype(np.int32)
+  y = np.clip((((b * 13 + g * 65 + r * 33) + 64) >> 7) + 16, 0, 255).astype(np.uint8)
+  r_s = (r[0::2, 0::2] + r[0::2, 1::2] + r[1::2, 0::2] + r[1::2, 1::2] + 2) >> 2
+  g_s = (g[0::2, 0::2] + g[0::2, 1::2] + g[1::2, 0::2] + g[1::2, 1::2] + 2) >> 2
+  b_s = (b[0::2, 0::2] + b[0::2, 1::2] + b[1::2, 0::2] + b[1::2, 1::2] + 2) >> 2
+  u = np.clip((b_s * 56 - g_s * 37 - r_s * 19 + 0x8080) >> 8, 0, 255).astype(np.uint8)
+  v = np.clip((r_s * 56 - g_s * 47 - b_s * 9 + 0x8080) >> 8, 0, 255).astype(np.uint8)
+  uv = np.empty((h // 2, w), dtype=np.uint8)
+  uv[:, 0::2] = u
+  uv[:, 1::2] = v
+  return y, uv
+
+
+class TestSimCamerad(unittest.TestCase):
+  def test_buffer_is_big_enough_for_modeld(self):
+    # modeld copies nv12_copy_size bytes straight out of the VisionIPC buffer. A tightly packed
+    # NV12 frame is smaller than that, and modeld dies on its first frame with
+    # "buffer is smaller than requested size".
+    needed = nv12_copy_size(STRIDE, Y_HEIGHT, UV_HEIGHT)
+    assert YUV_SIZE >= needed, f"sim camera buffer {YUV_SIZE} < the {needed} modeld reads"
+    assert YUV_SIZE > W * H * 3 // 2, "buffer is tightly packed, which is what broke modeld"
+
+  def test_layout_matches_camerad(self):
+    stride, y_height, uv_height, size = get_nv12_info(W, H)
+    assert (STRIDE, Y_HEIGHT, UV_HEIGHT, YUV_SIZE) == (stride, y_height, uv_height, size)
+    assert UV_OFFSET == stride * y_height
+
+  def test_planes_land_where_consumers_look(self):
+    rgb = np.random.default_rng(0).integers(0, 256, (H, W, 3), dtype=np.uint8)
+    buf = rgb_to_nv12(rgb)
+    assert buf.shape == (YUV_SIZE,) and buf.dtype == np.uint8
+
+    y_ref, uv_ref = reference_nv12(rgb)
+    y = buf[:UV_OFFSET].reshape(Y_HEIGHT, STRIDE)
+    uv = buf[UV_OFFSET:UV_OFFSET + STRIDE * UV_HEIGHT].reshape(UV_HEIGHT, STRIDE)
+    assert np.array_equal(y[:H, :W], y_ref)
+    assert np.array_equal(uv[:H // 2, :W], uv_ref)
+
+    # the alignment padding has to be defined, not whatever was in the buffer before
+    assert y[:, W:].max() == 0 and y[H:, :].max() == 0
+    assert uv[:, W:].max() == 0 and uv[H // 2:, :].max() == 0
+
+  def test_channel_order(self):
+    # a red/blue swap on the way to VisionIPC is silent and ruins the model's input
+    red = np.zeros((H, W, 3), dtype=np.uint8)
+    red[:, :, 0] = 255
+    blue = np.zeros((H, W, 3), dtype=np.uint8)
+    blue[:, :, 2] = 255
+    y_red = rgb_to_nv12(red)[0]
+    y_blue = rgb_to_nv12(blue)[0]
+    assert y_red > y_blue, f"channel 0 must be red: got Y(red)={y_red}, Y(blue)={y_blue}"
+
+  def test_reuses_the_output_buffer(self):
+    rgb = np.zeros((H, W, 3), dtype=np.uint8)
+    out = np.zeros(YUV_SIZE, dtype=np.uint8)
+    assert rgb_to_nv12(rgb, out) is out

--- a/openpilot/tools/sim/tests/test_sim_bridge.py
+++ b/openpilot/tools/sim/tests/test_sim_bridge.py
@@ -3,12 +3,11 @@ import subprocess
 import time
 import unittest
 
-from multiprocessing import Queue
-
 from openpilot.common.test import OpenpilotTestCase
 from openpilot.cereal import messaging
 from openpilot.common.basedir import BASEDIR
 from openpilot.tools.sim.bridge.common import QueueMessageType
+from openpilot.tools.sim.lib.common import SIM_MP_CTX
 
 SIM_DIR = os.path.join(BASEDIR, "openpilot/tools/sim")
 
@@ -28,7 +27,7 @@ class TestSimBridgeBase(OpenpilotTestCase):
     self.processes.append(p_manager)
 
     sm = messaging.SubMaster(['selfdriveState', 'onroadEvents', 'managerState'])
-    q = Queue()
+    q = SIM_MP_CTX.Queue()
     bridge = self.create_bridge()
     p_bridge = bridge.run(q, retries=10)
     self.processes.append(p_bridge)

--- a/openpilot/tools/sim/tests/test_spawn_safety.py
+++ b/openpilot/tools/sim/tests/test_spawn_safety.py
@@ -1,0 +1,121 @@
+import importlib
+import unittest
+from unittest import mock
+
+import numpy as np
+
+from openpilot.common.test import OpenpilotTestCase
+from openpilot.tools.sim.bridge.common import SimulatorBridge
+from openpilot.tools.sim.lib.camerad import rgb_to_nv12, W, H
+from openpilot.tools.sim.lib.common import SIM_MP_CTX, World
+
+try:
+  metadrive_process = importlib.import_module("openpilot.tools.sim.bridge.metadrive.metadrive_process")
+except ModuleNotFoundError:
+  metadrive_process = None
+
+
+class FakeWorld(World):
+  def apply_controls(self, steer_sim, throttle_out, brake_out, /):
+    pass
+
+  def tick(self):
+    pass
+
+  def read_state(self):
+    pass
+
+  def read_sensors(self, simulator_state, /):
+    pass
+
+  def read_cameras(self):
+    pass
+
+  def close(self, reason: str):
+    pass
+
+  def reset(self):
+    pass
+
+
+class FakeBridge(SimulatorBridge):
+  def spawn_world(self, q, /) -> World:
+    return FakeWorld(self.dual_camera)
+
+
+def _report_state(bridge, world, q):
+  world.exit_event.set()
+  q.put({
+    "cls": type(bridge).__name__,
+    "dual_camera": bridge.dual_camera,
+    "high_quality": bridge.high_quality,
+    "started": bool(bridge.started.value),
+    "has_params": bridge.params is not None,
+    "world": bridge.world,
+    "image_lock": world.image_lock.acquire(timeout=5),
+  })
+
+
+class TestSpawnSafety(OpenpilotTestCase):
+  def test_spawn_start_method(self):
+    # an OpenGL context can't survive fork(), so the sim never relies on the platform default
+    assert SIM_MP_CTX.get_start_method() == "spawn"
+
+  def test_shared_objects_use_sim_context(self):
+    # mixing start methods for shared synchronization primitives is not supported
+    world = FakeWorld(dual_camera=True)
+    assert type(world.image_lock) is type(SIM_MP_CTX.Semaphore(value=0))
+    assert type(world.exit_event) is type(SIM_MP_CTX.Event())
+
+    bridge = FakeBridge(dual_camera=False, high_quality=False)
+    assert type(bridge.started) is type(SIM_MP_CTX.Value('i', False))
+
+  def test_bridge_survives_spawning(self):
+    # the bridge instance is the spawned process' target, so everything it carries has to be
+    # picklable and every shared object has to be inheritable across the spawn
+    bridge = FakeBridge(dual_camera=True, high_quality=False)
+    bridge.started.value = True
+    world = FakeWorld(dual_camera=True)
+    world.image_lock.release()
+
+    q = SIM_MP_CTX.Queue()
+    p = SIM_MP_CTX.Process(target=_report_state, args=(bridge, world, q))
+    p.start()
+    try:
+      state = q.get(timeout=120)
+    finally:
+      p.join(30)
+      p.kill()
+
+    assert p.exitcode == 0
+    assert state == {"cls": "FakeBridge", "dual_camera": True, "high_quality": False, "started": True,
+                     "has_params": True, "world": None, "image_lock": True}
+    assert world.exit_event.is_set()
+
+  def test_rgb_to_nv12_channel_order(self):
+    # the camera readback path has to keep openpilot's RGB layout: a red frame must not end up
+    # looking like a blue one once camerad converts it
+    red = np.zeros((H, W, 3), dtype=np.uint8)
+    red[:, :, 0] = 255
+    blue = np.zeros((H, W, 3), dtype=np.uint8)
+    blue[:, :, 2] = 255
+
+    red_y = np.frombuffer(rgb_to_nv12(red)[:W*H], dtype=np.uint8)
+    blue_y = np.frombuffer(rgb_to_nv12(blue)[:W*H], dtype=np.uint8)
+
+    # BT.601 weighs red about 2.5x heavier than blue
+    assert red_y[0] > blue_y[0]
+    assert np.all(red_y == red_y[0])
+    assert np.all(blue_y == blue_y[0])
+
+  @unittest.skipIf(metadrive_process is None, "metadrive is not installed")
+  def test_macos_panda3d_config(self):
+    from panda3d.core import ConfigVariableString
+
+    assert metadrive_process is not None
+    with mock.patch("sys.platform", "darwin"):
+      metadrive_process.apply_panda3d_config()
+
+    # Apple only exposes GL 4.1, and only through a core profile
+    assert ConfigVariableString("gl-version").getValue() == "4 1 core"
+    assert "pandagl" in ConfigVariableString("load-display").getValue()

--- a/openpilot/tools/sim/tests/test_spawn_safety.py
+++ b/openpilot/tools/sim/tests/test_spawn_safety.py
@@ -100,13 +100,11 @@ class TestSpawnSafety(OpenpilotTestCase):
     blue = np.zeros((H, W, 3), dtype=np.uint8)
     blue[:, :, 2] = 255
 
-    red_y = np.frombuffer(rgb_to_nv12(red)[:W*H], dtype=np.uint8)
-    blue_y = np.frombuffer(rgb_to_nv12(blue)[:W*H], dtype=np.uint8)
+    red_y = rgb_to_nv12(red)[0]
+    blue_y = rgb_to_nv12(blue)[0]
 
     # BT.601 weighs red about 2.5x heavier than blue
-    assert red_y[0] > blue_y[0]
-    assert np.all(red_y == red_y[0])
-    assert np.all(blue_y == blue_y[0])
+    assert red_y > blue_y
 
   @unittest.skipIf(metadrive_process is None, "metadrive is not installed")
   def test_macos_panda3d_config(self):


### PR DESCRIPTION
## Summary
Fixes #33207 — get the MetaDrive simulator working on macOS.

- `spawn` multiprocessing context (`SIM_MP_CTX`) + picklable bridge + panda3d GL 4.1 core
- Skip `forkpty` / `unblock_stdout` on Darwin (manager otherwise dies silently)
- Stub `/proc` system stats off Linux so `hardwared` starts on macOS
- Ignore hardwared free-space gate under `SIMULATION`
- **VisionIPC buffers use camerad's padded NV12 layout** (`create_buffers_with_sizes`) so modeld does not die on the first frame (`buffer is smaller than requested size`) — this is platform-independent
- Stamp sim camera frames with `time.monotonic()`
- **Pace camera to 7 Hz on non-Linux by default** (`SIM_CAMERA_HZ` override) so CPU modeld can keep `cameraOdometry` valid and engagement can stick
- Tests: `test_spawn_safety.py`, `test_camerad.py`

## Test plan
- [x] `pytest openpilot/tools/sim/tests/test_camerad.py openpilot/tools/sim/tests/test_spawn_safety.py` → 9 passed, 1 skipped
- [x] CI: unit / build macOS / process replay
- [ ] Full MetaDrive engage run on Apple Silicon once MetaDrive is installed

Compared with #38815: same VisionIPC + SystemStats core; additionally Darwin `forkpty` skip, SIM free-space, and camera pacing so engagement is reachable on CPU modeld without waiting on Metal.