### PR TITLE
cruise: preserve Hyundai set speed across MAIN

### DIFF
--- a/openpilot/selfdrive/car/cruise.py
+++ b/openpilot/selfdrive/car/cruise.py
@@ -59,7 +59,7 @@ class VCruiseHelper:
         elif CS.cruiseState.speed == -1:
           self.v_cruise_kph = -1
           self.v_cruise_cluster_kph = -1
-    else:
+    elif self.CP.pcmCruise or self.CP.brand != "hyundai":
       self.v_cruise_kph = V_CRUISE_UNSET
       self.v_cruise_cluster_kph = V_CRUISE_UNSET
 

--- a/openpilot/selfdrive/car/tests/test_cruise_speed.py
+++ b/openpilot/selfdrive/car/tests/test_cruise_speed.py
@@ -149,3 +149,16 @@ class TestVCruiseHelper(OpenpilotTestCase):
         self.enable(float(v_ego), experimental_mode)
         assert V_CRUISE_INITIAL <= self.v_cruise_helper.v_cruise_kph <= V_CRUISE_MAX
         assert self.v_cruise_helper.v_cruise_initialized
+
+
+class TestHyundaiVCruiseHelper(OpenpilotTestCase):
+  def test_main_button_preserves_cruise_speed(self):
+    CP = car.CarParams(brand="hyundai", pcmCruise=False)
+    cruise_helper = VCruiseHelper(CP)
+    cruise_helper.initialize_v_cruise(car.CarState(vEgo=20), experimental_mode=False)
+    expected_speed = cruise_helper.v_cruise_kph
+
+    cruise_helper.update_v_cruise(car.CarState(cruiseState={"available": False}), enabled=False, is_metric=True)
+
+    assert cruise_helper.v_cruise_kph == expected_speed
+    assert cruise_helper.v_cruise_cluster_kph == expected_speed


### PR DESCRIPTION
Fixes #30950.

Depends on commaai/opendbc#3719.

When MAIN makes cruise unavailable on a non-PCM Hyundai, preserve the initialized openpilot set speed. This matches the stock behavior implemented in the dependent opendbc PR, where MAIN gates availability without erasing the remembered speed.

The existing reset behavior is unchanged for PCM cruise and every non-Hyundai brand.

## Tests

- 6 focused VCruiseHelper tests passed, including the Hyundai MAIN regression test
- ruff passed on both changed Python files