### PR TITLE
cabana: fix video startup and desktop interactions

### DIFF
--- a/openpilot/tools/cabana/ui/helpoverlay.cc
+++ b/openpilot/tools/cabana/ui/helpoverlay.cc
@@ -139,15 +139,19 @@ void HelpOverlay::toggle() {
 }
 
 void HelpOverlay::add(const std::string &text, const ImRect &rect) {
-  if (visible_) texts_.emplace_back(text, rect);
+  if (visible_) texts_.push_back({text, rect, ImGui::GetWindowViewport()});
 }
 
 void HelpOverlay::draw() {
   if (!visible_) return;
-  const ImGuiViewport *viewport = ImGui::GetMainViewport();
-  ImDrawList *dl = ImGui::GetForegroundDrawList();
-  const ImRect work_rect(viewport->WorkPos, ImVec2(viewport->WorkPos.x + viewport->WorkSize.x, viewport->WorkPos.y + viewport->WorkSize.y));
-  dl->AddRectFilled(viewport->Pos, ImVec2(viewport->Pos.x + viewport->Size.x, viewport->Pos.y + viewport->Size.y), IM_COL32(0, 0, 0, 50));
+  // Each panel belongs to a viewport; detached panels need their own foreground layer.
+  std::vector<ImGuiViewport *> viewports{ImGui::GetMainViewport()};
+  for (const auto &entry : texts_) {
+    if (std::find(viewports.begin(), viewports.end(), entry.viewport) == viewports.end()) viewports.push_back(entry.viewport);
+  }
+  for (auto *viewport : viewports) {
+    ImGui::GetForegroundDrawList(viewport)->AddRectFilled(viewport->Pos, ImVec2(viewport->Pos.x + viewport->Size.x, viewport->Pos.y + viewport->Size.y), IM_COL32(0, 0, 0, 50));
+  }
   ImFont *font = ImGui::GetFont();
   ImFont *bold_font = boldFont() ? boldFont() : font;
   const float font_size = ImGui::GetFontSize();
@@ -156,7 +160,8 @@ void HelpOverlay::draw() {
     if (r.swatch) return font_size;
     return (r.bold ? bold_font : font)->CalcTextSizeA(font_size, FLT_MAX, 0.0f, r.text.c_str()).x;
   };
-  for (const auto &[raw, rect] : texts_) {
+  for (const auto &[raw, rect, viewport] : texts_) {
+    ImDrawList *dl = ImGui::GetForegroundDrawList(viewport);
     if (raw.empty()) continue;
     const auto lines = parseHelpHtml(raw);
     float width = 0;
@@ -167,7 +172,6 @@ void HelpOverlay::draw() {
     }
     const ImVec2 size(width, lines.size() * line_h);
     const ImVec2 center((rect.Min.x + rect.Max.x) * 0.5f, (rect.Min.y + rect.Max.y) * 0.5f);
-    if (!work_rect.Contains(center)) continue;  // a torn off panel is in another viewport
     const ImVec2 min(center.x - size.x * 0.5f - 8.0f, center.y - size.y * 0.5f - 8.0f);
     const ImVec2 max(center.x + size.x * 0.5f + 8.0f, center.y + size.y * 0.5f + 8.0f);
     dl->AddRectFilled(min, max, ImGui::GetColorU32(ImGuiCol_PopupBg), ImGui::GetStyle().PopupRounding);

--- a/openpilot/tools/cabana/ui/helpoverlay.h
+++ b/openpilot/tools/cabana/ui/helpoverlay.h
@@ -18,7 +18,12 @@ public:
   void draw();
 
 private:
-  std::vector<std::pair<std::string, ImRect>> texts_;
+  struct Entry {
+    std::string text;
+    ImRect rect;
+    ImGuiViewport *viewport;
+  };
+  std::vector<Entry> texts_;
   bool visible_ = false;
   int opened_frame_ = -1;
 };

--- a/openpilot/tools/cabana/ui/mainwin.cc
+++ b/openpilot/tools/cabana/ui/mainwin.cc
@@ -96,8 +96,8 @@ void MainWindow::drawFileMenu() {
   if (ImGui::MenuItem("Export to CSV...", nullptr, false, has_stream)) exportToCSV();
   ImGui::Separator();
 
-  if (ImGui::MenuItem("New DBC File", "Ctrl+N")) newFile();
-  if (ImGui::MenuItem("Open DBC File...", "Ctrl+O")) openFile();
+  if (ImGui::MenuItem("New DBC File", shortcut("N").c_str())) newFile();
+  if (ImGui::MenuItem("Open DBC File...", shortcut("O").c_str())) openFile();
 
   if (ImGui::BeginMenu("Manage DBC Files", has_stream)) {
     drawManageDBCsMenu();
@@ -120,8 +120,8 @@ void MainWindow::drawFileMenu() {
   ImGui::Separator();
   const int cnt = dbc()->nonEmptyDBCCount();
   const std::string save_text = cnt > 1 ? "Save " + std::to_string(cnt) + " DBCs..." : "Save DBC...";
-  if (ImGui::MenuItem(save_text.c_str(), "Ctrl+S", false, cnt > 0)) save();
-  if (ImGui::MenuItem("Save DBC As...", "Ctrl+Shift+S", false, cnt == 1)) saveAs();
+  if (ImGui::MenuItem(save_text.c_str(), shortcut("S").c_str(), false, cnt > 0)) save();
+  if (ImGui::MenuItem("Save DBC As...", shortcut("Shift+S").c_str(), false, cnt == 1)) saveAs();
   // TODO: Support clipboard for multiple files
   if (ImGui::MenuItem("Copy DBC To Clipboard", nullptr, false, cnt == 1)) saveToClipboard();
 
@@ -129,7 +129,7 @@ void MainWindow::drawFileMenu() {
   if (ImGui::MenuItem("Settings...")) openSettings();
 
   ImGui::Separator();
-  if (ImGui::MenuItem("Exit", "Ctrl+Q")) close();
+  if (ImGui::MenuItem("Exit", shortcut("Q").c_str())) close();
 }
 
 namespace {
@@ -175,13 +175,13 @@ void MainWindow::drawMenuBar() {
     auto stack = UndoStack::instance();
     const std::string undo_text = stack->canUndo() ? "Undo " + stack->undoText() : "Undo";
     const std::string redo_text = stack->canRedo() ? "Redo " + stack->redoText() : "Redo";
-    if (ImGui::MenuItem(undo_text.c_str(), "Ctrl+Z", false, stack->canUndo())) stack->undo();
-    if (ImGui::MenuItem(redo_text.c_str(), "Ctrl+Shift+Z", false, stack->canRedo())) stack->redo();
+    if (ImGui::MenuItem(undo_text.c_str(), shortcut("Z").c_str(), false, stack->canUndo())) stack->undo();
+    if (ImGui::MenuItem(redo_text.c_str(), shortcut("Shift+Z").c_str(), false, stack->canRedo())) stack->redo();
     ImGui::EndMenu();
   }
 
   if (beginTopMenu("View")) {
-    if (ImGui::MenuItem("Full Screen", "Ctrl+F11")) toggleFullScreen();
+    if (ImGui::MenuItem("Full Screen", shortcut("F11").c_str())) toggleFullScreen();
     ImGui::Separator();
     ImGui::MenuItem(messages_widget_ ? messages_widget_->title().c_str() : "MESSAGES", nullptr, &messages_visible_);
     ImGui::MenuItem(video_dock_title_.empty() ? "Video" : video_dock_title_.c_str(), nullptr, &video_visible_);
@@ -216,7 +216,6 @@ void MainWindow::createDockWidgets() {
   center_widget_.setChartsWidget(charts_widget_.get());
   video_widget_ = std::make_unique<VideoWidget>();
   widget_connections_.push_back(charts_widget_->toggleChartsDocking.connect([this]() { toggleChartsDocking(); }));
-  widget_connections_.push_back(charts_widget_->showTip.connect([this](double sec) { video_widget_->showThumbnail(sec); }));
 }
 
 void MainWindow::showStatusMessage(const std::string &msg, int timeout_ms) {
@@ -976,7 +975,10 @@ void MainWindow::draw() {
     bool open = true;
     ImGui::SetNextWindowSize(ImGui::GetMainViewport()->WorkSize, ImGuiCond_Appearing);
     setNextWindowFloatsOut();
-    if (ImGui::Begin(CHARTS_WINDOW, &open, ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoScrollWithMouse)) charts_widget_->draw();
+    if (ImGui::Begin(CHARTS_WINDOW, &open, ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoScrollWithMouse)) {
+      help_overlay_.add(charts_widget_->whatsThis(), ImGui::GetCurrentWindow()->Rect());
+      charts_widget_->draw();
+    }
     ImGui::End();
     if (!open) toggleChartsDocking();
   }

--- a/openpilot/tools/cabana/ui/util.cc
+++ b/openpilot/tools/cabana/ui/util.cc
@@ -499,7 +499,12 @@ void drawToolbar(const std::vector<ToolbarItem> &items, size_t spacer_index, flo
     // the extension button sits fully inside the toolbar: its right edge is the content region right edge
     const float extension_x = std::max(start_x, right_edge - extension_width);
     visible == 0 ? ImGui::SetCursorPosX(extension_x) : ImGui::SameLine(extension_x);
-    if (iconButton("toolbar_extension", icon::CHEVRON_DOUBLE_RIGHT, "More")) ImGui::OpenPopup("toolbar_extension_menu");
+    const bool extension_open = ImGui::IsPopupOpen("toolbar_extension_menu");
+    const bool extension_clicked = iconButton("toolbar_extension", icon::CHEVRON_DOUBLE_RIGHT, "More");
+    if (!extension_open && (extension_clicked ||
+        (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenBlockedByPopup) && ImGui::IsMouseClicked(ImGuiMouseButton_Left)))) {
+      ImGui::OpenPopup("toolbar_extension_menu");
+    }
     // the popup opens inward: its right edge is aligned with the button so it stays inside the window
     ImGui::SetNextWindowPos(ImVec2(ImGui::GetItemRectMax().x, ImGui::GetItemRectMax().y), ImGuiCond_Always, ImVec2(1, 0));
     if (ImGui::BeginPopup("toolbar_extension_menu")) {
@@ -545,7 +550,11 @@ bool menuButton(const char *id, const std::string &text, const char *popup_id, b
   ImGui::PushStyleColor(ImGuiCol_Button, popup_open ? style.Colors[ImGuiCol_ButtonActive] : style.Colors[ImGuiCol_Button]);
   ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(padding_x, style.FramePadding.y));
   ImGui::PushStyleVar(ImGuiStyleVar_ButtonTextAlign, ImVec2(0.0f, 0.5f));
-  const bool clicked = ImGui::ButtonEx((text + "###" + id).c_str(), ImVec2(width, 0.0f), ImGuiButtonFlags_PressedOnClick);
+  const bool pressed = ImGui::ButtonEx((text + "###" + id).c_str(), ImVec2(width, 0.0f), ImGuiButtonFlags_PressedOnClick);
+  // A sibling menu blocks normal button input. Let this press replace its popup immediately;
+  // IsItemHovered still respects modal dialogs, disabled items, and overlapping windows.
+  const bool clicked = pressed || (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenBlockedByPopup) &&
+                                   ImGui::IsMouseClicked(ImGuiMouseButton_Left));
   ImGui::PopStyleVar(2);
   ImGui::PopStyleColor();
   if (bold) popBoldFont();

--- a/openpilot/tools/cabana/ui/util.cc
+++ b/openpilot/tools/cabana/ui/util.cc
@@ -551,8 +551,6 @@ bool menuButton(const char *id, const std::string &text, const char *popup_id, b
   ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(padding_x, style.FramePadding.y));
   ImGui::PushStyleVar(ImGuiStyleVar_ButtonTextAlign, ImVec2(0.0f, 0.5f));
   const bool pressed = ImGui::ButtonEx((text + "###" + id).c_str(), ImVec2(width, 0.0f), ImGuiButtonFlags_PressedOnClick);
-  // A sibling menu blocks normal button input. Let this press replace its popup immediately;
-  // IsItemHovered still respects modal dialogs, disabled items, and overlapping windows.
   const bool clicked = pressed || (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenBlockedByPopup) &&
                                    ImGui::IsMouseClicked(ImGuiMouseButton_Left));
   ImGui::PopStyleVar(2);

--- a/openpilot/tools/cabana/ui/util.h
+++ b/openpilot/tools/cabana/ui/util.h
@@ -71,8 +71,6 @@ int doubleValidator(ImGuiInputTextCallbackData *data);
 int ipValidator(ImGuiInputTextCallbackData *data);
 int nonWhitespaceValidator(ImGuiInputTextCallbackData *data);
 
-// The primary shortcut modifier as shown in labels. ImGui swaps Cmd and Ctrl on macOS, so io.KeyCtrl and
-// the menu shortcuts already follow the platform; only the copy needs to.
 #ifdef __APPLE__
 constexpr const char *MOD_KEY = "Cmd";
 #else

--- a/openpilot/tools/cabana/ui/util.h
+++ b/openpilot/tools/cabana/ui/util.h
@@ -71,6 +71,15 @@ int doubleValidator(ImGuiInputTextCallbackData *data);
 int ipValidator(ImGuiInputTextCallbackData *data);
 int nonWhitespaceValidator(ImGuiInputTextCallbackData *data);
 
+// The primary shortcut modifier as shown in labels. ImGui swaps Cmd and Ctrl on macOS, so io.KeyCtrl and
+// the menu shortcuts already follow the platform; only the copy needs to.
+#ifdef __APPLE__
+constexpr const char *MOD_KEY = "Cmd";
+#else
+constexpr const char *MOD_KEY = "Ctrl";
+#endif
+inline std::string shortcut(const char *keys) { return std::string(MOD_KEY) + "+" + keys; }
+
 // Use ItemInnerSpacing between related buttons and ItemSpacing between groups.
 bool iconButton(const char *id, const char *icon, const char *tooltip = nullptr);
 float iconButtonWidth();

--- a/openpilot/tools/cabana/ui/widgets/cameraview.h
+++ b/openpilot/tools/cabana/ui/widgets/cameraview.h
@@ -18,7 +18,8 @@
 #include "tools/cabana/core/observable.h"
 #include "msgq/visionipc/visionipc_client.h"
 
-constexpr float DEFAULT_CAMERA_ASPECT_RATIO = 1928.0f / 1208.0f;
+// OS04C10 output, also used by its 1344x760 downscaled video.
+constexpr float DEFAULT_CAMERA_ASPECT_RATIO = 2688.0f / 1520.0f;
 
 // Center-crop the source to fill the destination without stretching.
 inline ImVec2 videoFillUv(const ImVec2 &size, float aspect_ratio) {

--- a/openpilot/tools/cabana/ui/widgets/videowidget.h
+++ b/openpilot/tools/cabana/ui/widgets/videowidget.h
@@ -89,10 +89,10 @@ public:
   // MainWindow calls this every frame with the video dock visibility, so the camera widget gets its
   // vipc thread started and stopped
   void setVisible(bool visible);
-  void showThumbnail(double seconds);
   std::string whatsThis() const;
 
 private:
+  void showThumbnail(double seconds);
   void updateSliderThumbnail();  // the thumbnail follows the mouse over the slider
   std::string formatTime(double sec, bool include_milliseconds = false);
   void timeRangeChanged();


### PR DESCRIPTION
Fix menu switching, detached help, camera aspect ratio, preview behavior, and macOS shortcut labels.

Tested on Linux: build, core/UI tests, demo launch/shutdown, and regression checks.

Synthetic-data comparison against upstream `9c02eebb7`.

| Before | After |
|---|---|
| ![Before](https://raw.githubusercontent.com/greatgitsby/openpilot/e7a25089c745940213d397c14c96e9fe7c0411cf/cabana-fixes/desktop-before.png) | ![After](https://raw.githubusercontent.com/greatgitsby/openpilot/e7a25089c745940213d397c14c96e9fe7c0411cf/cabana-fixes/desktop-after.png) |
