### PR TITLE
cabana: add native replay log signal plots

### DIFF
--- a/openpilot/tools/cabana/.gitignore
+++ b/openpilot/tools/cabana/.gitignore
@@ -1,5 +1,8 @@
 bootstrap_icons.cc
 
 _cabana_ui
+tests/test_logsignals
+tests/test_log_replay
+tests/test_logpanel
 dbc/car_fingerprint_to_dbc.json
 tests/test_cabana

--- a/openpilot/tools/cabana/LOG_SIGNALS.md
+++ b/openpilot/tools/cabana/LOG_SIGNALS.md
@@ -1,0 +1,64 @@
+# Openpilot log signals in Cabana
+
+Cabana can plot numeric cereal log fields alongside its CAN tools and video. Enable log plotting when opening a route:
+
+```sh
+./openpilot/tools/cabana/cabana --log --demo
+./openpilot/tools/cabana/cabana --log "<route>"
+./openpilot/tools/cabana/cabana --log-layout openpilot/tools/cabana/layouts/steering.json "<route>"
+```
+
+This is an initial integration toward commaai/openpilot#38752. PlotJuggler remains available; this change does not claim full feature parity or completion of the bounty.
+
+## Plotting
+
+Open **View > Log Signals**. Search for a field such as `carState/vEgo`, then choose it from **Add signal**. Select a plot to add more curves to it, or click **New plot** before adding another signal. Scalars, booleans, enums, active union members, and numeric lists are supported. List names use indices, for example `modelV2/position/x/0`. The `_valid` field under each topic retains the message validity flag.
+
+Plots share an x range. **Follow playback** follows the same clock and selected time range as CAN charts and video. Drag or scroll in a plot to inspect a fixed range; Shift+click seeks playback. **Curves** provides scale, offset, and a first derivative in units per second. The derivative is computed after scaling/offset, and begins with a gap because the first sample has no predecessor.
+
+**Save layout** stores curve groups and transforms as JSON. Loading a malformed layout leaves the existing plots in place. A layout can reference fields that are not present in the current route; these are reported as having no cached samples, and remain in the layout.
+
+**Export visible CSV** exports selected, transformed samples in the displayed range using long-form rows. It includes the plot number and transform settings. Non-finite values and missing-segment boundaries appear as blank values. No interpolation is performed. Time is in seconds relative to the replay route origin.
+
+## Data loading and scope
+
+Log fields are extracted on replay's merge thread. Only the currently cached replay segments are retained. Seeking loads the required segments and updates the plots; exporting an interval does **not** download the entire route. Use Cabana's segment-cache setting to adjust the amount of data retained. There are no background log-field subscriptions or new message publishers.
+
+| Capability | This change |
+| --- | --- |
+| Numeric cereal fields, arrays, active unions | Supported for route replay |
+| Multiple curves, shared time range, video seek | Supported |
+| Scale, offset, first derivative | Supported |
+| Native JSON layouts and visible CSV export | Supported |
+| PlotJuggler XML curve groups | Import utility; restrictions below |
+| Live cereal streaming | Pending; `--log` rejects live-stream options |
+| XY plots, Lua/custom math, expression dependencies | Pending |
+| PlotJuggler tabs, docking, colors, axis settings | Pending |
+| Full-route performance and user acceptance | Pending real-route validation |
+
+## Importing a PlotJuggler layout
+
+```sh
+python3 openpilot/tools/cabana/import_loglayout.py \
+  openpilot/tools/plotjuggler/layouts/longitudinal.xml longitudinal.json
+./openpilot/tools/cabana/cabana --log-layout longitudinal.json "<route>"
+```
+
+The converter preserves raw time-series curve groups and scale/offset transforms with zero time offset. It strips the leading slash from field names. Tabs are flattened into plot groups, and styling/axis settings are not transferred. Unsupported modes, custom math curves, derivative plugins, and time shifts are rejected before creating the output file. Existing output files are never overwritten. Successful conversion does not guarantee that an older field name exists in a newer route.
+
+## Validation
+
+```sh
+scons -u -j4 openpilot/tools/cabana/_cabana_ui \
+  openpilot/tools/cabana/tests/test_logsignals \
+  openpilot/tools/cabana/tests/test_log_replay \
+  openpilot/tools/cabana/tests/test_logpanel
+openpilot/tools/cabana/tests/test_logsignals
+openpilot/tools/cabana/tests/test_log_replay
+openpilot/tools/cabana/tests/test_logpanel
+python3 -m unittest openpilot.tools.cabana.tests.test_loglayout -v
+```
+
+The native data tests cover typed fields, nested groups, inactive unions, arrays, non-finite values, duplicate/out-of-order samples, nanosecond precision, cache eviction, missing-segment gaps, transforms, layout validation, and CSV escaping. The replay integration test uses a generated local qlog with no CAN data to check paced playback, seeking, and exclusion of synthetic video-frame events. The headless ImGui/ImPlot test checks rendering with empty, non-finite, missing, and evicted data without requiring a display server.
+
+Before considering removal of PlotJuggler, exercise representative long routes and streaming sessions, migrate custom layouts/formulas, verify performance and video interaction on supported desktop platforms, and complete the maintainer's acceptance period.

--- a/openpilot/tools/cabana/README.md
+++ b/openpilot/tools/cabana/README.md
@@ -95,4 +95,6 @@ cabana
 
 ## Additional Information
 
