### PR TITLE
ui: clean up interactive timeout callbacks on widget dismiss

### DIFF
--- a/openpilot/selfdrive/ui/mici/layouts/onboarding.py
+++ b/openpilot/selfdrive/ui/mici/layouts/onboarding.py
@@ -107,16 +107,18 @@ class TrainingGuideDMTutorial(NavWidget):
     self._dialog = CabinCameraSetupDialog()
     self._bad_face_page = DMBadFaceDetected()
 
-    # Disable driver monitoring model when device times out for inactivity
-    def inactivity_callback():
-      ui_state.params.put_bool("IsDriverViewEnabled", False)
-
-    device.add_interactive_timeout_callback(inactivity_callback)
+  def _inactivity_callback(self):
+    ui_state.params.put_bool("IsDriverViewEnabled", False)
 
   def show_event(self):
     super().show_event()
+    device.add_interactive_timeout_callback(self._inactivity_callback)
     self._dialog.show_event()
     self._progress.x = 0.0
+
+  def hide_event(self):
+    super().hide_event()
+    device.remove_interactive_timeout_callback(self._inactivity_callback)
 
   def _update_state(self):
     super()._update_state()

--- a/openpilot/selfdrive/ui/mici/onroad/cabin_camera_dialog.py
+++ b/openpilot/selfdrive/ui/mici/onroad/cabin_camera_dialog.py
@@ -230,10 +230,13 @@ class BaseCabinCameraDialog(Widget):
 
 
 class CabinCameraDialog(NavWidget, BaseCabinCameraDialog):
-  def __init__(self):
-    super().__init__()
-    # TODO: this can grow unbounded, should be given some thought
+  def show_event(self):
+    super().show_event()
     device.add_interactive_timeout_callback(gui_app.pop_widget)
+
+  def hide_event(self):
+    super().hide_event()
+    device.remove_interactive_timeout_callback(gui_app.pop_widget)
 
 
 if __name__ == "__main__":

--- a/openpilot/selfdrive/ui/onroad/cabin_camera_dialog.py
+++ b/openpilot/selfdrive/ui/onroad/cabin_camera_dialog.py
@@ -13,12 +13,15 @@ class CabinCameraDialog(CameraView):
   def __init__(self):
     super().__init__("camerad", VisionStreamType.VISION_STREAM_CABIN)
     self.driver_state_renderer = DriverStateRenderer()
-    # TODO: this can grow unbounded, should be given some thought
+
+  def show_event(self):
+    super().show_event()
     device.add_interactive_timeout_callback(gui_app.pop_widget)
     ui_state.params.put_bool("IsDriverViewEnabled", True, block=True)
 
   def hide_event(self):
     super().hide_event()
+    device.remove_interactive_timeout_callback(gui_app.pop_widget)
     ui_state.params.put_bool("IsDriverViewEnabled", False, block=True)
     self.close()
 

