### PR TITLE
sim: fix the MetaDrive bridge on macOS, and the VisionIPC buffer everywhere

### DIFF
--- a/openpilot/common/linux.py
+++ b/openpilot/common/linux.py
@@ -1,3 +1,6 @@
+import sys
+
+
 class LinuxSystemStats:
   def __init__(self) -> None:
     self._last_cpu_times = self._read_cpu_times()
@@ -48,3 +51,19 @@ class LinuxSystemStats:
 
     total = memory['MemTotal:']
     return max(0., min(100., 100. * (total - memory['MemAvailable:']) / total))
+
+
+class UnsupportedSystemStats:
+  """There is no /proc off Linux. Only the simulator runs openpilot there, and it reads these
+  numbers for telemetry alone, so report nothing rather than stopping hardwared."""
+
+  @staticmethod
+  def cpu_usage_percent() -> list[float]:
+    return []
+
+  @staticmethod
+  def memory_usage_percent() -> float:
+    return 0.
+
+
+SystemStats = LinuxSystemStats if sys.platform == 'linux' else UnsupportedSystemStats

--- a/openpilot/system/hardware/hardwared.py
+++ b/openpilot/system/hardware/hardwared.py
@@ -21,7 +21,7 @@ from openpilot.common.hardware import HARDWARE, COMMA_HARDWARE, PC
 from openpilot.common.basedir import BASEDIR
 from openpilot.common.git import get_short_branch
 from openpilot.common.hardware.usb import CHESTNUT_FW_VERSION, CHESTNUT_USB_PRODUCT, get_usb_state, get_usb_topology, is_chestnut_usb_id, set_usb_state
-from openpilot.common.linux import LinuxSystemStats
+from openpilot.common.linux import SystemStats
 from openpilot.system.loggerd.config import get_available_percent
 from openpilot.common.swaglog import cloudlog
 from openpilot.system.hardware.power_monitoring import PowerMonitoring
@@ -194,7 +194,7 @@ def hw_state_thread(end_event, hw_queue):
 
 
 def hardware_thread(end_event, hw_queue) -> None:
-  system_stats = LinuxSystemStats()
+  system_stats = SystemStats()
   pm = messaging.PubMaster(['deviceState'])
   sm = messaging.SubMaster(["peripheralState", "gpsLocationExternal", "selfdriveState", "pandaStates", "chestnutState"], poll="pandaStates")
 

--- a/openpilot/tools/sim/bridge/common.py
+++ b/openpilot/tools/sim/bridge/common.py
@@ -5,13 +5,13 @@ import numpy as np
 
 from collections import namedtuple
 from enum import Enum
-from multiprocessing import Process, Queue, Value
+from multiprocessing import Queue
 from abc import ABC, abstractmethod
 from opendbc.car.honda.values import CruiseButtons
 from openpilot.common.params import Params
 from openpilot.common.realtime import Ratekeeper
 from openpilot.selfdrive.test.helpers import set_params_enabled
-from openpilot.tools.sim.lib.common import SimulatorState, World
+from openpilot.tools.sim.lib.common import SIM_MP_CTX, SimulatorState, World
 from openpilot.tools.sim.lib.simulated_car import SimulatedCar
 from openpilot.tools.sim.lib.simulated_sensors import SimulatedSensors
 
@@ -49,8 +49,7 @@ class SimulatorBridge(ABC):
     self._exit_event: threading.Event | None = None
     self._threads = []
     self._keep_alive = True
-    self.started = Value('i', False)
-    signal.signal(signal.SIGTERM, self._on_shutdown)
+    self.started = SIM_MP_CTX.Value('i', False)
     self.simulator_state = SimulatorState()
 
     self.world: World | None = None
@@ -63,10 +62,22 @@ class SimulatorBridge(ABC):
   def _on_shutdown(self, signal, frame):
     self.shutdown()
 
+  def __getstate__(self):
+    # the loop runs in the spawned process, so the objects it owns are recreated there
+    return {k: v for k, v in self.__dict__.items() if k not in ('_exit_event', '_threads', 'world')}
+
+  def __setstate__(self, state):
+    self.__dict__.update(state)
+    self._exit_event = None
+    self._threads = []
+    self.world = None
+
   def shutdown(self):
     self._keep_alive = False
 
   def bridge_keep_alive(self, q: Queue, retries: int):
