### PR TITLE
mici: remove duplicate pairing button from main settings

### DIFF
--- a/openpilot/selfdrive/ui/mici/layouts/settings/settings.py
+++ b/openpilot/selfdrive/ui/mici/layouts/settings/settings.py
@@ -3,7 +3,7 @@ from openpilot.system.ui.widgets.scroller import NavScroller
 from openpilot.selfdrive.ui.mici.widgets.button import BigButton
 from openpilot.selfdrive.ui.mici.layouts.settings.toggles import TogglesLayoutMici
 from openpilot.selfdrive.ui.mici.layouts.settings.network.network_layout import NetworkLayoutMici
-from openpilot.selfdrive.ui.mici.layouts.settings.device import DeviceLayoutMici, PairBigButton
+from openpilot.selfdrive.ui.mici.layouts.settings.device import DeviceLayoutMici
 from openpilot.selfdrive.ui.mici.layouts.settings.developer import DeveloperLayoutMici
 from openpilot.selfdrive.ui.mici.layouts.settings.software import SoftwareLayoutMici
 from openpilot.selfdrive.ui.mici.layouts.settings.firehose import FirehoseLayout
@@ -49,7 +49,6 @@ class SettingsLayout(NavScroller):
       network_btn,
       device_btn,
       software_btn,
-      PairBigButton(),
       firehose_btn,
       developer_btn,
     ])


### PR DESCRIPTION
noticed there was an extra pairing btn.. deleted! keeping the one under device menu.