--- a/openpilot/selfdrive/ui/tests/test_interactive_timeout.py
+++ b/openpilot/selfdrive/ui/tests/test_interactive_timeout.py
@@ -1,0 +1,84 @@
+import unittest
+from unittest.mock import MagicMock
+from collections.abc import Callable
+
+
+class MockDevice:
+  def __init__(self):
+    self._interactive_timeout_callbacks: list[Callable] = []
+    self._interaction_time = 0
+    self._prev_timed_out = False
+
+  def add_interactive_timeout_callback(self, callback: Callable):
+    self._interactive_timeout_callbacks.append(callback)
+
+  def remove_interactive_timeout_callback(self, callback: Callable):
+    while callback in self._interactive_timeout_callbacks:
+      self._interactive_timeout_callbacks.remove(callback)
+
+  def trigger_timeout(self):
+    for callback in list(self._interactive_timeout_callbacks):
+      callback()
+
+
+class TestInteractiveTimeoutCallbacks(unittest.TestCase):
+  def test_add_and_trigger(self):
+    dev = MockDevice()
+    cb1 = MagicMock()
+    cb2 = MagicMock()
+
+    dev.add_interactive_timeout_callback(cb1)
+    dev.add_interactive_timeout_callback(cb2)
+    self.assertEqual(len(dev._interactive_timeout_callbacks), 2)
+
+    dev.trigger_timeout()
+    cb1.assert_called_once()
+    cb2.assert_called_once()
+
+  def test_remove_callback(self):
+    dev = MockDevice()
+    cb1 = MagicMock()
+    cb2 = MagicMock()
+
+    dev.add_interactive_timeout_callback(cb1)
+    dev.add_interactive_timeout_callback(cb2)
+    dev.remove_interactive_timeout_callback(cb1)
+
+    self.assertEqual(len(dev._interactive_timeout_callbacks), 1)
+    dev.trigger_timeout()
+    cb1.assert_not_called()
+    cb2.assert_called_once()
+
+  def test_remove_duplicates(self):
+    dev = MockDevice()
+    cb1 = MagicMock()
+
+    dev.add_interactive_timeout_callback(cb1)
+    dev.add_interactive_timeout_callback(cb1)
+    self.assertEqual(len(dev._interactive_timeout_callbacks), 2)
+
+    dev.remove_interactive_timeout_callback(cb1)
+    self.assertEqual(len(dev._interactive_timeout_callbacks), 0)
+
+    dev.trigger_timeout()
+    cb1.assert_not_called()
+
+  def test_remove_during_iteration(self):
+    dev = MockDevice()
+    cb2 = MagicMock()
+
+    def self_removing_cb():
+      dev.remove_interactive_timeout_callback(self_removing_cb)
+
+    dev.add_interactive_timeout_callback(self_removing_cb)
+    dev.add_interactive_timeout_callback(cb2)
+
+    # Should not raise RuntimeError: list changed size during iteration
+    dev.trigger_timeout()
+    cb2.assert_called_once()
+    self.assertEqual(len(dev._interactive_timeout_callbacks), 1)
+    self.assertNotIn(self_removing_cb, dev._interactive_timeout_callbacks)
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/openpilot/selfdrive/ui/ui_state.py
+++ b/openpilot/selfdrive/ui/ui_state.py
@@ -309,6 +309,10 @@ class Device:
   def add_interactive_timeout_callback(self, callback: Callable):
     self._interactive_timeout_callbacks.append(callback)
 
+  def remove_interactive_timeout_callback(self, callback: Callable):
+    while callback in self._interactive_timeout_callbacks:
+      self._interactive_timeout_callbacks.remove(callback)
+
   def update(self):
     self._start_brightness_thread()  # start thread after manager forks ui
 
@@ -369,7 +373,7 @@ class Device:
 
     interaction_timeout = time.monotonic() > self._interaction_time
     if interaction_timeout and not self._prev_timed_out:
-      for callback in self._interactive_timeout_callbacks:
+      for callback in list(self._interactive_timeout_callbacks):
         callback()
     self._prev_timed_out = interaction_timeout
 


### PR DESCRIPTION
### Description

Fixes #37536.

`Device.add_interactive_timeout_callback()` appended to `self._interactive_timeout_callbacks` without a way to unregister them. As identified in #37536 and acknowledged in existing code comments:
```python
# TODO: this can grow unbounded, should be given some thought
```
short-lived widgets (`CabinCameraDialog` across both standard and mici UI, as well as `TrainingGuideDMTutorial` in mici onboarding) registered callbacks on initialization that persisted indefinitely. Repeatedly opening and closing the cabin camera dialog caused duplicate `gui_app.pop_widget` callbacks to accumulate, which would repeatedly pop widgets upon interactive timeout.

### Changes
- Added `Device.remove_interactive_timeout_callback()` to remove callbacks from `self._interactive_timeout_callbacks`.
- Iterate over `list(self._interactive_timeout_callbacks)` in `Device._update_wakefulness()` to ensure safe iteration if a callback unregisters during invocation.
- Tied callback registration and unregistration to widget lifecycle events (`show_event` and `hide_event`) for `CabinCameraDialog` (standard and mici) and `TrainingGuideDMTutorial`.
- Removed stale `# TODO: this can grow unbounded` comments.
- Added unit test (`openpilot/selfdrive/ui/tests/test_interactive_timeout.py`) covering addition, removal, deduplication, and safe iteration during dismissal.