+    # register in the process that actually runs the loop, not the one that built the bridge
+    signal.signal(signal.SIGTERM, self._on_shutdown)
     try:
       self._run(q)
     finally:
@@ -82,7 +93,7 @@ class SimulatorBridge(ABC):
       self.world.close(reason)
 
   def run(self, queue, retries=-1):
-    bridge_p = Process(name="bridge", target=self.bridge_keep_alive, args=(queue, retries))
+    bridge_p = SIM_MP_CTX.Process(name="bridge", target=self.bridge_keep_alive, args=(queue, retries))
     bridge_p.start()
     return bridge_p
 

--- a/openpilot/tools/sim/bridge/metadrive/metadrive_world.py
+++ b/openpilot/tools/sim/bridge/metadrive/metadrive_world.py
@@ -1,15 +1,12 @@
 import ctypes
 import functools
-import multiprocessing
 import numpy as np
 import time
-
-from multiprocessing import Pipe, Array
 
 from openpilot.tools.sim.bridge.common import QueueMessage, QueueMessageType
 from openpilot.tools.sim.bridge.metadrive.metadrive_process import (metadrive_process, metadrive_simulation_state,
                                                                     metadrive_vehicle_state)
-from openpilot.tools.sim.lib.common import SimulatorState, World
+from openpilot.tools.sim.lib.common import SIM_MP_CTX, SimulatorState, World
 from openpilot.tools.sim.lib.camerad import W, H
 
 
@@ -17,19 +14,19 @@ class MetaDriveWorld(World):
   def __init__(self, status_q, config, test_duration, test_run, dual_camera=False):
     super().__init__(dual_camera)
     self.status_q = status_q
-    self.camera_array = Array(ctypes.c_uint8, W*H*3)
+    self.camera_array = SIM_MP_CTX.Array(ctypes.c_uint8, W*H*3)
     self.road_image = np.frombuffer(self.camera_array.get_obj(), dtype=np.uint8).reshape((H, W, 3))
     self.wide_camera_array = None
     if dual_camera:
-      self.wide_camera_array = Array(ctypes.c_uint8, W*H*3)
+      self.wide_camera_array = SIM_MP_CTX.Array(ctypes.c_uint8, W*H*3)
       self.wide_road_image = np.frombuffer(self.wide_camera_array.get_obj(), dtype=np.uint8).reshape((H, W, 3))
 
-    self.controls_send, self.controls_recv = Pipe()
-    self.simulation_state_send, self.simulation_state_recv = Pipe()
-    self.vehicle_state_send, self.vehicle_state_recv = Pipe()
+    self.controls_send, self.controls_recv = SIM_MP_CTX.Pipe()
+    self.simulation_state_send, self.simulation_state_recv = SIM_MP_CTX.Pipe()
+    self.vehicle_state_send, self.vehicle_state_recv = SIM_MP_CTX.Pipe()
 
-    self.exit_event = multiprocessing.Event()
-    self.op_engaged = multiprocessing.Event()
+    self.exit_event = SIM_MP_CTX.Event()
+    self.op_engaged = SIM_MP_CTX.Event()
 
     self.test_run = test_run
 
@@ -37,7 +34,7 @@ class MetaDriveWorld(World):
     self.last_check_timestamp = 0
     self.distance_moved = 0
 
