### PR TITLE
cabana: export chart signals to CSV

### DIFF
--- a/openpilot/tools/cabana/ui/chart/chart.cc
+++ b/openpilot/tools/cabana/ui/chart/chart.cc
@@ -4,13 +4,17 @@
 #include <algorithm>
 #include <cfloat>
 #include <cmath>
+#include <cstdint>
 #include <cstdio>
+#include <fstream>
+#include <iomanip>
 #include <limits>
 #include <random>
 
 #include "tools/cabana/core/settings.h"
 #include "tools/cabana/settings.h"
 #include "tools/cabana/ui/chart/chartswidget.h"
+#include "tools/cabana/ui/dialogs/filedialog.h"
 #include "tools/cabana/ui/icons.h"
 #include "tools/cabana/ui/util.h"
 #include "tools/cabana/utils/strings.h"
@@ -64,7 +68,57 @@ void ChartView::drawMenuActions() {
   ImGui::Indent(indent);
   if (ImGui::MenuItem("Manage Signals")) manageSignals();
   if (ImGui::MenuItem("Split Chart", nullptr, false, sigs_.size() > 1)) charts_widget_->splitChart(this);
+  if (ImGui::MenuItem("Export to CSV...", nullptr, false, !sigs_.empty())) {
+    std::string dir = settings.last_dir + "/" + can->routeName() + "_chart.csv";
+    FileDialog::getSaveFileName("Export chart to CSV file", dir, ".csv", [this](const std::string &fn) {
+      if (!fn.empty()) exportToCSV(fn);
+    });
+  }
   ImGui::Unindent(indent);
+}
+
+// exports exactly what's plotted: every signal on this chart, time-aligned onto one shared axis.
+// Unlike utils::exportSignalsToCSV (which is scoped to a single message), a chart's signals can
+// come from several different messages, so each column is held at its last known value (the same
+// zero-order hold the chart itself renders) rather than only printing rows where every signal
+// happens to update at once.
+void ChartView::exportToCSV(const std::string &file_name) const {
+  if (sigs_.empty()) return;
+
+  // round to microseconds so near-identical floats from different signals collapse into one row
+  auto quantize = [](double sec) { return (int64_t)std::llround(sec * 1e6); };
+
+  std::vector<int64_t> times;
+  for (const auto &s : sigs_) {
+    times.reserve(times.size() + s.vals.size());
+    for (const auto &pt : s.vals) times.push_back(quantize(pt.x));
+  }
+  std::sort(times.begin(), times.end());
+  times.erase(std::unique(times.begin(), times.end()), times.end());
+  if (times.empty()) return;
+
+  std::ofstream stream(file_name, std::ios::trunc);
+  if (!stream) return;
+
+  stream << "time";
+  for (const auto &s : sigs_) stream << "," << msgName(s.msg_id) << "." << s.sig->name;
+  stream << "\n";
+
+  // one cursor per signal; `times` and every signal's `vals` are both already sorted, so each
+  // cursor only advances forward as we scan `times` once (a single linear merge, no per-row search)
+  std::vector<size_t> cursor(sigs_.size(), 0);
+  for (int64_t t : times) {
+    stream << std::fixed << std::setprecision(6) << (t / 1e6);
+    for (size_t i = 0; i < sigs_.size(); ++i) {
+      const auto &vals = sigs_[i].vals;
+      while (cursor[i] < vals.size() && quantize(vals[cursor[i]].x) <= t) ++cursor[i];
+      stream << ",";
+      if (cursor[i] > 0) {
+        stream << std::fixed << std::setprecision(sigs_[i].sig->precision) << vals[cursor[i] - 1].y;
+      }
+    }
+    stream << "\n";
+  }
 }
 
 // the buttons and their menus are drawn every frame, at the rects updateLayout() placed them at

--- a/openpilot/tools/cabana/ui/chart/chart.h
+++ b/openpilot/tools/cabana/ui/chart/chart.h
@@ -58,6 +58,8 @@ public:
   void adoptSignal(SigItem s);
   void setDropHighlight(bool highlight) { can_drop_ = highlight; }
   const std::vector<SigItem> &signals() const { return sigs_; }
+  // every signal on this chart, time-aligned onto one shared, zero-order-held axis
+  void exportToCSV(const std::string &file_name) const;
   const ImRect &rect() const { return layout_.rect; }  // the whole chart widget, screen coordinates
   bool plotHovered() const { return layout_.plot_hovered; }
   double secondsAtPoint(const ImVec2 &pt) const {


### PR DESCRIPTION
## cabana: export chart signals to CSV

### What
Adds an "Export to CSV..." option to each chart's menu. It exports exactly the signals plotted on that chart, even when they come from different CAN messages, onto one shared time-aligned CSV.

### Why
The existing `utils::exportSignalsToCSV` only handles a single message at a time. Once you build a chart mixing signals from multiple messages (a very common workflow, e.g. comparing a request signal against a sensor reading from a different message), there's no way to export what you're actually looking at. You'd have to export each message separately and manually align timestamps yourself. This closes that specific gap.

Each column is held at its last known value between updates (zero-order hold), matching how the chart itself renders the series, rather than only emitting rows where every signal happens to update at once.

### Testing
- Verified the merge/align algorithm in isolation with a standalone unit test (multi-message merge, single-signal case, empty input, and near-duplicate float timestamps).
- Built and ran cabana against a real demo route, added signals from two different messages (`ACCDATA`, `ABS_BrkBst_Data`) to the same chart and confirmed the exported CSV is correct. In particular a rolling counter signal (`BrkTotTqRqDrv_No_Cnt`) wraps 0→15→0 cleanly with no skipped or duplicated values across the full ~920s route.

### Related
Related to #38752. I see that issue is already assigned, so I'm not claiming it. Just sharing this as a small standalone step toward PlotJuggler parity in case it's useful, or as its own contribution either way.