### PR TITLE
Preserve experimental mode preference during lateral maneuvers

### DIFF
--- a/openpilot/selfdrive/car/card.py
+++ b/openpilot/selfdrive/car/card.py
@@ -152,7 +152,8 @@ class Car:
     self.v_cruise_helper = VCruiseHelper(self.CP)
 
     self.is_metric = self.params.get_bool("IsMetric")
-    self.experimental_mode = self.params.get_bool("ExperimentalMode")
+    self.experimental_mode = (self.params.get_bool("ExperimentalMode") and self.CP.openpilotLongitudinalControl and
+                              not self.params.get_bool("LateralManeuverMode"))
 
     # card is driven by can recv, expected at 100Hz
     self.rk = Ratekeeper(100, print_delay_threshold=None)
@@ -255,7 +256,8 @@ class Car:
   def params_thread(self, evt):
     while not evt.is_set():
       self.is_metric = self.params.get_bool("IsMetric")
-      self.experimental_mode = self.params.get_bool("ExperimentalMode") and self.CP.openpilotLongitudinalControl
+      self.experimental_mode = (self.params.get_bool("ExperimentalMode") and self.CP.openpilotLongitudinalControl and
+                                not self.params.get_bool("LateralManeuverMode"))
       time.sleep(0.1)
 
   def card_thread(self):

--- a/openpilot/selfdrive/selfdrived/selfdrived.py
+++ b/openpilot/selfdrive/selfdrived/selfdrived.py
@@ -566,7 +566,9 @@ class SelfdriveD:
       self.is_metric = self.params.get_bool("IsMetric")
       self.is_ldw_enabled = self.params.get_bool("IsLdwEnabled")
       self.disengage_on_accelerator = self.params.get_bool("DisengageOnAccelerator")
-      self.experimental_mode = self.params.get_bool("ExperimentalMode") and self.CP.openpilotLongitudinalControl
+      # Lateral maneuvers temporarily use chill mode without changing the saved preference.
+      self.experimental_mode = (self.params.get_bool("ExperimentalMode") and self.CP.openpilotLongitudinalControl and
+                                not self.params.get_bool("LateralManeuverMode"))
       self.personality = self.params.get("LongitudinalPersonality", return_default=True)
       time.sleep(0.1)
 

--- a/openpilot/selfdrive/ui/layouts/settings/developer.py
+++ b/openpilot/selfdrive/ui/layouts/settings/developer.py
@@ -177,7 +177,6 @@ class DeveloperLayout(Widget):
 
   def _on_lat_maneuver_mode(self, state: bool):
     self._params.put_bool("LateralManeuverMode", state, block=True)
-    self._params.put_bool("ExperimentalMode", False, block=True)
     self._params.put_bool("JoystickDebugMode", False, block=True)
     self._joystick_toggle.action_item.set_state(False)
     self._params.put_bool("LongitudinalManeuverMode", False, block=True)

--- a/openpilot/selfdrive/ui/mici/layouts/settings/developer.py
+++ b/openpilot/selfdrive/ui/mici/layouts/settings/developer.py
@@ -179,7 +179,6 @@ class DeveloperLayoutMici(NavScroller):
 
   def _on_lat_maneuver_mode(self, state: bool):
     ui_state.params.put_bool("LateralManeuverMode", state, block=True)
-    ui_state.params.put_bool("ExperimentalMode", False, block=True)
     ui_state.params.put_bool("JoystickDebugMode", False, block=True)
     self._joystick_toggle.set_checked(False)
     ui_state.params.put_bool("LongitudinalManeuverMode", False, block=True)

