### PR TITLE
Revert "pandad: guarantee SPI slave turnaround time (#38464)"

### DIFF
--- a/openpilot/selfdrive/pandad/spi.cc
+++ b/openpilot/selfdrive/pandad/spi.cc
@@ -29,12 +29,6 @@ enum SpiError {
 
 const unsigned int SPI_ACK_TIMEOUT = 500; // milliseconds
 const std::string SPI_DEVICE = "/dev/spidev0.0";
-// TODO: fix SPI turnaround synchronization at the protocol level.
-static uint64_t spi_last_bus_activity_ns = 0;  // protected by hw_lock
-
-static void wait_for_spi_turnaround(uint64_t start_ns) {
-  while ((nanos_since_boot() - start_ns) < 400000) {}
-}
 
 class LockEx {
 public:
@@ -325,8 +319,6 @@ int PandaSpiHandle::spi_transfer(uint8_t endpoint, uint8_t *tx_data, uint16_t tx
   assert(tx_len < SPI_BUF_SIZE);
   assert(max_rx_len < SPI_BUF_SIZE);
 
-  wait_for_spi_turnaround(spi_last_bus_activity_ns);
-
   xfer_count++;
   header = {
     .sync = SPI_SYNC,
@@ -355,7 +347,6 @@ int PandaSpiHandle::spi_transfer(uint8_t endpoint, uint8_t *tx_data, uint16_t tx
   if (ret < 0) {
     goto fail;
   }
-  wait_for_spi_turnaround(nanos_since_boot());
 
   // Send data
   if (tx_data != NULL) {
@@ -398,7 +389,6 @@ int PandaSpiHandle::spi_transfer(uint8_t endpoint, uint8_t *tx_data, uint16_t tx
     memcpy(rx_data, rx_buf + 3, rx_data_len);
   }
 
-  spi_last_bus_activity_ns = nanos_since_boot();
   return rx_data_len;
 
 fail:
@@ -413,7 +403,6 @@ fail:
     }
   }
 
-  spi_last_bus_activity_ns = nanos_since_boot();
   if (ret >= 0) ret = -1;
   return ret;
 }


### PR DESCRIPTION
This reverts commit aa0ac919baa0df2fa792e281246d4a1a1e6a1652 (#38464).

Fixes #38755

### Motivation
Commit aa0ac919b added an unconditional 400 µs (`400000` ns) busy-wait spinlock in `spi.cc`:
```cpp
static void wait_for_spi_turnaround(uint64_t start_ns) {
  while ((nanos_since_boot() - start_ns) < 400000) {}
}
```
called inside `PandaSpiHandle::spi_transfer()` via `wait_for_spi_turnaround(nanos_since_boot())`.

### Impact & Root Cause Analysis
1. **pandad Loop Overrun:** `pandad` executes >1,200 SPI transfers per second across its 100 Hz main loop (`can_recv`, `serial_read`, peripheral/panda state) and `can_send_thread`. The 400 µs spinlock and `hw_lock` contention cause `pandad` to exceed its 10.0 ms budget, dropping its effective execution rate to ~99.53 Hz.
2. **Linear Growth in `carState.cumLagMs`:** `card.py` is event-driven by CAN arrival and cannot run faster to catch up. In `realtime.py`, `Ratekeeper.monitor_time()` accumulates each ~47 µs frame delay without resetting `_next_frame_time`, resulting in an exact linear drift of ~4.73 ms/s (~283 ms per 60-second segment, reaching ~6 seconds of accumulated lag in a 20-minute drive on route `424b2a6c1b69a3bc/0000006c--00a1917b4c`).
3. **LKAS Steering Errors:** Contention on `hw_lock` between the spinloops and `can_send_thread` delays outgoing steering CAN messages, violating EPS watchdog timing and triggering dashboard LKAS faults.

Reverting restores the proven baseline for the 0.11.2 release while proper protocol/firmware-level turnaround synchronization (moving blocking tick work out of IRQ context in Panda firmware) is developed.