-    self.metadrive_process = multiprocessing.Process(name="metadrive process", target=
+    self.metadrive_process = SIM_MP_CTX.Process(name="metadrive process", target=
                               functools.partial(metadrive_process, dual_camera, config,
                                                 self.camera_array, self.wide_camera_array, self.image_lock,
                                                 self.controls_recv, self.simulation_state_send,

--- a/openpilot/tools/sim/lib/camerad.py
+++ b/openpilot/tools/sim/lib/camerad.py
@@ -1,14 +1,23 @@
+import time
+
 import numpy as np
 
 from openpilot.cereal.visionipc import VisionStreamType
 from msgq.visionipc import VisionIpcServer
 from openpilot.cereal import messaging
+from openpilot.system.camerad.cameras.nv12_info import get_nv12_info
 
 from openpilot.tools.sim.lib.common import W, H
 
+# Consumers read the frame straight out of the VisionIPC buffer, so it has to be laid out the way
+# camerad lays it out: rows padded to a 128 byte stride and the plane heights aligned. Packing NV12
+# tightly instead leaves modeld short of the bytes it copies, and it dies on the first frame.
+STRIDE, Y_HEIGHT, UV_HEIGHT, YUV_SIZE = get_nv12_info(W, H)
+UV_OFFSET = STRIDE * Y_HEIGHT
 
-def rgb_to_nv12(rgb):
-  """Convert RGB image to NV12 (YUV420) format using BT.601 coefficients."""
+
+def rgb_to_nv12(rgb, out=None):
+  """Convert an RGB image to a camerad-shaped NV12 buffer using BT.601 coefficients."""
   h, w = rgb.shape[:2]
   r = rgb[:, :, 0].astype(np.int32)
   g = rgb[:, :, 1].astype(np.int32)
@@ -27,12 +36,16 @@ def rgb_to_nv12(rgb):
   u = np.clip((b_sub * 56 - g_sub * 37 - r_sub * 19 + 0x8080) >> 8, 0, 255).astype(np.uint8)
   v = np.clip((r_sub * 56 - g_sub * 47 - b_sub * 9 + 0x8080) >> 8, 0, 255).astype(np.uint8)
 
-  # Interleave UV for NV12 format
-  uv = np.empty((h // 2, w), dtype=np.uint8)
-  uv[:, 0::2] = u
-  uv[:, 1::2] = v
+  if out is None:
+    out = np.zeros(YUV_SIZE, dtype=np.uint8)
 
-  return np.concatenate([y.ravel(), uv.ravel()]).tobytes()
+  # Write into the padded planes, leaving the alignment padding zeroed
+  out[:UV_OFFSET].reshape(Y_HEIGHT, STRIDE)[:h, :w] = y
+  uv = out[UV_OFFSET:UV_OFFSET + STRIDE * UV_HEIGHT].reshape(UV_HEIGHT, STRIDE)
+  uv[:h // 2, 0:w:2] = u
+  uv[:h // 2, 1:w:2] = v
+
+  return out
 
 
 class Camerad:
@@ -44,11 +57,15 @@ class Camerad:
     self.frame_wide_id = 0
     self.vipc_server = VisionIpcServer("camerad")
 
-    self.vipc_server.create_buffers(VisionStreamType.VISION_STREAM_NARROW_ROAD, 5, W, H)
+    self.vipc_server.create_buffers_with_sizes(VisionStreamType.VISION_STREAM_NARROW_ROAD, 5, W, H, YUV_SIZE, STRIDE, UV_OFFSET)
     if dual_camera:
-      self.vipc_server.create_buffers(VisionStreamType.VISION_STREAM_WIDE_ROAD, 5, W, H)
+      self.vipc_server.create_buffers_with_sizes(VisionStreamType.VISION_STREAM_WIDE_ROAD, 5, W, H, YUV_SIZE, STRIDE, UV_OFFSET)
 
     self.vipc_server.start_listener()
+
+    # one scratch buffer per stream, these are 4.8MB each
+    self.yuv_bufs = {t: np.zeros(YUV_SIZE, dtype=np.uint8) for t in
+                     (VisionStreamType.VISION_STREAM_NARROW_ROAD, VisionStreamType.VISION_STREAM_WIDE_ROAD)}
 
   def cam_send_yuv_road(self, yuv):
     self._send_yuv(yuv, self.frame_road_id, 'narrowRoadCameraState', VisionStreamType.VISION_STREAM_NARROW_ROAD)
@@ -58,14 +75,16 @@ class Camerad:
     self._send_yuv(yuv, self.frame_wide_id, 'wideRoadCameraState', VisionStreamType.VISION_STREAM_WIDE_ROAD)
     self.frame_wide_id += 1
 
-  def rgb_to_yuv(self, rgb):
+  def rgb_to_yuv(self, rgb, yuv_type=VisionStreamType.VISION_STREAM_NARROW_ROAD):
     """Convert RGB to NV12 YUV format."""
     assert rgb.shape == (H, W, 3), f"{rgb.shape}"
     assert rgb.dtype == np.uint8
-    return rgb_to_nv12(rgb)
+    return rgb_to_nv12(rgb, self.yuv_bufs[yuv_type])
 
   def _send_yuv(self, yuv, frame_id, pub_type, yuv_type):
-    eof = int(frame_id * 0.05 * 1e9)
+    # same clock as logMonoTime, otherwise locationd rejects the camera odometry these frames
+    # produce as out of range and never gets a valid pose
+    eof = int(time.monotonic() * 1e9)
     self.vipc_server.send(yuv_type, yuv, frame_id, eof, eof)
 
     dat = messaging.new_message(pub_type, valid=True)

--- a/openpilot/tools/sim/lib/common.py
+++ b/openpilot/tools/sim/lib/common.py
@@ -7,6 +7,11 @@ from collections import namedtuple
 
 W, H = 1928, 1208
 
+# A panda3d/OpenGL context can't be inherited across fork(), so the simulator always spawns.
+# Everything shared with a sim process has to come from this one context: mixing contexts for
+# synchronization primitives isn't supported.
+SIM_MP_CTX = multiprocessing.get_context("spawn")
+
 
 vec3 = namedtuple("vec3", ["x", "y", "z"])
 
@@ -65,11 +70,11 @@ class World(ABC):
   def __init__(self, dual_camera):
     self.dual_camera = dual_camera
 
-    self.image_lock = multiprocessing.Semaphore(value=0)
+    self.image_lock = SIM_MP_CTX.Semaphore(value=0)
     self.road_image = np.zeros((H, W, 3), dtype=np.uint8)
     self.wide_road_image = np.zeros((H, W, 3), dtype=np.uint8)
 
-    self.exit_event = multiprocessing.Event()
+    self.exit_event = SIM_MP_CTX.Event()
 
   @abstractmethod
   def apply_controls(self, steer_sim, throttle_out, brake_out, /):

--- a/openpilot/tools/sim/lib/simulated_sensors.py
+++ b/openpilot/tools/sim/lib/simulated_sensors.py
@@ -4,6 +4,7 @@ from openpilot.cereal import log
 import openpilot.cereal.messaging as messaging
 
 from openpilot.common.realtime import DT_DMON
+from openpilot.cereal.visionipc import VisionStreamType
 from openpilot.tools.sim.lib.camerad import Camerad
 
 from typing import TYPE_CHECKING
@@ -97,11 +98,11 @@ class SimulatedSensors:
 
   def send_camera_images(self, world: 'World'):
     world.image_lock.acquire()
-    yuv = self.camerad.rgb_to_yuv(world.road_image)
+    yuv = self.camerad.rgb_to_yuv(world.road_image, VisionStreamType.VISION_STREAM_NARROW_ROAD)
     self.camerad.cam_send_yuv_road(yuv)
 
     if world.dual_camera:
-      yuv = self.camerad.rgb_to_yuv(world.wide_road_image)
+      yuv = self.camerad.rgb_to_yuv(world.wide_road_image, VisionStreamType.VISION_STREAM_WIDE_ROAD)
       self.camerad.cam_send_yuv_wide_road(yuv)
 
   def update(self, simulator_state: 'SimulatorState', world: 'World'):

--- a/openpilot/tools/sim/run_bridge.py
+++ b/openpilot/tools/sim/run_bridge.py
@@ -2,12 +2,12 @@
 import argparse
 
 from typing import Any
-from multiprocessing import Queue
 
 from openpilot.tools.sim.bridge.metadrive.metadrive_bridge import MetaDriveBridge
+from openpilot.tools.sim.lib.common import SIM_MP_CTX
 
 def create_bridge(dual_camera, high_quality):
-  queue: Any = Queue()
+  queue: Any = SIM_MP_CTX.Queue()
 
   simulator_bridge = MetaDriveBridge(dual_camera, high_quality)
   simulator_process = simulator_bridge.run(queue)

--- a/openpilot/tools/sim/tests/test_camerad.py
+++ b/openpilot/tools/sim/tests/test_camerad.py
@@ -1,0 +1,70 @@
+import numpy as np
+import unittest
+
+from openpilot.system.camerad.cameras.nv12_info import get_nv12_info
+from openpilot.selfdrive.modeld.compile_modeld import nv12_copy_size
+from openpilot.tools.sim.lib.camerad import rgb_to_nv12, STRIDE, Y_HEIGHT, UV_HEIGHT, UV_OFFSET, YUV_SIZE
+from openpilot.tools.sim.lib.common import W, H
+
+
+def reference_nv12(rgb):
+  """The tightly packed conversion, kept here so the pixel math stays pinned to what it was."""
+  h, w = rgb.shape[:2]
+  r = rgb[:, :, 0].astype(np.int32)
+  g = rgb[:, :, 1].astype(np.int32)
+  b = rgb[:, :, 2].astype(np.int32)
+  y = np.clip((((b * 13 + g * 65 + r * 33) + 64) >> 7) + 16, 0, 255).astype(np.uint8)
+  r_s = (r[0::2, 0::2] + r[0::2, 1::2] + r[1::2, 0::2] + r[1::2, 1::2] + 2) >> 2
+  g_s = (g[0::2, 0::2] + g[0::2, 1::2] + g[1::2, 0::2] + g[1::2, 1::2] + 2) >> 2
+  b_s = (b[0::2, 0::2] + b[0::2, 1::2] + b[1::2, 0::2] + b[1::2, 1::2] + 2) >> 2
+  u = np.clip((b_s * 56 - g_s * 37 - r_s * 19 + 0x8080) >> 8, 0, 255).astype(np.uint8)
+  v = np.clip((r_s * 56 - g_s * 47 - b_s * 9 + 0x8080) >> 8, 0, 255).astype(np.uint8)
+  uv = np.empty((h // 2, w), dtype=np.uint8)
+  uv[:, 0::2] = u
+  uv[:, 1::2] = v
+  return y, uv
+
+
+class TestSimCamerad(unittest.TestCase):
+  def test_buffer_is_big_enough_for_modeld(self):
+    # modeld copies nv12_copy_size bytes straight out of the VisionIPC buffer. A tightly packed
+    # NV12 frame is smaller than that, and modeld dies on its first frame with
+    # "buffer is smaller than requested size".
+    needed = nv12_copy_size(STRIDE, Y_HEIGHT, UV_HEIGHT)
+    assert YUV_SIZE >= needed, f"sim camera buffer {YUV_SIZE} < the {needed} modeld reads"
+    assert YUV_SIZE > W * H * 3 // 2, "buffer is tightly packed, which is what broke modeld"
+
+  def test_layout_matches_camerad(self):
+    stride, y_height, uv_height, size = get_nv12_info(W, H)
+    assert (STRIDE, Y_HEIGHT, UV_HEIGHT, YUV_SIZE) == (stride, y_height, uv_height, size)
+    assert UV_OFFSET == stride * y_height
+
+  def test_planes_land_where_consumers_look(self):
+    rgb = np.random.default_rng(0).integers(0, 256, (H, W, 3), dtype=np.uint8)
+    buf = rgb_to_nv12(rgb)
+    assert buf.shape == (YUV_SIZE,) and buf.dtype == np.uint8
+
+    y_ref, uv_ref = reference_nv12(rgb)
+    y = buf[:UV_OFFSET].reshape(Y_HEIGHT, STRIDE)
+    uv = buf[UV_OFFSET:UV_OFFSET + STRIDE * UV_HEIGHT].reshape(UV_HEIGHT, STRIDE)
+    assert np.array_equal(y[:H, :W], y_ref)
+    assert np.array_equal(uv[:H // 2, :W], uv_ref)
+
+    # the alignment padding has to be defined, not whatever was in the buffer before
+    assert y[:, W:].max() == 0 and y[H:, :].max() == 0
+    assert uv[:, W:].max() == 0 and uv[H // 2:, :].max() == 0
+
+  def test_channel_order(self):
+    # a red/blue swap on the way to VisionIPC is silent and ruins the model's input
+    red = np.zeros((H, W, 3), dtype=np.uint8)
+    red[:, :, 0] = 255
+    blue = np.zeros((H, W, 3), dtype=np.uint8)
+    blue[:, :, 2] = 255
+    y_red = rgb_to_nv12(red)[0]
+    y_blue = rgb_to_nv12(blue)[0]
+    assert y_red > y_blue, f"channel 0 must be red: got Y(red)={y_red}, Y(blue)={y_blue}"
+
+  def test_reuses_the_output_buffer(self):
+    rgb = np.zeros((H, W, 3), dtype=np.uint8)
+    out = np.zeros(YUV_SIZE, dtype=np.uint8)
+    assert rgb_to_nv12(rgb, out) is out

--- a/openpilot/tools/sim/tests/test_spawn_safety.py
+++ b/openpilot/tools/sim/tests/test_spawn_safety.py
@@ -1,0 +1,74 @@
+import multiprocessing
+import unittest
+
+from openpilot.tools.sim.bridge.common import SimulatorBridge
+from openpilot.tools.sim.lib.common import SIM_MP_CTX, World
+
+
+def _touch(bridge_state, lock, event, arr, conn):
+  """Runs in a spawned child: proves every shared object survived the trip."""
+  lock.release()
+  event.set()
+  arr[0] = 7
+  conn.send(bridge_state)
+
+
+class TestSpawnSafety(unittest.TestCase):
+  def test_context_is_spawn(self):
+    # a panda3d/OpenGL context can't be inherited across fork()
+    assert SIM_MP_CTX.get_start_method() == "spawn"
+
+  def test_world_primitives_come_from_the_sim_context(self):
+    # mixing contexts for synchronization primitives is unsupported and fails at spawn time
+    ctx_types = SIM_MP_CTX.Semaphore(0).__class__, SIM_MP_CTX.Event().__class__
+    world_lock = World.__init__.__globals__["SIM_MP_CTX"].Semaphore(0)
+    assert isinstance(world_lock, ctx_types[0])
+    assert SIM_MP_CTX is not multiprocessing
+
+  def test_shared_objects_survive_a_spawn(self):
+    import ctypes
+    lock = SIM_MP_CTX.Semaphore(value=0)
+    event = SIM_MP_CTX.Event()
+    arr = SIM_MP_CTX.Array(ctypes.c_uint8, 4)
+    parent_conn, child_conn = SIM_MP_CTX.Pipe()
+
+    p = SIM_MP_CTX.Process(target=_touch, args=("hello", lock, event, arr, child_conn))
+    p.start()
+    try:
+      assert parent_conn.recv() == "hello"
+      assert lock.acquire(timeout=10)
+      assert event.wait(timeout=10)
+      assert arr[0] == 7
+    finally:
+      p.join(timeout=10)
+      if p.is_alive():
+        p.kill()
+
+  def test_bridge_is_picklable(self):
+    # the bridge is handed to the spawned process, so the objects it owns must be dropped
+    import pickle
+
+    bridge = _StubBridge()
+    state = bridge.__getstate__()
+    assert "_exit_event" not in state and "_threads" not in state and "world" not in state
+    pickle.dumps(state)
+
+    revived = _StubBridge()
+    revived.__setstate__(state)
+    assert revived._threads == [] and revived._exit_event is None and revived.world is None
+    assert revived.dual_camera is False
+
+
+class _StubBridge(SimulatorBridge):
+  """Skips SimulatorBridge.__init__ so this doesn't need a MetaDrive install or Params."""
+  def __init__(self):  # deliberately not calling super(): no Params or MetaDrive needed here
+    import threading
+    self.dual_camera = False
+    self.high_quality = False
+    self._exit_event = threading.Event()
+    self._threads = [object()]
+    self.world = None
+    self._keep_alive = True
+
+  def spawn_world(self, q, /):
+    raise NotImplementedError


### PR DESCRIPTION
Towards #33207. This is the half that's unambiguously a bug fix. The part that still needs a decision from you is in a comment on the issue, with numbers.

## The one that isn't macOS specific

`tools/sim/lib/camerad.py` allocated its VisionIPC buffers with `create_buffers()`, which packs NV12 tightly at `width * height * 3 / 2`. Consumers read the frame straight out of that buffer using camerad's real layout, where rows are padded to a 128 byte stride and the plane heights are aligned. For 1928x1208 that's 3,735,552 bytes against the 3,493,536 the sim allocated, so modeld died on its first frame:

```
File "openpilot/selfdrive/modeld/modeld.py", line 203, in run
ValueError: buffer is smaller than requested size
```

This isn't platform specific. It fails the same way on Linux, and it's why the sim can't get past startup anywhere. The fix is to allocate and fill the padded layout, which is what `process_replay.py:209-210` already does:

```python
STRIDE, Y_HEIGHT, UV_HEIGHT, YUV_SIZE = get_nv12_info(W, H)
self.vipc_server.create_buffers_with_sizes(stream, 5, W, H, YUV_SIZE, STRIDE, STRIDE * Y_HEIGHT)
```

`rgb_to_nv12` now writes into that layout and zeroes the alignment padding. The pixel maths is untouched: `test_camerad.py` re-implements the old tightly packed conversion and asserts the new one is byte identical over the meaningful region.

## The macOS ones

**hardwared never started.** `openpilot/common/linux.py` reads `/proc/stat` and `/proc/meminfo`, which don't exist on macOS, so `hardware_thread` raised `FileNotFoundError` on its first line and the process died. Since it's `always_run`, the whole stack sat there with `processNotRunning`. There's now an `UnsupportedSystemStats` selected by `sys.platform`, which reports nothing rather than stopping the process. Those numbers only feed telemetry and the `lowMemory` event on PC.

**Shared objects didn't survive the start method.** A panda3d/OpenGL context can't be inherited across `fork()`, and mixing multiprocessing contexts for synchronization primitives isn't supported. The sim was creating its `Semaphore`, `Event`, `Array`, `Pipe`, `Value`, `Queue` and `Process` from the default context in four different modules. On macOS that meant a spawned child failing to rebuild a semaphore:

```
File ".../multiprocessing/synchronize.py", line 115, in __setstate__
    self._semlock = _multiprocessing.SemLock._rebuild(*state)
FileNotFoundError: [Errno 2] No such file or directory
```

Everything now comes from one `SIM_MP_CTX = multiprocessing.get_context("spawn")`. The sim always spawns, on every platform, rather than special casing Darwin. One tested path, and a GL context can't survive `fork()` on Linux either. `SimulatorBridge` gained `__getstate__`/`__setstate__` to drop the objects the loop owns, and registers its `SIGTERM` handler in the process that actually runs the loop instead of the one that constructed it.

**Camera frames were stamped with a made up clock.** `_send_yuv` used `eof = int(frame_id * 0.05 * 1e9)`, which starts at zero and drifts away from `logMonoTime`. locationd validates camera odometry against `msg.timestampEof`, so it rejected every pose. It now uses `time.monotonic()`, which is the clock `logMonoTime` comes from.

## What this gets you

On an M2 Max, `tools/test_runner.py openpilot/tools/sim/tests/test_metadrive_bridge.py` with the skip removed goes from dying immediately to: every managed process running, calibration reaching `calibrated` with 20 valid blocks, `sensorsOK` and `posenetOK` true, and the car engaging (`selfdriveState.active`) once the model can keep up with the camera.

It doesn't pass yet. The remaining wall is a rate problem rather than a macOS one, and it's written up on the issue.

## Tests

`tools/sim/tests/test_camerad.py` and `tools/sim/tests/test_spawn_safety.py`, 9 tests. I checked each by reverting the thing it covers:

| mutation | result |
|---|---|
| tightly packed NV12, the old layout | 2 failed, 1 error |
| swap the R and B channels | 2 failed |
| leave the alignment padding uninitialised | 1 failed |
| default multiprocessing context | 1 failed |
| keep process owned attributes in `__getstate__` | 1 failed |
| none, reverted | 9 passed |

Note that `tools/test_runner.py` excludes `openpilot/tools/sim` from collection, so these need to be invoked explicitly:

```
tools/test_runner.py openpilot/tools/sim/tests/test_camerad.py openpilot/tools/sim/tests/test_spawn_safety.py
```

## Validation

* `scons` clean on macOS arm64.
* `tools/op.sh test`: 849 passed, 44 skipped, 1 xfailed, 1 failed, 7 error, which is byte identical to the same run on master. The failures are pre-existing macOS environment issues (`os.getxattr`, athenad and messaging timing, the raylib UI test).
* `scripts/lint/lint.sh` clean apart from two failures that are also present on a clean tree: a shebang check matching the binary `updater`, and a `ty` diagnostic on `metadrive_process.py:50` that only shows up when MetaDrive is installed locally.
* CI green on a fork for every job: process replay, unit tests, build release, build macOS, static analysis, UI report. The process replay diff report reads 0 changed, 66 passed, 0 errors.
* `process_replay` fails identically on macOS on master and on this branch, on the same 16 segments. The reference artifacts are generated on Linux and acados differs here, so Linux CI is the authority for that one.

## Prior art

The spawn context and picklability work is the correct core of #38729 and #38764 and I've kept their shape. What I can add is that I ran it: this is on Apple Silicon with MetaDrive actually installed, which is how the buffer, `/proc` and clock bugs surfaced. One correction worth noting is that `Params` is picklable since merged #34023, so it doesn't need dropping from `__getstate__`. Only the process owned objects do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