+For plotting numeric openpilot log fields, layouts, and CSV export, see [Log Signals](LOG_SIGNALS.md).
+
 For more information, see the [openpilot wiki](https://github.com/commaai/openpilot/wiki/Cabana)

--- a/openpilot/tools/cabana/SConscript
+++ b/openpilot/tools/cabana/SConscript
@@ -28,7 +28,7 @@ bootstrap_icons_src = env.Command('assets/bootstrap_icons.cc', str(bootstrap_ico
 # sources shared by the imgui frontend and the core test
 core_srcs = ['streams/pandastream.cc', 'streams/devicestream.cc', 'streams/livestream.cc', 'streams/abstractstream.cc', 'streams/replaystream.cc',
              'dbc/dbc.cc', 'dbc/dbcfile.cc', 'dbc/dbcmanager.cc', 'utils/export.cc', 'utils/util.cc', 'utils/strings.cc',
-             'commands.cc', 'settings.cc', 'routes.cc', 'panda.cc']
+             'commands.cc', 'settings.cc', 'routes.cc', 'panda.cc', 'core/logsignals.cc']
 if arch != "Darwin":
   core_srcs += ['streams/socketcanstream.cc']
 
@@ -54,6 +54,8 @@ else:
 cabana_ui = ui_env.Program('_cabana_ui', ui_objs, LIBS=ui_libs)
 
 if GetOption('extras'):
+  logpanel_objs = [src for src in ui_objs if src != ui_env.File('ui/main.cc')]
+  ui_env.Program('tests/test_logpanel', ['tests/test_logpanel.cc'] + logpanel_objs, LIBS=ui_libs)
   cabana_core_test_env = env.Clone()
   cabana_core_test_env['CXXFLAGS'] += [opendbc_path]
   cabana_core_test_objects = [
@@ -68,6 +70,12 @@ if GetOption('extras'):
     cabana_core_test_env.Object('tests/cabana_core_qtstate', 'ui/qtstate.cc'),
   ]
   cabana_core_test_env.Program('tests/test_cabana', cabana_core_test_objects, LIBS=[replay_lib, common])
+  cabana_core_test_env.Program('tests/test_logsignals', ['tests/test_logsignals.cc', 'core/logsignals.cc'],
+                             LIBS=[cereal, 'capnp', 'kj', 'json11'])
+  log_replay_objects = [cabana_core_test_env.Object('tests/log_replay_' + src.replace('/', '_')[:-3], src)
+                       for src in ['tests/test_log_replay.cc', 'streams/abstractstream.cc', 'streams/replaystream.cc', 'settings.cc', 'core/logsignals.cc']]
+  cabana_core_test_env.Program('tests/test_log_replay', log_replay_objects + cabana_core_test_objects[1:],
+                             LIBS=[replay_lib, common, messaging, visionipc, cereal] + ffmpeg_libs + ['zstd', 'm', 'pthread'])
 
 output_json_file = 'openpilot/tools/cabana/dbc/car_fingerprint_to_dbc.json'
 generate_dbc = ui_env.Command('#' + output_json_file,

--- a/openpilot/tools/cabana/core/logsignals.cc
+++ b/openpilot/tools/cabana/core/logsignals.cc
@@ -1,0 +1,150 @@
+#include "tools/cabana/core/logsignals.h"
+
+#include <algorithm>
+#include <cmath>
+#include <iomanip>
+#include <limits>
+#include <locale>
+#include <sstream>
+#include <stdexcept>
+
+#include "json11/json11.hpp"
+
+namespace cabana {
+
+void appendLogSignal(capnp::DynamicValue::Reader value, const std::string &path, uint64_t mono_time, LogSignals &signals) {
+  double number;
+  switch (value.getType()) {
+    case capnp::DynamicValue::BOOL: number = value.as<bool>(); break;
+    case capnp::DynamicValue::INT: number = value.as<int64_t>(); break;
+    case capnp::DynamicValue::UINT: number = value.as<uint64_t>(); break;
+    case capnp::DynamicValue::FLOAT: number = value.as<double>(); break;
+    case capnp::DynamicValue::ENUM: number = value.as<capnp::DynamicEnum>().getRaw(); break;
+    case capnp::DynamicValue::STRUCT: {
+      auto reader = value.as<capnp::DynamicStruct>();
+      auto append_field = [&](capnp::StructSchema::Field field) {
+        auto type = field.getType();
+        if ((type.isStruct() || type.isList()) && !reader.has(field)) return;
+        appendLogSignal(reader.get(field), path + "/" + field.getProto().getName().cStr(), mono_time, signals);
+      };
+      for (auto field : reader.getSchema().getNonUnionFields()) append_field(field);
+      KJ_IF_MAYBE(field, reader.which()) { append_field(*field); }
+      return;
+    }
+    case capnp::DynamicValue::LIST: {
+      auto list = value.as<capnp::DynamicList>();
+      for (uint32_t i = 0; i < list.size(); ++i) {
+        appendLogSignal(list[i], path + "/" + std::to_string(i), mono_time, signals);
+      }
+      return;
+    }
+    default: return;
+  }
+  signals[path].push_back({mono_time, std::isfinite(number) ? number : std::numeric_limits<double>::quiet_NaN()});
+}
+
+std::vector<LogPoint> logPoints(const LogSegments &segments, const LogCurve &curve, uint64_t origin) {
+  std::vector<std::pair<LogSample, int>> samples;
+  for (const auto &[segment, signals] : segments) {
+    if (auto it = signals->find(curve.signal); it != signals->end()) {
+      for (const auto &sample : it->second) samples.emplace_back(sample, segment);
+    }
+  }
+  std::stable_sort(samples.begin(), samples.end(), [](const auto &a, const auto &b) { return a.first.mono_time < b.first.mono_time; });
+  std::vector<LogPoint> points;
+  points.reserve(samples.size());
+  int previous_segment = 0;
+  for (const auto &[sample, segment] : samples) {
+    // Subtract as integers first to retain nanosecond resolution without unsigned underflow.
+    double sec = sample.mono_time >= origin ? (sample.mono_time - origin) / 1e9 : -((origin - sample.mono_time) / 1e9);
+    double value = sample.value * curve.scale + curve.offset;
+    if (!std::isfinite(value)) value = std::numeric_limits<double>::quiet_NaN();
+    if (!points.empty() && points.back().x == sec) points.back().y = value;
+    else {
+      // Do not imply a continuous trace (or a derivative) across an unloaded segment.
+      if (!points.empty() && std::abs(int64_t(segment) - previous_segment) > 1) {
+        points.push_back({sec, std::numeric_limits<double>::quiet_NaN()});
+      }
+      points.push_back({sec, value});
+    }
+    previous_segment = segment;
+  }
+  if (curve.derivative) {
+    for (size_t i = points.size(); i > 0; --i) {
+      points[i - 1].y = i > 1 && points[i - 1].x > points[i - 2].x
+                             ? (points[i - 1].y - points[i - 2].y) / (points[i - 1].x - points[i - 2].x)
+                             : std::numeric_limits<double>::quiet_NaN();
+      if (!std::isfinite(points[i - 1].y)) points[i - 1].y = std::numeric_limits<double>::quiet_NaN();
+    }
+  }
+  return points;
+}
+
+std::vector<LogPlot> parseLogLayout(const std::string &text) {
+  std::string error;
+  auto root = json11::Json::parse(text, error);
+  if (!error.empty() || !root.is_object() || root["version"].number_value() != 1 || !root["plots"].is_array()) {
+    throw std::runtime_error("Expected a Cabana log layout with version 1 and a plots array.");
+  }
+  std::vector<LogPlot> plots;
+  for (const auto &plot : root["plots"].array_items()) {
+    if (!plot.is_array() || plot.array_items().empty()) throw std::runtime_error("Each plot must contain at least one curve.");
+    LogPlot curves;
+    for (const auto &item : plot.array_items()) {
+      if (!item.is_object() || !item["signal"].is_string() || item["signal"].string_value().empty()) {
+        throw std::runtime_error("Every curve needs a nonempty signal name.");
+      }
+      LogCurve curve{item["signal"].string_value()};
+      for (auto entry : {std::pair{"scale", &curve.scale}, std::pair{"offset", &curve.offset}}) {
+        if (item.object_items().count(entry.first)) {
+          if (!item[entry.first].is_number() || !std::isfinite(item[entry.first].number_value())) {
+            throw std::runtime_error(std::string(entry.first) + " must be a finite number.");
+          }
+          *entry.second = item[entry.first].number_value();
+        }
+      }
+      if (item.object_items().count("derivative")) {
+        if (!item["derivative"].is_bool()) throw std::runtime_error("derivative must be a boolean.");
+        curve.derivative = item["derivative"].bool_value();
+      }
+      curves.push_back(std::move(curve));
+    }
+    plots.push_back(std::move(curves));
+  }
+  return plots;
+}
+
+std::string serializeLogLayout(const std::vector<LogPlot> &plots) {
+  json11::Json::array result;
+  for (const auto &plot : plots) {
+    json11::Json::array curves;
+    for (const auto &curve : plot) {
+      curves.push_back(json11::Json::object{{"signal", curve.signal}, {"scale", curve.scale},
+                                          {"offset", curve.offset}, {"derivative", curve.derivative}});
+    }
+    result.push_back(std::move(curves));
+  }
+  return json11::Json(json11::Json::object{{"version", 1}, {"plots", std::move(result)}}).dump();
+}
+
+std::string logCsv(const LogSegments &segments, const std::vector<LogPlot> &plots, uint64_t origin, double begin, double end) {
+  std::ostringstream out;
+  out.imbue(std::locale::classic());
+  out << "plot,signal,time,value,scale,offset,derivative\n" << std::setprecision(17);
+  for (size_t i = 0; i < plots.size(); ++i) {
+    for (const auto &curve : plots[i]) {
+      std::string name = "\"";
+      for (char c : curve.signal) name += c == '"' ? "\"\"" : std::string(1, c);
+      name += '"';
+      for (const auto &p : logPoints(segments, curve, origin)) {
+        if (p.x < begin || p.x > end) continue;
+        out << i + 1 << ',' << name << ',' << p.x << ',';
+        if (std::isfinite(p.y)) out << p.y;
+        out << ',' << curve.scale << ',' << curve.offset << ',' << curve.derivative << '\n';
+      }
+    }
+  }
+  return out.str();
+}
+
+}  // namespace cabana

--- a/openpilot/tools/cabana/core/logsignals.h
+++ b/openpilot/tools/cabana/core/logsignals.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <cstdint>
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <capnp/dynamic.h>
+
+namespace cabana {
+
+struct LogSample {
+  uint64_t mono_time;
+  double value;
+};
+using LogSeries = std::vector<LogSample>;
+using LogSignals = std::map<std::string, LogSeries>;
+// Immutable segments are shared with the UI; evicted replay segments release their plotted data too.
+using LogSegments = std::map<int, std::shared_ptr<const LogSignals>>;
+
+struct LogPoint {
+  double x, y;
+};
+
+struct LogCurve {
+  std::string signal;
+  double scale = 1.0;
+  double offset = 0.0;
+  bool derivative = false;
+};
+using LogPlot = std::vector<LogCurve>;
+
+// Flatten active numeric fields, including groups and lists, using PlotJuggler's slash-separated names.
+// Text/data and absent pointers are omitted. Non-finite values become gaps, not zero-valued samples.
+void appendLogSignal(capnp::DynamicValue::Reader value, const std::string &path, uint64_t mono_time, LogSignals &signals);
+std::vector<LogPoint> logPoints(const LogSegments &segments, const LogCurve &curve, uint64_t origin);
+
+// Layout parsing is transactional: invalid input throws before the caller replaces its current plots.
+std::vector<LogPlot> parseLogLayout(const std::string &text);
+std::string serializeLogLayout(const std::vector<LogPlot> &plots);
+std::string logCsv(const LogSegments &segments, const std::vector<LogPlot> &plots, uint64_t origin, double begin, double end);
+
+}  // namespace cabana

--- a/openpilot/tools/cabana/import_loglayout.py
+++ b/openpilot/tools/cabana/import_loglayout.py
@@ -1,0 +1,73 @@
+"""Import time-series curve groups from a PlotJuggler XML layout into Cabana.
+
+Unsupported math and plot modes are rejected rather than producing different data.
+Window geometry, tabs, curve colors, and axis limits are not transferred.
+"""
+import argparse
+import json
+import math
+from pathlib import Path
+import xml.etree.ElementTree as ET
+
+
+def convert_layout(xml: str) -> dict:
+  root = ET.fromstring(xml)
+  if root.tag != "root":
+    raise ValueError("Expected a PlotJuggler <root> layout")
+  equations = {item.get("name") for item in root.findall("./customMathEquations/*")}
+  plots = []
+  for plot in root.iter("plot"):
+    if plot.get("mode", "TimeSeries") != "TimeSeries":
+      raise ValueError("Only TimeSeries plots are supported; XY plots require manual migration")
+    curves = []
+    for element in plot.findall("curve"):
+      name = element.get("name", "")
+      if name in equations or not name.startswith("/"):
+        raise ValueError(f"Custom or unrecognized curve requires manual migration: {name}")
+      curve = {"signal": name.lstrip("/"), "scale": 1.0, "offset": 0.0, "derivative": False}
+      if not curve["signal"]:
+        raise ValueError("Empty signal name")
+      transforms = element.findall("transform")
+      if len(transforms) > 1:
+        raise ValueError(f"Multiple transforms require manual migration: {name}")
+      for transform in transforms:
+        if transform.get("name") != "Scale/Offset":
+          raise ValueError(f"Unsupported transform on {name}: {transform.get('name')}")
+        options = transform.find("options")
+        if options is None:
+          raise ValueError(f"Missing Scale/Offset options: {name}")
+        scale = float(options.get("value_scale", "1"))
+        offset = float(options.get("value_offset", "0"))
+        time_offset = float(options.get("time_offset", "0"))
+        if not all(math.isfinite(v) for v in (scale, offset, time_offset)) or time_offset != 0:
+          raise ValueError(f"Non-finite or time-shifted transform requires manual migration: {name}")
+        curve.update(scale=scale, offset=offset)
+      curves.append(curve)
+    if curves:
+      plots.append(curves)
+  if not plots:
+    raise ValueError("No time-series curves found")
+  return {"version": 1, "plots": plots}
+
+
+def main():
+  parser = argparse.ArgumentParser(description=__doc__)
+  parser.add_argument("layout", type=Path)
+  parser.add_argument("output", type=Path)
+  args = parser.parse_args()
+  try:
+    result = convert_layout(args.layout.read_text())
+  except (ET.ParseError, ValueError, OSError) as error:
+    parser.exit(1, f"Import failed: {error}\n")
+  # Exclusive creation keeps an existing layout intact, including on rejected imports.
+  try:
+    with args.output.open("x") as output:
+      json.dump(result, output, indent=2, allow_nan=False)
+      output.write("\n")
+  except OSError as error:
+    parser.exit(1, f"Unable to create output: {error}\n")
+  print(f"Imported {len(result['plots'])} plot groups. Review them in Cabana; window styling and tabs were not transferred.")
+
+
+if __name__ == "__main__":
+  main()

--- a/openpilot/tools/cabana/layouts/steering.json
+++ b/openpilot/tools/cabana/layouts/steering.json
@@ -1,0 +1,20 @@
+{
+  "version": 1,
+  "plots": [
+    [
+      {"signal": "carState/steeringAngleDeg"}
+    ],
+    [
+      {"signal": "carControl/actuators/torque"},
+      {"signal": "carOutput/actuatorsOutput/torque"},
+      {"signal": "carState/steeringPressed"}
+    ],
+    [
+      {"signal": "carState/vEgo", "scale": 3.6}
+    ],
+    [
+      {"signal": "controlsState/lateralControlState/torqueState/actualLateralAccel"},
+      {"signal": "controlsState/lateralControlState/torqueState/desiredLateralAccel"}
+    ]
+  ]
+}

--- a/openpilot/tools/cabana/streams/abstractstream.h
+++ b/openpilot/tools/cabana/streams/abstractstream.h
@@ -15,6 +15,7 @@
 
 #include "openpilot/cereal/messaging/messaging.h"
 #include "tools/cabana/core/can_data.h"
+#include "tools/cabana/core/logsignals.h"
 #include "tools/cabana/core/observable.h"
 #include "tools/cabana/dbc/dbcmanager.h"
 #include "tools/cabana/utils/util.h"
@@ -37,6 +38,9 @@ public:
   virtual double getSpeed() { return 1; }
   virtual bool isPaused() const { return false; }
   virtual void pause(bool pause) {}
+  virtual bool logSignalsEnabled() const { return false; }
+  const cabana::LogSegments &logSegments() const { return log_segments_; }
+  uint64_t logRevision() const { return log_revision_; }
   void setTimeRange(const std::optional<std::pair<double, double>> &range);
   const std::optional<std::pair<double, double>> &timeRange() const { return time_range_; }
 
@@ -63,6 +67,7 @@ public:
   Observable<double> seekedTo;
   Observable<const std::optional<std::pair<double, double>> &> timeRangeChanged;
   Observable<const MessageEventsMap &> eventsMerged;
+  Observable<> logSignalsChanged;
   Observable<const std::set<MessageId> *, bool> msgsReceived;
   Observable<const std::string &> error;
 
@@ -82,6 +87,8 @@ protected:
   std::vector<const CanEvent *> all_events_;
   double current_sec_ = 0;
   std::optional<std::pair<double, double>> time_range_;
+  cabana::LogSegments log_segments_;  // main thread only, immutable segment payloads
+  uint64_t log_revision_ = 0;
 
 private:
   void updateLastMsgsTo(double sec);

--- a/openpilot/tools/cabana/streams/replaystream.cc
+++ b/openpilot/tools/cabana/streams/replaystream.cc
@@ -18,14 +18,38 @@ ReplayStream::ReplayStream() {
 }
 
 ReplayStream::~ReplayStream() {
+  log_cancel_ = true;
   cancelWaits();
 }
 
 // runs on replay's merge thread: a segment of CAN data takes ~30 ms to parse and group, which dropped
 // frames when it ran on the main thread. Only the sorted insert and the merged signal need the main thread.
 void ReplayStream::mergeSegments() {
+  if (log_cancel_) return;
   auto event_data = replay->getEventData();
+  cabana::LogSegments next_log_segments;
   for (const auto &[n, seg] : event_data->segments) {
+    if (logSignalsEnabled()) {
+      auto it = log_cache_.find(n);
+      if (it != log_cache_.end()) {
+        next_log_segments.emplace(n, it->second);
+      } else {
+        auto signals = std::make_shared<cabana::LogSignals>();
+        for (const Event &e : seg->log->events) {
+          if (log_cancel_) return;
+          if (e.eidx_segnum != -1 || e.which == cereal::Event::CAN || e.which == cereal::Event::SENDCAN) continue;
+          capnp::FlatArrayMessageReader reader(e.data);
+          auto event = reader.getRoot<cereal::Event>();
+          auto dynamic = capnp::toDynamic(event);
+          KJ_IF_MAYBE(field, dynamic.which()) {
+            const std::string topic = field->getProto().getName().cStr();
+            cabana::appendLogSignal(dynamic.get(*field), topic, e.mono_time, *signals);
+            (*signals)[topic + "/_valid"].push_back({e.mono_time, double(event.getValid())});
+          }
+        }
+        next_log_segments.emplace(n, std::move(signals));
+      }
+    }
     if (!processed_segments.count(n)) {
       processed_segments.insert(n);
 
@@ -46,6 +70,20 @@ void ReplayStream::mergeSegments() {
       postToMainThreadAndWait([&]() { insertEvents(new_events, msg_events); });
     }
   }
+  if (logSignalsEnabled()) {
+    log_cache_ = std::move(next_log_segments);
+    postToMainThreadAndWait([this]() {
+      log_segments_ = log_cache_;
+      ++log_revision_;
+      logSignalsChanged();
+    });
+  }
+}
+
+void ReplayStream::updateLastMessages() {
+  // qlogs and other logs can contain no CAN messages; their playback clock must still advance.
+  if (logSignalsEnabled()) current_sec_ = replay->currentSeconds();
+  AbstractStream::updateLastMessages();
 }
 
 bool ReplayStream::loadRoute(const std::string &route, const std::string &data_dir, uint32_t replay_flags, bool auto_source) {

--- a/openpilot/tools/cabana/streams/replaystream.h
+++ b/openpilot/tools/cabana/streams/replaystream.h
@@ -17,6 +17,7 @@ public:
   bool eventFilter(const Event *event);
   void seekTo(double ts) override { replay->seekTo(std::max(double(0), ts), false); }
   bool liveStreaming() const override { return false; }
+  bool logSignalsEnabled() const override { return replay && replay->hasFlag(REPLAY_FLAG_LOAD_ALL_EVENTS); }
   inline std::string routeName() const override { return replay->route().name(); }
   inline std::string carFingerprint() const override { return replay->carFingerprint(); }
   double minSeconds() const override { return replay->minSeconds(); }
@@ -36,8 +37,12 @@ public:
 
 private:
   void mergeSegments();
-  std::unique_ptr<Replay> replay = nullptr;
+  void updateLastMessages() override;
+  cabana::LogSegments log_cache_;  // replay merge thread only
+  std::atomic<bool> log_cancel_ = false;
   Connection settings_connection_;
   std::set<int> processed_segments;
   std::unique_ptr<OpenpilotPrefix> op_prefix;
+  // Destroy Replay first: its merge thread reads the fields above until it has joined.
+  std::unique_ptr<Replay> replay = nullptr;
 };

--- a/openpilot/tools/cabana/tests/test_cabana_ui.py
+++ b/openpilot/tools/cabana/tests/test_cabana_ui.py
@@ -11,3 +11,22 @@ class TestCabanaUi(OpenpilotTestCase):
     result = subprocess.run(["./_cabana_ui", "-h"], cwd=CABANA_DIR, capture_output=True, text=True)
     assert result.returncode == 0, result.stderr
     assert "Usage:" in result.stderr
+    assert "--log-layout" in result.stderr
+
+  def test_log_arguments(self):
+    for args in (["--log"], ["--log", "--msgq"], ["--log-layout"]):
+      result = subprocess.run(["./_cabana_ui", *args], cwd=CABANA_DIR, capture_output=True, text=True, timeout=10)
+      assert result.returncode == 1, result.stderr
+      assert "error:" in result.stderr
+
+  def test_log_signals(self):
+    result = subprocess.run(["./tests/test_logsignals"], cwd=CABANA_DIR, capture_output=True, text=True, timeout=10)
+    assert result.returncode == 0, result.stderr
+
+  def test_log_replay(self):
+    result = subprocess.run(["./tests/test_log_replay"], cwd=CABANA_DIR, capture_output=True, text=True, timeout=15)
+    assert result.returncode == 0, result.stderr
+
+  def test_log_panel(self):
+    result = subprocess.run(["./tests/test_logpanel"], cwd=CABANA_DIR, capture_output=True, text=True, timeout=15)
+    assert result.returncode == 0, result.stderr

--- a/openpilot/tools/cabana/tests/test_log_replay.cc
+++ b/openpilot/tools/cabana/tests/test_log_replay.cc
@@ -1,0 +1,97 @@
+#include <chrono>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <thread>
+
+#include <capnp/serialize.h>
+
+#include "common/tests/native_test.h"
+#include "tools/cabana/streams/replaystream.h"
+
+namespace {
+
+struct Fixture {
+  Fixture() {
+    char path[] = "/tmp/cabana-log-replay-XXXXXX";
+    auto *created = mkdtemp(path);
+    REQUIRE(created != nullptr);
+    directory = created;
+    std::filesystem::create_directory(directory / (route + "--0"));
+    std::ofstream log(directory / (route + "--0/qlog"), std::ios::binary);
+    auto append = [&](uint64_t offset, auto init) {
+      capnp::MallocMessageBuilder message;
+      auto event = message.initRoot<cereal::Event>();
+      event.setLogMonoTime(origin + offset);
+      event.setValid(true);
+      init(event);
+      auto words = capnp::messageToFlatArray(message);
+      auto bytes = words.asBytes();
+      log.write(reinterpret_cast<const char *>(bytes.begin()), bytes.size());
+    };
+    append(0, [](auto e) { e.initInitData(); });
+    append(1, [](auto e) { e.initSelfdriveState(); });  // current schema; no legacy migration
+    for (int i = 0; i <= 20; ++i) {
+      append(i * 50000000ULL, [i](auto e) { e.initCarState().setVEgo(i); });
+    }
+    append(100000000, [&](auto e) {
+      auto idx = e.initNarrowRoadEncodeIdx();
+      idx.setType(cereal::EncodeIndex::Type::FULL_H_E_V_C);
+      idx.setTimestampSof(origin + 50000000);
+      idx.setSegmentNum(0);
+    });
+    log.close();
+    REQUIRE(bool(log));
+  }
+  ~Fixture() { std::filesystem::remove_all(directory); }
+  std::filesystem::path directory;
+  const std::string route = "2024-01-01--00-00-00";
+  const uint64_t origin = 1000000000000ULL;
+};
+
+template <typename Predicate>
+bool pumpUntil(Predicate predicate, int timeout_ms = 5000) {
+  const auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(timeout_ms);
+  while (std::chrono::steady_clock::now() < deadline) {
+    utils::drainMainThreadQueue();
+    if (predicate()) return true;
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
+  return false;
+}
+
+void test_log_replay() {
+  Fixture fixture;
+  struct ResetCan { ~ResetCan() { can = nullptr; } } reset;
+  ReplayStream stream;
+  can = &stream;
+  REQUIRE(stream.loadRoute(fixture.route, fixture.directory.string(),
+                          REPLAY_FLAG_LOAD_ALL_EVENTS | REPLAY_FLAG_NO_VIPC | REPLAY_FLAG_NO_LOOP));
+  REQUIRE(stream.logSignalsEnabled());
+  stream.start();
+  REQUIRE(pumpUntil([&]() { return stream.logRevision() > 0; }));
+  REQUIRE(stream.allEvents().empty());
+  auto points = cabana::logPoints(stream.logSegments(), {"carState/vEgo"}, stream.beginMonoTime());
+  REQUIRE(points.size() == 21);
+  REQUIRE(points.front().x == 0 && points.back().x == 1 && points.back().y == 20);
+  auto camera = cabana::logPoints(stream.logSegments(), {"narrowRoadEncodeIdx/segmentNum"}, stream.beginMonoTime());
+  REQUIRE(camera.size() == 1 && camera[0].x == 0.1);  // exclude replay's synthetic frame event
+  const auto start = std::chrono::steady_clock::now();
+  REQUIRE(pumpUntil([&]() { return stream.currentSec() >= 0.8; }));
+  REQUIRE(std::chrono::steady_clock::now() - start >= std::chrono::milliseconds(400));
+  stream.pause(true);
+  stream.seekTo(0.2);
+  REQUIRE(pumpUntil([&]() { return std::abs(stream.currentSec() - 0.2) < 0.01; }));
+  const auto revision = stream.logRevision();
+  REQUIRE(cabana::logPoints(stream.logSegments(), {"carState/vEgo"}, stream.beginMonoTime()).size() == 21);
+  REQUIRE(stream.logRevision() == revision);
+}
+
+}  // namespace
+
+int main() {
+  return run_native_test([] {
+    test_log_replay();
+    std::cout << "Log replay integration passed (no CAN, paced playback, seek, frame de-duplication)\n";
+  });
+}

--- a/openpilot/tools/cabana/tests/test_loglayout.py
+++ b/openpilot/tools/cabana/tests/test_loglayout.py
@@ -1,0 +1,40 @@
+from pathlib import Path
+import unittest
+
+from openpilot.tools.cabana.import_loglayout import convert_layout
+
+
+class TestLogLayoutImport(unittest.TestCase):
+  def test_upstream_longitudinal_layout(self):
+    path = Path(__file__).parents[2] / "plotjuggler/layouts/longitudinal.xml"
+    layout = convert_layout(path.read_text())
+    self.assertEqual(len(layout["plots"]), 4)
+    self.assertEqual(layout["plots"][0][0]["signal"], "carState/aEgo")
+    self.assertEqual(len(layout["plots"][0]), 4)
+
+  def test_scale_and_offset(self):
+    layout = convert_layout('''<root><plot mode="TimeSeries"><curve name="/carState/vEgo">
+      <transform name="Scale/Offset"><options value_scale="3.6" value_offset="-1" time_offset="0"/>
+      </transform></curve></plot></root>''')
+    self.assertEqual(layout["plots"][0][0], {"signal": "carState/vEgo", "scale": 3.6, "offset": -1, "derivative": False})
+
+  def test_unsupported_modes_are_rejected(self):
+    for xml in ('<root><plot mode="XY"><curve name="/carState/vEgo"/></plot></root>',
+                '<root><plot><curve name="custom math"/></plot></root>',
+                '<root><plot><curve name="/x"><transform name="Derivative"/></curve></plot></root>',
+                '<root><plot><curve name="/x"><transform name="Scale/Offset">'
+                '<options time_offset="1"/></transform></curve></plot></root>',
+                '<root><plot><curve name="/x"><transform name="Scale/Offset">'
+                '<options value_scale="nan"/></transform></curve></plot></root>',
+                '<root><plot><curve name="/"/></plot></root>', '<root/>'):
+      with self.subTest(xml=xml), self.assertRaises(ValueError):
+        convert_layout(xml)
+
+  def test_custom_math_cannot_masquerade_as_raw_signal(self):
+    xml = '<root><plot><curve name="/derived"/></plot><customMathEquations><snippet name="/derived"/></customMathEquations></root>'
+    with self.assertRaises(ValueError):
+      convert_layout(xml)
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/openpilot/tools/cabana/tests/test_logpanel.cc
+++ b/openpilot/tools/cabana/tests/test_logpanel.cc
@@ -1,0 +1,77 @@
+#include <cmath>
+#include <cstdio>
+#include <fstream>
+#include <limits>
+#include <unistd.h>
+
+#include "imgui.h"
+#include "implot.h"
+#include "common/tests/native_test.h"
+#include "tools/cabana/streams/abstractstream.h"
+#include "tools/cabana/ui/chart/logpanel.h"
+
+class TestLogStream : public DummyStream {
+public:
+  bool logSignalsEnabled() const override { return true; }
+  double maxSeconds() const override { return 1; }
+  void setData() {
+    auto signals = std::make_shared<cabana::LogSignals>();
+    (*signals)["carState/vEgo"] = {{0, 0}, {100000000, 1}, {200000000, std::numeric_limits<double>::quiet_NaN()}, {300000000, 3}};
+    log_segments_ = {{0, signals}};
+    ++log_revision_;
+  }
+  void evict() { log_segments_.clear(); ++log_revision_; }
+};
+
+void drawFrame(LogPanel &panel) {
+  ImGui::NewFrame();
+  ImGui::SetNextWindowSize(ImVec2(1000, 700));
+  ImGui::Begin("Log Signals");
+  panel.draw();
+  ImGui::End();
+  ImGui::Render();
+  const auto *data = ImGui::GetDrawData();
+  REQUIRE(data->TotalVtxCount > 0);
+  for (const auto *list : data->CmdLists) {
+    for (const auto &vertex : list->VtxBuffer) {
+      REQUIRE(std::isfinite(vertex.pos.x) && std::isfinite(vertex.pos.y));
+    }
+  }
+}
+
+int main() {
+  return run_native_test([] {
+    ImGui::CreateContext();
+    ImPlot::CreateContext();
+    auto &io = ImGui::GetIO();
+    io.IniFilename = nullptr;
+    io.DisplaySize = ImVec2(1100, 800);
+    io.DeltaTime = 1.0f / 60;
+    unsigned char *pixels;
+    int width, height;
+    io.Fonts->GetTexDataAsRGBA32(&pixels, &width, &height);
+    io.Fonts->SetTexID(1);
+    {
+      TestLogStream stream;
+      can = &stream;
+      LogPanel panel;
+      drawFrame(panel);
+      stream.setData();
+      char path[] = "/tmp/cabana-log-layout-XXXXXX";
+      int fd = mkstemp(path);
+      REQUIRE(fd >= 0);
+      close(fd);
+      std::ofstream(path) << R"({"version":1,"plots":[[{"signal":"carState/vEgo"},{"signal":"carState/vEgo","derivative":true}],[{"signal":"missing"}]]})";
+      panel.loadLayout(path);
+      std::remove(path);
+      drawFrame(panel);
+      drawFrame(panel);
+      stream.evict();
+      drawFrame(panel);
+      can = nullptr;
+    }
+    ImPlot::DestroyContext();
+    ImGui::DestroyContext();
+    std::cout << "Log panel headless rendering passed (empty, non-finite, missing, evicted data)\n";
+  });
+}

--- a/openpilot/tools/cabana/tests/test_logsignals.cc
+++ b/openpilot/tools/cabana/tests/test_logsignals.cc
@@ -1,0 +1,165 @@
+#include <cmath>
+#include <limits>
+#include <memory>
+#include <stdexcept>
+
+#include <capnp/message.h>
+
+#include "common/tests/native_test.h"
+#include "openpilot/cereal/gen/cpp/log.capnp.h"
+#include "tools/cabana/core/logsignals.h"
+
+namespace {
+
+void test_numeric_fields() {
+  capnp::MallocMessageBuilder message;
+  auto event = message.initRoot<cereal::Event>();
+  auto state = event.initCarState();
+  state.setVEgo(12.5);
+  state.setSteeringPressed(true);
+  state.setGearShifter(cereal::CarState::GearShifter::DRIVE);
+  state.initWheelSpeeds().setFl(13.0);
+  cabana::LogSignals signals;
+  cabana::appendLogSignal(capnp::toDynamic(state.asReader()), "carState", 42, signals);
+  REQUIRE(signals.at("carState/vEgo")[0].value == 12.5);
+  REQUIRE(signals.at("carState/vEgo")[0].mono_time == 42);
+  REQUIRE(signals.at("carState/steeringPressed")[0].value == 1);
+  REQUIRE(signals.at("carState/gasPressed")[0].value == 0);
+  REQUIRE(signals.at("carState/gearShifter")[0].value == static_cast<int>(cereal::CarState::GearShifter::DRIVE));
+  REQUIRE(signals.at("carState/wheelSpeeds/fl")[0].value == 13.0);
+}
+
+void test_lists_and_active_union() {
+  capnp::MallocMessageBuilder message;
+  auto event = message.initRoot<cereal::Event>();
+  auto model = event.initModelV2();
+  auto position = model.initPosition();
+  auto xs = position.initX(3);
+  xs.set(0, 1); xs.set(1, 2); xs.set(2, 3);
+  cabana::LogSignals signals;
+  cabana::appendLogSignal(capnp::toDynamic(event.asReader()), "event", 100, signals);
+  REQUIRE(signals.at("event/modelV2/position/x/0")[0].value == 1);
+  REQUIRE(signals.at("event/modelV2/position/x/2")[0].value == 3);
+  REQUIRE(!signals.count("event/modelV2/position/x/3"));
+  REQUIRE(!signals.count("event/carState/vEgo"));
+  REQUIRE(!signals.count("event/modelV2/velocity/x/0"));
+  // Switching the event union must not read the previous member.
+  signals.clear();
+  event.initCarState().setVEgo(2);
+  cabana::appendLogSignal(capnp::toDynamic(event.asReader()), "event", 101, signals);
+  REQUIRE(signals.at("event/carState/vEgo")[0].value == 2);
+  REQUIRE(!signals.count("event/modelV2/position/x/0"));
+  signals.clear();
+  event.initCarParams().initLateralTuning().initTorque().setFriction(0.1);
+  cabana::appendLogSignal(capnp::toDynamic(event.asReader()), "event", 102, signals);
+  REQUIRE(std::abs(signals.at("event/carParams/lateralTuning/torque/friction")[0].value - 0.1) < 1e-6);
+  REQUIRE(!signals.count("event/carParams/lateralTuning/pid/kpBP/0"));
+}
+
+void test_missing_and_non_numeric_fields() {
+  capnp::MallocMessageBuilder message;
+  auto event = message.initRoot<cereal::Event>();
+  auto params = event.initCarParams();
+  params.setCarFingerprint("TEST");
+  cabana::LogSignals signals;
+  cabana::appendLogSignal(capnp::toDynamic(params.asReader()), "carParams", 1, signals);
+  REQUIRE(!signals.count("carParams/carFingerprint"));
+  REQUIRE(!signals.count("carParams/carFw/0/ecu"));
+}
+
+void test_nonfinite_samples() {
+  capnp::MallocMessageBuilder message;
+  auto state = message.initRoot<cereal::Event>().initCarState();
+  state.setVEgo(std::numeric_limits<float>::infinity());
+  state.setAEgo(std::numeric_limits<float>::quiet_NaN());
+  cabana::LogSignals signals;
+  cabana::appendLogSignal(capnp::toDynamic(state.asReader()), "carState", 7, signals);
+  REQUIRE(std::isnan(signals.at("carState/vEgo")[0].value));
+  REQUIRE(std::isnan(signals.at("carState/aEgo")[0].value));
+}
+
+cabana::LogSegments sample_segments() {
+  auto a = std::make_shared<cabana::LogSignals>();
+  auto b = std::make_shared<cabana::LogSignals>();
+  (*a)["carState/vEgo"] = {{2000000000, 4}, {1000000000, 2}};
+  (*b)["carState/vEgo"] = {{2000000000, 5}, {3000000000, 8}};
+  return {{0, a}, {1, b}};
+}
+
+void test_ordering_duplicates_and_timestamps() {
+  auto points = cabana::logPoints(sample_segments(), {"carState/vEgo"}, 2000000000);
+  REQUIRE(points.size() == 3);
+  REQUIRE(points[0].x == -1 && points[0].y == 2);
+  REQUIRE(points[1].x == 0 && points[1].y == 5);
+  REQUIRE(points[2].x == 1 && points[2].y == 8);
+  REQUIRE(cabana::logPoints(sample_segments(), {"missing"}, 0).empty());
+  auto high = std::make_shared<cabana::LogSignals>();
+  const uint64_t origin = 9007199254740992ULL;
+  (*high)["x"] = {{origin - 1, 1}, {origin, 2}, {origin + 1, 3}};
+  auto tiny = cabana::logPoints({{0, high}}, {"x"}, origin);
+  REQUIRE(tiny[0].x == -1e-9 && tiny[2].x == 1e-9);
+}
+
+void test_transforms_and_eviction() {
+  auto segments = sample_segments();
+  auto points = cabana::logPoints(segments, {"carState/vEgo", 3.6, 1, true}, 0);
+  REQUIRE(std::isnan(points[0].y));
+  REQUIRE(std::abs(points[1].y - 10.8) < 1e-10);
+  REQUIRE(std::abs(points[2].y - 10.8) < 1e-10);
+  segments.erase(0);
+  points = cabana::logPoints(segments, {"carState/vEgo"}, 0);
+  REQUIRE(points.size() == 2 && points.front().x == 2);
+  auto gap = std::make_shared<cabana::LogSignals>();
+  (*gap)["x"] = {{0, 1}, {1000000000, std::numeric_limits<double>::quiet_NaN()}, {2000000000, 3}, {3000000000, 5}};
+  points = cabana::logPoints({{0, gap}}, {"x", 1, 0, true}, 0);
+  REQUIRE(std::isnan(points[1].y) && std::isnan(points[2].y) && points[3].y == 2);
+  (*gap)["x"] = {{0, 1}};
+  auto later = std::make_shared<cabana::LogSignals>();
+  (*later)["x"] = {{180000000000, 3}, {181000000000, 4}};
+  points = cabana::logPoints({{0, gap}, {3, later}}, {"x", 1, 0, true}, 0);
+  REQUIRE(points.size() == 4);
+  REQUIRE(std::isnan(points[1].y) && std::isnan(points[2].y) && points[3].y == 1);
+}
+
+void test_layout_roundtrip_and_validation() {
+  std::vector<cabana::LogPlot> plots = {{{"carState/vEgo", 3.6, -1, true}, {"carState/steeringPressed"}}, {{"modelV2/position/x/0"}}};
+  const auto text = cabana::serializeLogLayout(plots);
+  const auto parsed = cabana::parseLogLayout(text);
+  REQUIRE(parsed.size() == 2 && parsed[0].size() == 2);
+  REQUIRE(parsed[0][0].scale == 3.6 && parsed[0][0].offset == -1 && parsed[0][0].derivative);
+  REQUIRE(cabana::serializeLogLayout(parsed) == text);
+  auto defaults = cabana::parseLogLayout(R"({"version":1,"plots":[[{"signal":"x"}]]})");
+  REQUIRE(defaults[0][0].scale == 1 && defaults[0][0].offset == 0 && !defaults[0][0].derivative);
+  for (const char *bad : {"garbage", "[]", R"({"version":2,"plots":[]})", R"({"version":1,"plots":[[]]})",
+       R"({"version":1,"plots":[[{"signal":""}]]})", R"({"version":1,"plots":[[{"signal":"x","scale":"2"}]]})",
+       R"({"version":1,"plots":[[{"signal":"x","derivative":1}]]})", R"({"version":1,"plots":[[{"signal":"x","offset":null}]]})"}) {
+    bool rejected = false;
+    try { cabana::parseLogLayout(bad); } catch (const std::runtime_error &) { rejected = true; }
+    REQUIRE(rejected);
+  }
+}
+
+void test_csv_range_and_escaping() {
+  auto csv = cabana::logCsv(sample_segments(), {{{"carState/vEgo"}}}, 0, 1.5, 2.5);
+  REQUIRE(csv == "plot,signal,time,value,scale,offset,derivative\n1,\"carState/vEgo\",2,5,1,0,0\n");
+  auto signals = std::make_shared<cabana::LogSignals>();
+  (*signals)["a,\"b"] = {{0, std::numeric_limits<double>::quiet_NaN()}};
+  csv = cabana::logCsv({{0, signals}}, {{{"a,\"b"}}}, 0, 0, 0);
+  REQUIRE(csv.find("1,\"a,\"\"b\",0,,1,0,0\n") != std::string::npos);
+}
+
+}  // namespace
+
+int main() {
+  return run_native_test([] {
+    test_numeric_fields();
+    test_lists_and_active_union();
+    test_missing_and_non_numeric_fields();
+    test_nonfinite_samples();
+    test_ordering_duplicates_and_timestamps();
+    test_transforms_and_eviction();
+    test_layout_roundtrip_and_validation();
+    test_csv_range_and_escaping();
+    std::cout << "8 log signal test groups passed\n";
+  });
+}

--- a/openpilot/tools/cabana/ui/app.cc
+++ b/openpilot/tools/cabana/ui/app.cc
@@ -180,7 +180,7 @@ std::vector<KeyEvent> takeKeyEvents() {
   return std::exchange(g_key_events, {});
 }
 
-int run(std::unique_ptr<AbstractStream> stream, StreamLoader stream_loader, const std::string &dbc_file) {
+int run(std::unique_ptr<AbstractStream> stream, StreamLoader stream_loader, const std::string &dbc_file, const std::string &log_layout) {
   try {
     // SIGINT/SIGTERM close all windows (which may ask about unsaved changes), then exit
     UnixSignalHandler signal_handler([]() { g_signal_exit = true; });
@@ -193,7 +193,7 @@ int run(std::unique_ptr<AbstractStream> stream, StreamLoader stream_loader, cons
     inistate::load();
     inistate::applyWindowGeometry(glfw.window());
 
-    MainWindow win(glfw.window(), std::move(stream), std::move(stream_loader), dbc_file);
+    MainWindow win(glfw.window(), std::move(stream), std::move(stream_loader), dbc_file, log_layout);
     while (!win.exited()) {
       if (g_signal_exit.exchange(false)) {
         printf("\nexiting...\n");

--- a/openpilot/tools/cabana/ui/app.h
+++ b/openpilot/tools/cabana/ui/app.h
@@ -12,7 +12,7 @@ using StreamLoader = std::function<std::unique_ptr<AbstractStream>()>;
 
 // takes ownership of stream; a loader runs behind the window instead of before it; with neither, the
 // stream selector opens
-int run(std::unique_ptr<AbstractStream> stream, StreamLoader stream_loader, const std::string &dbc_file);
+int run(std::unique_ptr<AbstractStream> stream, StreamLoader stream_loader, const std::string &dbc_file, const std::string &log_layout = {});
 
 // key presses with the modifier state at event time: imgui may apply a modifier release in the same frame as
 // the key press it belongs to, which loses fast shortcut sequences. Consumed once per frame by MainWindow.

--- a/openpilot/tools/cabana/ui/chart/logpanel.cc
+++ b/openpilot/tools/cabana/ui/chart/logpanel.cc
@@ -1,0 +1,215 @@
+#include "tools/cabana/ui/chart/logpanel.h"
+
+#include <algorithm>
+#include <cmath>
+#include <fstream>
+#include <iterator>
+#include <set>
+#include <stdexcept>
+#include <tuple>
+
+#include "imgui.h"
+#include "implot.h"
+#include "tools/cabana/streams/abstractstream.h"
+#include "tools/cabana/ui/dialogs/filedialog.h"
+#include "tools/cabana/ui/dialogs/messagebox.h"
+#include "tools/cabana/ui/util.h"
+#include "tools/cabana/utils/strings.h"
+
+void LogPanel::loadLayout(const std::string &path) {
+  try {
+    std::ifstream in(path);
+    if (!in) throw std::runtime_error("Unable to read " + path);
+    const std::string text((std::istreambuf_iterator<char>(in)), {});
+    auto plots = cabana::parseLogLayout(text);
+    plots_ = std::move(plots);
+    active_plot_ = plots_.empty() ? -1 : 0;
+    dirty_ = true;
+  } catch (const std::exception &e) {
+    MessageBox::warning("Log Layout", e.what());
+  }
+}
+
+void LogPanel::writeFile(const std::string &path, const std::string &text) {
+  std::ofstream out(path);
+  out << text;
+  out.close();
+  if (!out) MessageBox::warning("Log Signals", "Unable to write " + path);
+}
+
+void LogPanel::fileActions() {
+  if (ImGui::Button("Load layout")) {
+    FileDialog::getOpenFileName("Load Log Layout", "", ".json", [this, alive = std::weak_ptr<bool>(alive_)](const auto &path) {
+      if (!alive.expired() && !path.empty()) loadLayout(path);
+    });
+  }
+  ImGui::SameLine();
+  ImGui::BeginDisabled(plots_.empty());
+  if (ImGui::Button("Save layout")) {
+    FileDialog::getSaveFileName("Save Log Layout", "log-layout.json", ".json", [this, alive = std::weak_ptr<bool>(alive_)](const auto &path) {
+      if (!alive.expired() && !path.empty()) writeFile(path, cabana::serializeLogLayout(plots_));
+    });
+  }
+  ImGui::SameLine();
+  if (ImGui::Button("Export visible CSV")) {
+    FileDialog::getSaveFileName("Export Log Signals", "log-signals.csv", ".csv", [this, alive = std::weak_ptr<bool>(alive_)](const auto &path) {
+      if (!alive.expired() && !path.empty()) {
+        writeFile(path, cabana::logCsv(can->logSegments(), plots_, can->beginMonoTime(), range_min_, range_max_));
+      }
+    });
+  }
+  ImGui::EndDisabled();
+}
+
+void LogPanel::refresh() {
+  if (revision_ != can->logRevision()) {
+    revision_ = can->logRevision();
+    std::set<std::string> names;
+    for (const auto &[_, signals] : can->logSegments()) {
+      for (const auto &[name, samples] : *signals) names.insert(name);
+    }
+    names_.assign(names.begin(), names.end());
+    dirty_ = true;
+  }
+  if (!dirty_) return;
+  points_.clear();
+  line_indices_.clear();
+  for (const auto &plot : plots_) {
+    auto &curves = points_.emplace_back();
+    auto &lines = line_indices_.emplace_back();
+    for (const auto &curve : plot) {
+      auto &points = curves.emplace_back(cabana::logPoints(can->logSegments(), curve, can->beginMonoTime()));
+      auto &indices = lines.emplace_back();
+      for (size_t i = 1; i < points.size(); ++i) {
+        if (std::isfinite(points[i - 1].y) && std::isfinite(points[i].y)) {
+          indices.push_back(i - 1);
+          indices.push_back(i);
+        }
+      }
+    }
+  }
+  dirty_ = false;
+}
+
+void LogPanel::draw() {
+  if (!can->logSignalsEnabled()) {
+    ImGui::TextWrapped("Open a route with --log to plot openpilot log fields alongside CAN data and video.");
+    return;
+  }
+  refresh();
+  fileActions();
+  ImGui::Checkbox("Follow playback", &follow_);
+  ImGui::SameLine();
+  if (ImGui::Button(can->isPaused() ? "Play" : "Pause")) can->pause(!can->isPaused());
+  ImGui::SameLine();
+  ImGui::Text("%.2f s | %zu cached segments", can->currentSec(), can->logSegments().size());
+  ImGui::TextDisabled("Drag to pan; wheel to zoom; Shift+click to seek the video. Export uses cached samples only.");
+
+  if (follow_) {
+    if (can->timeRange()) {
+      std::tie(range_min_, range_max_) = *can->timeRange();
+    } else {
+      range_min_ = std::max(can->minSeconds(), can->currentSec() - 15.0);
+      range_max_ = range_min_ + 30.0;
+    }
+  }
+  ImGui::SetNextItemWidth(-1);
+  inputText("##log_filter", &filter_, "Search log fields (e.g. carState/vEgo)");
+  if (ImGui::BeginCombo("Add signal", "Select a log field")) {
+    for (const auto &name : names_) {
+      if (!filter_.empty() && !utils::containsCI(name, filter_)) continue;
+      if (ImGui::Selectable(name.c_str())) {
+        if (active_plot_ < 0 || active_plot_ >= (int)plots_.size()) {
+          plots_.push_back({});
+          active_plot_ = plots_.size() - 1;
+        }
+        auto &plot = plots_[active_plot_];
+        if (std::none_of(plot.begin(), plot.end(), [&](const auto &curve) { return curve.signal == name; })) {
+          plot.push_back({name});
+          dirty_ = true;
+        }
+      }
+    }
+    ImGui::EndCombo();
+  }
+  ImGui::SameLine();
+  if (ImGui::Button("New plot")) active_plot_ = -1;
+  ImGui::SameLine();
+  if (active_plot_ < 0) ImGui::TextDisabled("Next signal starts a new plot");
+  else ImGui::TextDisabled("Adding to plot %d", active_plot_ + 1);
+
+  refresh();
+  if (names_.empty()) ImGui::TextWrapped("Waiting for numeric log fields in the loaded segments.");
+  ImGui::BeginChild("log_plots");
+  int remove_plot = -1;
+  for (size_t i = 0; i < plots_.size(); ++i) {
+    ImGui::PushID((int)i);
+    if (ImGui::RadioButton(("Plot " + std::to_string(i + 1)).c_str(), active_plot_ == (int)i)) active_plot_ = i;
+    ImGui::SameLine();
+    if (ImGui::Button("Curves")) ImGui::OpenPopup("curves");
+    ImGui::SameLine();
+    if (ImGui::Button("Remove plot")) remove_plot = i;
+    if (ImGui::BeginPopup("curves")) {
+      int remove_curve = -1;
+      for (size_t j = 0; j < plots_[i].size(); ++j) {
+        auto &curve = plots_[i][j];
+        ImGui::PushID((int)j);
+        ImGui::TextUnformatted(curve.signal.c_str());
+        double scale = curve.scale, offset = curve.offset;
+        if (ImGui::InputDouble("Scale", &scale) && std::isfinite(scale)) { curve.scale = scale; dirty_ = true; }
+        if (ImGui::InputDouble("Offset", &offset) && std::isfinite(offset)) { curve.offset = offset; dirty_ = true; }
+        if (ImGui::Checkbox("Derivative (per second)", &curve.derivative)) dirty_ = true;
+        if (ImGui::Button("Remove curve")) remove_curve = j;
+        ImGui::Separator();
+        ImGui::PopID();
+      }
+      if (remove_curve >= 0) {
+        plots_[i].erase(plots_[i].begin() + remove_curve);
+        dirty_ = true;
+        if (plots_[i].empty()) remove_plot = i;
+      }
+      ImGui::EndPopup();
+    }
+    // A curve edit changes the number/order of cached series before this frame's plot is drawn.
+    refresh();
+    ImPlot::SetNextAxisLimits(ImAxis_X1, range_min_, range_max_, ImPlotCond_Always);
+    if (ImPlot::BeginPlot("##log_plot", ImVec2(-1, 240))) {
+      ImPlot::SetupAxes("Time (s)", nullptr, ImPlotAxisFlags_None, ImPlotAxisFlags_AutoFit);
+      for (size_t j = 0; j < plots_[i].size(); ++j) {
+        auto &points = points_[i][j];
+        const auto &curve = plots_[i][j];
+        const std::string label = curve.signal + (curve.derivative ? " (d/dt)" : "") + "##" + std::to_string(j);
+        // Explicit finite pairs preserve gaps without passing NaNs to the renderer.
+        using LineData = std::pair<const std::vector<cabana::LogPoint> *, const std::vector<int> *>;
+        auto &indices = line_indices_[i][j];
+        LineData data{&points, &indices};
+        ImPlot::PlotLineG(label.c_str(), [](int idx, void *user_data) {
+          const auto &[line_points, line_indices] = *static_cast<const LineData *>(user_data);
+          const auto &p = (*line_points)[(*line_indices)[idx]];
+          return ImPlotPoint(p.x, p.y);
+        }, &data, indices.size(), ImPlotSpec(ImPlotProp_Flags, ImPlotLineFlags_Segments));
+      }
+      const double cursor = can->currentSec();
+      ImPlot::PlotInfLines("Playback", &cursor, 1);
+      if (ImPlot::IsPlotHovered()) {
+        if (ImGui::GetIO().KeyShift && ImGui::IsMouseClicked(ImGuiMouseButton_Left)) {
+          can->seekTo(std::clamp(ImPlot::GetPlotMousePos().x, can->minSeconds(), can->maxSeconds()));
+        }
+        if (ImGui::IsMouseDragging(ImGuiMouseButton_Left) || ImGui::GetIO().MouseWheel != 0) follow_ = false;
+      }
+      const auto limits = ImPlot::GetPlotLimits();
+      if (!follow_) { range_min_ = limits.X.Min; range_max_ = limits.X.Max; }
+      ImPlot::EndPlot();
+    }
+    for (size_t j = 0; j < plots_[i].size(); ++j) {
+      if (points_[i][j].empty()) ImGui::TextDisabled("No cached samples: %s", plots_[i][j].signal.c_str());
+    }
+    ImGui::PopID();
+  }
+  if (remove_plot >= 0) {
+    plots_.erase(plots_.begin() + remove_plot);
+    active_plot_ = plots_.empty() ? -1 : std::min(active_plot_, (int)plots_.size() - 1);
+    dirty_ = true;
+  }
+  ImGui::EndChild();
+}

--- a/openpilot/tools/cabana/ui/chart/logpanel.h
+++ b/openpilot/tools/cabana/ui/chart/logpanel.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <limits>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "tools/cabana/core/logsignals.h"
+
+class LogPanel {
+public:
+  void draw();
+  void loadLayout(const std::string &path);
+
+private:
+  void refresh();
+  void writeFile(const std::string &path, const std::string &text);
+  void fileActions();
+  std::vector<cabana::LogPlot> plots_;
+  std::vector<std::vector<std::vector<cabana::LogPoint>>> points_;
+  std::vector<std::vector<std::vector<int>>> line_indices_;
+  std::vector<std::string> names_;
+  std::string filter_;
+  int active_plot_ = -1;
+  bool dirty_ = true;
+  bool follow_ = true;
+  uint64_t revision_ = std::numeric_limits<uint64_t>::max();
+  double range_min_ = 0, range_max_ = 30;
+  std::shared_ptr<bool> alive_ = std::make_shared<bool>(true);
+};

--- a/openpilot/tools/cabana/ui/main.cc
+++ b/openpilot/tools/cabana/ui/main.cc
@@ -31,12 +31,14 @@ struct CabanaArgs {
   bool panda = false;
   bool no_vipc = false;
   bool no_cache = false;
+  bool log = false;
   std::string panda_serial;
   std::string socketcan;
   std::string zmq;
   std::string data_dir;
   std::string dbc;
   std::string route;
+  std::string log_layout;
 };
 
 void printUsage(const char *argv0) {
@@ -63,6 +65,8 @@ void printUsage(const char *argv0) {
           "  --data_dir <dir>          local directory with routes\n"
           "  --no-vipc                 do not output video\n"
           "  --no-cache                turn off the local route file cache\n"
+          "  --log                     plot numeric openpilot log fields (route replay)\n"
+          "  --log-layout <file>       load a Cabana log layout and enable --log\n"
           "  --dbc <file>              dbc file to open\n",
           argv0);
 }
@@ -114,6 +118,11 @@ std::optional<int> parseArgs(int argc, char *argv[], CabanaArgs &args) {
       args.no_vipc = true;
     } else if (std::strcmp(a, "--no-cache") == 0) {
       args.no_cache = true;
+    } else if (std::strcmp(a, "--log") == 0) {
+      args.log = true;
+    } else if (std::strcmp(a, "--log-layout") == 0) {
+      if (!takeValue(argc, argv, i, args.log_layout)) return 1;
+      args.log = true;
     } else if (std::strcmp(a, "--dbc") == 0) {
       if (!takeValue(argc, argv, i, args.dbc)) return 1;
     } else if (a[0] == '-') {
@@ -139,12 +148,22 @@ int main(int argc, char *argv[]) {
   // arenas fragment without bound (RSS grew ~3 MB/min with charts open). macOS has a single allocator zone.
   mallopt(M_ARENA_MAX, 1);
 #endif
+  const auto invocation_dir = std::filesystem::current_path();
   // ensure the current dir matches the executable's directory
   std::error_code ec;
   std::filesystem::current_path(executableDir(), ec);
 
   CabanaArgs args;
   if (auto code = parseArgs(argc, argv, args)) return *code;
+  if (!args.log_layout.empty()) args.log_layout = (invocation_dir / args.log_layout).string();
+  if (args.log && (args.msgq || args.panda || !args.zmq.empty() || !args.socketcan.empty())) {
+    fprintf(stderr, "error: --log currently requires route replay\n");
+    return 1;
+  }
+  if (args.log && args.route.empty() && !args.demo) {
+    fprintf(stderr, "error: --log requires a route or --demo\n");
+    return 1;
+  }
 
   std::unique_ptr<AbstractStream> stream;
   StreamLoader stream_loader;
@@ -175,6 +194,7 @@ int main(int argc, char *argv[]) {
     if (args.cabin) replay_flags |= REPLAY_FLAG_CABIN_CAMERA;
     if (args.no_vipc) replay_flags |= REPLAY_FLAG_NO_VIPC;
     if (args.no_cache) replay_flags |= REPLAY_FLAG_NO_FILE_CACHE;
+    if (args.log) replay_flags |= REPLAY_FLAG_LOAD_ALL_EVENTS;
 
     std::string route;
     if (!args.route.empty()) {
@@ -198,5 +218,5 @@ int main(int argc, char *argv[]) {
     }
   }
 
-  return run(std::move(stream), std::move(stream_loader), args.dbc);
+  return run(std::move(stream), std::move(stream_loader), args.dbc, args.log_layout);
 }

--- a/openpilot/tools/cabana/ui/mainwin.cc
+++ b/openpilot/tools/cabana/ui/mainwin.cc
@@ -33,10 +33,11 @@ namespace {
 constexpr const char *VIDEO_PANEL = "###VideoPanel";
 constexpr const char *CENTER_PANEL = "###CenterWidget";
 constexpr const char *CHARTS_WINDOW = "Charts###ChartsWindow";
+constexpr const char *LOG_PANEL = "Log Signals###LogSignals";
 }  // namespace
 
 MainWindow::MainWindow(GLFWwindow *window, std::unique_ptr<AbstractStream> stream, StreamLoader stream_loader,
-                       const std::string &dbc_file) : window_(window) {
+                       const std::string &dbc_file, const std::string &log_layout) : window_(window), startup_log_layout_(log_layout) {
   can = &dummy_;
   video_splitter_ratio_ = inistate::main_window.video_splitter_ratio;
   messages_visible_ = inistate::main_window.messages_visible;
@@ -153,6 +154,7 @@ void MainWindow::drawMenuBar() {
     ImGui::Separator();
     ImGui::MenuItem(messages_widget_ ? messages_widget_->title().c_str() : "MESSAGES", nullptr, &messages_visible_);
     ImGui::MenuItem(video_dock_title_.empty() ? "##video_dock" : video_dock_title_.c_str(), nullptr, &video_visible_);
+    ImGui::MenuItem("Log Signals", nullptr, &log_visible_);
     ImGui::Separator();
     if (ImGui::MenuItem("Reset Window Layout")) {
       messages_visible_ = video_visible_ = true;
@@ -180,6 +182,9 @@ void MainWindow::createDockWidgets() {
   widget_connections_.push_back(messages_widget_->msgSelectionChanged.connect([this](const MessageId &id) { center_widget_.setMessage(id); }));
 
   charts_widget_ = std::make_unique<ChartsWidget>();
+  log_panel_ = std::make_unique<LogPanel>();
+  log_visible_ = can->logSignalsEnabled();
+  if (!startup_log_layout_.empty()) log_panel_->loadLayout(std::exchange(startup_log_layout_, {}));
   center_widget_.setChartsWidget(charts_widget_.get());
   video_widget_ = std::make_unique<VideoWidget>();
   widget_connections_.push_back(charts_widget_->toggleChartsDocking.connect([this]() { toggleChartsDocking(); }));
@@ -336,6 +341,7 @@ void MainWindow::releaseStream() {
   wait_dlg_.open = false;
   widget_connections_.clear();
   charts_widget_.reset();
+  log_panel_.reset();
   video_widget_.reset();
   center_widget_.clear();
   messages_widget_.reset();
@@ -368,6 +374,10 @@ void MainWindow::startStream(std::unique_ptr<AbstractStream> stream, const std::
     }
 
     stream_connections_.push_back(can->eventsMerged.connect([this](const MessageEventsMap &) { eventsMerged(); }));
+    stream_connections_.push_back(can->logSignalsChanged.connect([this]() {
+      eventsMerged();
+      wait_dlg_.open = false;
+    }));
 
     if (hasStream()) {
       wait_dlg_.text = can->liveStreaming() ? "Waiting for the live stream to start..." : "Loading segment data...";
@@ -783,7 +793,7 @@ void MainWindow::drawDockspace() {
     ImGui::DockBuilderDockWindow(MESSAGES_PANEL_ID, left);
     ImGui::DockBuilderDockWindow(VIDEO_PANEL, right);
     ImGui::DockBuilderDockWindow(CENTER_PANEL, center);
-    ImGui::DockBuilderGetNode(center)->LocalFlags |= ImGuiDockNodeFlags_NoTabBar;
+    ImGui::DockBuilderDockWindow(LOG_PANEL, center);
     ImGui::DockBuilderFinish(dock_id);
     reset_layout_ = false;
   }
@@ -901,6 +911,10 @@ void MainWindow::draw() {
   if (messages_widget_ && messages_visible_) drawMessagesPanel();
   if (video_widget_ && !video_visible_) video_widget_->setVisible(false);
   if (video_widget_ && video_visible_) drawVideoPanel();
+  if (log_panel_ && log_visible_) {
+    if (ImGui::Begin(LOG_PANEL, &log_visible_)) log_panel_->draw();
+    ImGui::End();
+  }
   if (charts_widget_ && charts_floating_) {
     bool open = true;
     ImGui::SetNextWindowSize(ImGui::GetMainViewport()->WorkSize, ImGuiCond_Appearing);

--- a/openpilot/tools/cabana/ui/mainwin.h
+++ b/openpilot/tools/cabana/ui/mainwin.h
@@ -15,6 +15,7 @@
 #include "tools/cabana/ui/helpoverlay.h"
 #include "tools/cabana/ui/tools/tooldialog.h"
 #include "tools/cabana/ui/chart/chartswidget.h"
+#include "tools/cabana/ui/chart/logpanel.h"
 #include "tools/cabana/ui/widgets/detailwidget.h"
 #include "tools/cabana/ui/widgets/messageswidget.h"
 #include "tools/cabana/ui/widgets/videowidget.h"
@@ -23,7 +24,8 @@ struct GLFWwindow;
 
 class MainWindow {
 public:
-  MainWindow(GLFWwindow *window, std::unique_ptr<AbstractStream> stream, StreamLoader stream_loader, const std::string &dbc_file);
+  MainWindow(GLFWwindow *window, std::unique_ptr<AbstractStream> stream, StreamLoader stream_loader, const std::string &dbc_file,
+             const std::string &log_layout = {});
   ~MainWindow();
   void draw();
   void toggleChartsDocking();
@@ -95,6 +97,9 @@ private:
   CenterWidget center_widget_;
   std::unique_ptr<VideoWidget> video_widget_;
   std::unique_ptr<ChartsWidget> charts_widget_;
+  std::unique_ptr<LogPanel> log_panel_;
+  std::string startup_log_layout_;
+  bool log_visible_ = false;
   StreamSelector stream_selector_;
   SettingsDialog settings_dialog_;
   HelpOverlay help_overlay_;

--- a/openpilot/tools/replay/replay.cc
+++ b/openpilot/tools/replay/replay.cc
@@ -63,7 +63,7 @@ void Replay::setupServices(const std::vector<std::string> &allow, const std::vec
 void Replay::setupSegmentManager(bool has_filters) {
   seg_mgr_->setCallback([this]() { handleSegmentMerge(); });
 
-  if (has_filters) {
+  if (has_filters && !hasFlag(REPLAY_FLAG_LOAD_ALL_EVENTS)) {
     std::vector<bool> filters(sockets_.size(), false);
     for (size_t i = 0; i < sockets_.size(); ++i) {
       filters[i] = (i == cereal::Event::Which::INIT_DATA || i == cereal::Event::Which::CAR_PARAMS || sockets_[i]);
@@ -366,7 +366,8 @@ std::vector<Event>::const_iterator Replay::publishEvents(std::vector<Event>::con
     cur_which_ = evt.which;
 
     // Skip events if socket is not present
-    if (!sockets_[evt.which]) continue;
+    const bool publish = sockets_[evt.which] != nullptr;
+    if (!publish && !hasFlag(REPLAY_FLAG_LOAD_ALL_EVENTS)) continue;
 
     const uint64_t current_nanos = nanos_since_boot();
     const int64_t time_diff = (evt.mono_time - evt_start_ts) / speed_ - (current_nanos - loop_start_ts);
@@ -385,7 +386,10 @@ std::vector<Event>::const_iterator Replay::publishEvents(std::vector<Event>::con
 
     if (interrupt_requested_) break;
 
-    if (evt.eidx_segnum == -1) {
+    if (!publish) {
+      // Log viewers still need a paced clock and callbacks for un-published services.
+      if (event_filter_) event_filter_(&evt);
+    } else if (evt.eidx_segnum == -1) {
       publishMessage(&evt);
     } else if (camera_server_) {
       if (speed_ > 1.0) {

--- a/openpilot/tools/replay/replay.h
+++ b/openpilot/tools/replay/replay.h
@@ -25,6 +25,7 @@ enum REPLAY_FLAGS {
   REPLAY_FLAG_NO_VIPC = 0x0400,
   REPLAY_FLAG_ALL_SERVICES = 0x0800,
   REPLAY_FLAG_BENCHMARK = 0x1000,
+  REPLAY_FLAG_LOAD_ALL_EVENTS = 0x2000,  // retain log fields without changing the services published
 };
 
 struct BenchmarkStats {


### PR DESCRIPTION
Add numeric cereal log extraction, synchronized multi-curve plots, basic transforms, JSON layouts, CSV export, and restricted PlotJuggler XML import. Cover data handling, no-CAN replay, and headless rendering with native tests.