--- a/openpilot/selfdrive/ui/tests/test_experimental_mode.py
+++ b/openpilot/selfdrive/ui/tests/test_experimental_mode.py
@@ -1,0 +1,91 @@
+import itertools
+import tempfile
+import threading
+import unittest
+from unittest.mock import Mock, patch
+
+from opendbc.car.structs import car
+from openpilot.common.params import Params, ParamKeyFlag
+from openpilot.selfdrive.car.card import Car
+from openpilot.selfdrive.selfdrived.selfdrived import SelfdriveD
+from openpilot.selfdrive.ui.layouts.settings.developer import DeveloperLayout
+from openpilot.selfdrive.ui.mici.layouts.settings.developer import DeveloperLayoutMici
+from openpilot.selfdrive.ui.ui_state import ui_state
+
+
+class TestExperimentalMode(unittest.TestCase):
+  def setUp(self):
+    self.params_dir = tempfile.TemporaryDirectory()
+    self.addCleanup(self.params_dir.cleanup)
+    self.params = Params(self.params_dir.name)
+
+  def read_experimental_mode(self, process_class, longitudinal_control=True):
+    # Exercise one iteration of the real parameter reader without starting car/control loops.
+    process = process_class.__new__(process_class)
+    process.params = self.params
+    process.CP = car.CarParams.new_message(openpilotLongitudinalControl=longitudinal_control)
+    stop = threading.Event()
+    with patch("time.sleep", side_effect=lambda _: stop.set()):
+      process.params_thread(stop)
+    return process.experimental_mode
+
+  def toggle_lateral_maneuvers(self, layout_class, enabled):
+    # Only the visual controls are mocked; parameter writes and the callback are real.
+    layout = layout_class.__new__(layout_class)
+    layout._params = self.params
+    layout._joystick_toggle = Mock()
+    layout._long_maneuver_toggle = Mock()
+    with patch.object(ui_state, "params", self.params):
+      layout._on_lat_maneuver_mode(enabled)
+
+  def test_toggle_preserves_preference(self):
+    for layout, preference, enabled in itertools.product((DeveloperLayout, DeveloperLayoutMici), (False, True), (False, True)):
+      with self.subTest(layout=layout.__name__, preference=preference, enabled=enabled):
+        self.params.put_bool("ExperimentalMode", preference, block=True)
+        self.toggle_lateral_maneuvers(layout, enabled)
+        self.assertEqual(self.params.get_bool("ExperimentalMode"), preference)
+        self.assertEqual(self.params.get_bool("LateralManeuverMode"), enabled)
+
+  def test_car_initialization_suppresses_experimental_mode_during_maneuvers(self):
+    self.params.put_bool("OpenpilotEnabledToggle", True, block=True)
+    self.params.put_bool("ExperimentalMode", True, block=True)
+    self.params.put_bool("LateralManeuverMode", True, block=True)
+    interface = Mock(CP=car.CarParams.new_message(openpilotLongitudinalControl=True), CC=object())
+    with patch("openpilot.selfdrive.car.card.Params", return_value=self.params), \
+         patch("openpilot.selfdrive.car.card.messaging.sub_sock"), \
+         patch("openpilot.selfdrive.car.card.messaging.SubMaster"), \
+         patch("openpilot.selfdrive.car.card.messaging.PubMaster"):
+      process = Car(CI=interface)
+    self.assertFalse(process.experimental_mode)
+    self.assertTrue(self.params.get_bool("ExperimentalMode"))
+
+  def test_runtime_suppresses_experimental_mode_during_maneuvers(self):
+    for process, preference, longitudinal, maneuver in itertools.product((Car, SelfdriveD), (False, True), (False, True), (False, True)):
+      with self.subTest(process=process.__name__, preference=preference, longitudinal=longitudinal, maneuver=maneuver):
+        self.params.put_bool("ExperimentalMode", preference, block=True)
+        self.params.put_bool("LateralManeuverMode", maneuver, block=True)
+        self.assertEqual(self.read_experimental_mode(process, longitudinal), preference and longitudinal and not maneuver)
+        self.assertEqual(self.params.get_bool("ExperimentalMode"), preference)
+
+  def test_preference_survives_maneuver_cleanup(self):
+    for layout, preference, cleanup in itertools.product((DeveloperLayout, DeveloperLayoutMici), (False, True),
+                                                        (None, ParamKeyFlag.CLEAR_ON_MANAGER_START, ParamKeyFlag.CLEAR_ON_OFFROAD_TRANSITION)):
+      with self.subTest(layout=layout.__name__, preference=preference, cleanup=cleanup):
+        self.params.put_bool("ExperimentalMode", preference, block=True)
+        self.toggle_lateral_maneuvers(layout, True)
+        for process in (Car, SelfdriveD):
+          self.assertFalse(self.read_experimental_mode(process))
+
+        if cleanup is None:
+          self.toggle_lateral_maneuvers(layout, False)
+        else:
+          self.params.clear_all(cleanup)
+
+        self.assertFalse(self.params.get_bool("LateralManeuverMode"))
+        self.assertEqual(self.params.get_bool("ExperimentalMode"), preference)
+        for process in (Car, SelfdriveD):
+          self.assertEqual(self.read_experimental_mode(process), preference)
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/openpilot/selfdrive/ui/tests/test_experimental_mode.py
+++ b/openpilot/selfdrive/ui/tests/test_experimental_mode.py
@@ -18,6 +18,8 @@ class TestExperimentalMode(unittest.TestCase):
     self.params_dir = tempfile.TemporaryDirectory()
     self.addCleanup(self.params_dir.cleanup)
     self.params = Params(self.params_dir.name)
+    # Drain pending writes before removing the temporary parameter directory.
+    self.addCleanup(self.params._finalizer)
 
   def read_experimental_mode(self, process_class, longitudinal_control=True):
     # Exercise one iteration of the real parameter reader without starting car/control loops.


### PR DESCRIPTION
## Problem

Changing the lateral maneuver mode toggle permanently clears the user's saved Experimental Mode preference. After maneuver mode clears on an offroad transition or manager restart, the next drive remains in chill mode until Experimental Mode is manually enabled again.

This affects both enabling and disabling the lateral maneuver toggle, and both UI variants. Temporary maneuver testing should use chill mode without overwriting the user's persistent preference.

## Reproduction

On a vehicle/configuration with openpilot longitudinal control available:

1. Enable Experimental Mode.
2. In Developer settings, enable lateral maneuver mode.
3. End the test session by going offroad/restarting openpilot, or disable lateral maneuver mode manually.
4. Check Experimental Mode on the next normal drive.

