### PR TITLE
modeld: build DM warp and model JITs for all camera configs

### DIFF
--- a/openpilot/selfdrive/modeld/SConscript
+++ b/openpilot/selfdrive/modeld/SConscript
@@ -23,14 +23,16 @@ def estimate_pickle_max_size(onnx_size):
   # the ONNX size. Overestimating only adds an empty trailing chunk.
   return 2.0 * onnx_size + 10 * 1024 * 1024
 
+CAMERA_CONFIGS = [
+  (_ar_ox_fisheye.width, _ar_ox_fisheye.height),  # tici: 1928x1208
+  (_os_fisheye.width, _os_fisheye.height),        # mici: 1344x760
+]
+camera_configs = CAMERA_CONFIGS
+
 if arch == 'comma_arm64':
-  from openpilot.common.hardware import HARDWARE
-  camera = _os_fisheye if HARDWARE.get_device_type() == "mici" else _ar_ox_fisheye
-  camera_configs = [(camera.width, camera.height)]
   tg_backend = 'QCOM'
   tg_flags = f'DEV={tg_backend} IMAGE=1 FLOAT16=1 NOLOCALS=1 JIT_BATCH_SIZE=0 OPENPILOT_HACKS=1'
 else:
-  camera_configs = [(c.width, c.height) for c in (_ar_ox_fisheye, _os_fisheye)]
   tg_backend = 'CPU'
   tg_flags = f'DEV=CPU' if arch == 'Darwin' else 'DEV=CPU:LLVM'
 

--- a/openpilot/selfdrive/modeld/SConscript
+++ b/openpilot/selfdrive/modeld/SConscript
@@ -23,11 +23,7 @@ def estimate_pickle_max_size(onnx_size):
   # the ONNX size. Overestimating only adds an empty trailing chunk.
   return 2.0 * onnx_size + 10 * 1024 * 1024
 
-CAMERA_CONFIGS = [
-  (_ar_ox_fisheye.width, _ar_ox_fisheye.height),  # tici: 1928x1208
-  (_os_fisheye.width, _os_fisheye.height),        # mici: 1344x760
-]
-camera_configs = CAMERA_CONFIGS
+camera_configs = [(c.width, c.height) for c in (_ar_ox_fisheye, _os_fisheye)]
 
 if arch == 'comma_arm64':
   tg_backend = 'QCOM'


### PR DESCRIPTION
### Description

Fixes #38762.

In PR #38684 (`amd warp`, commit `cb85ac1f0e78425752cf744b2ca2cd268720a337`), `openpilot/selfdrive/modeld/SConscript` replaced static `CAMERA_CONFIGS` with host device-dependent resolution selection on `comma_arm64`:
```python
if arch == 'comma_arm64':
  from openpilot.common.hardware import HARDWARE
  camera = _os_fisheye if HARDWARE.get_device_type() == "mici" else _ar_ox_fisheye
  camera_configs = [(camera.width, camera.height)]
```

Because prebuilt staging/nightly release jobs (e.g. `tizi-needs-can` build stage in Jenkins) build on TICI runners, `camera_configs` only contained `(1928, 1208)`. Consequently:
- `dm_warp_1344x760_tinygrad.pkl` was omitted from the packaged prebuilt bundle.
- When installed on a Comma 4 (MICI), `dmonitoringmodeld` crashed with:
  `FileNotFoundError: openpilot/selfdrive/modeld/models/dm_warp_1344x760_tinygrad.pkl`
  leaving DM calibration at 0%.

### Solution
Restore `CAMERA_CONFIGS` containing both camera resolutions (`(_ar_ox_fisheye.width, _ar_ox_fisheye.height)` and `(_os_fisheye.width, _os_fisheye.height)`) across all platforms so prebuilts contain the DM warp artifacts and model JITs for both Comma 3/3X and Comma 4.