Before this change, Experimental Mode remains off. Re-enabling it in Toggles restores it, but another lateral maneuver session repeats the problem. A previously disabled Experimental Mode preference should remain disabled throughout.

## Root cause and source evidence

Confirmed against upstream master `bb86bee6882ed5422c89d2333fe98b85db21812d`:

- Both lateral maneuver callbacks unconditionally save `ExperimentalMode = false`, regardless of the new maneuver toggle value: [standard UI](https://github.com/commaai/openpilot/blob/bb86bee6882ed5422c89d2333fe98b85db21812d/openpilot/selfdrive/ui/layouts/settings/developer.py#L178-L185), [comma 4 UI](https://github.com/commaai/openpilot/blob/bb86bee6882ed5422c89d2333fe98b85db21812d/openpilot/selfdrive/ui/mici/layouts/settings/developer.py#L180-L187).
- `ExperimentalMode` is [persistent](https://github.com/commaai/openpilot/blob/bb86bee6882ed5422c89d2333fe98b85db21812d/openpilot/common/params_keys.h#L42), while `LateralManeuverMode` [clears on manager start and offroad transition](https://github.com/commaai/openpilot/blob/bb86bee6882ed5422c89d2333fe98b85db21812d/openpilot/common/params_keys.h#L87).
- Manager performs those clears at [startup](https://github.com/commaai/openpilot/blob/bb86bee6882ed5422c89d2333fe98b85db21812d/openpilot/system/manager/manager.py#L29-L33) and [offroad transition](https://github.com/commaai/openpilot/blob/bb86bee6882ed5422c89d2333fe98b85db21812d/openpilot/system/manager/manager.py#L126-L131). The saved Experimental Mode value is therefore still false after maneuver mode disappears.

## Change

- Stop overwriting `ExperimentalMode` in both lateral maneuver toggle callbacks.
- Suppress effective Experimental Mode while `LateralManeuverMode` is enabled in `selfdrived` and `card`, including `card` initialization.
- Retain the existing openpilot-longitudinal-control requirement. The longitudinal planner and onroad rendering continue receiving the effective mode through `selfdriveState.experimentalMode`.
- Preserve the saved preference through manual exit, manager restart, and offroad cleanup. Settings continue to represent the saved preference; effective Experimental Mode remains off during lateral maneuvers.

No new parameters, migrations, vehicle overrides, or unrelated changes. This prevents future preference loss; it cannot infer or restore a preference already erased by an earlier version.

## Device-log evidence

Filtered first-segment qlogs from a comma 4 show two maneuver sessions associated with the persistent off state:

| Logged route start (America/Chicago) | ExperimentalMode parameter | LateralManeuverMode parameter | Recorded selfdriveState.experimentalMode |
| --- | --- | --- | --- |
| 2026-09-05 19:08 | 1 | absent | true |
| 2026-09-05 19:11 | 0 | 1 | false |
| 2026-09-06 14:20 | 1 | absent | true |
| 2026-09-06 17:16 | 0 | 1 | false |
| 2026-09-07 08:49 | 0 | absent | false |
| 2026-09-07 10:18 | 1 | absent | true |
| 2026-09-07 11:42 | 1 | absent | true |

All seven sampled segments identify `FORD_EXPEDITION_MK4`, with `openpilotLongitudinalControl=true`, `alphaLongitudinalAvailable=true`, and saved `AlphaLongitudinalEnabled=1` and `ExperimentalModeConfirmed=1`.

These logs came from personal test branch `fix-mici-dm-warp-ford-expedition`, commit `e855605fdf1b2ba480185d9473fa544b8ee4b99c`, not stock master. The same destructive callbacks were separately confirmed and reproduced against the upstream base above. The snapshots corroborate the sequence; they do not record which individual UI action wrote a parameter or prove every reported occurrence had this cause.

## Validation

Added `openpilot/selfdrive/ui/tests/test_experimental_mode.py`:

- Both UI callbacks preserve initially enabled and disabled preferences, on both toggle directions.
- Both runtime readers suppress Experimental Mode during lateral maneuvers, including combinations without longitudinal control.
- `card` starts with effective Experimental Mode off during a maneuver, without changing the saved preference.
- Manual disable, manager-start cleanup, and offroad cleanup preserve the preference and restore the appropriate effective mode.

Four test methods cover 37 scenarios. The same final test source produced:

```text
Original upstream source: Ran 4 tests — FAILED (failures=13)
Patched source:           Ran 4 tests — OK
```

These were isolated unit runs on the comma's existing Python/native runtime: actual source snapshots and native Params storage, temporary parameter and messaging directories, mocked visual controls/IPC where needed. No control loops were started and no installed source, live parameters, or services were changed. Source SHA-256 hashes were captured with both runs. This is not a full build of the new upstream checkout.

Ruff 0.16.6, Python 3.12 byte-compilation of all five changed files, and `git diff --check` passed. Independent source review found no actionable issues.

Normal test command in a built openpilot development environment:

```sh
python -m unittest openpilot.selfdrive.ui.tests.test_experimental_mode -v
```