### PR TITLE
uploader: the 12h metered delay never applied to boot and crash logs

### DIFF
--- a/openpilot/system/loggerd/tests/test_uploader.py
+++ b/openpilot/system/loggerd/tests/test_uploader.py
@@ -157,6 +157,17 @@ class TestUploader(UploaderTestCase):
       fn = f_path.with_suffix(f_path.suffix.replace(".zst", ""))
       assert all(candidate[2] != str(fn) for candidate in uploader.list_upload_files(metered=False)), "Locked file selected for upload"
 
+  def test_metered_delays_recent_boot_logs(self):
+    self.gen_files(lock=False, boot=True)
+    uploader = Uploader("0000000000000000", Paths.log_root())
+
+    unmetered = {candidate[1] for candidate in uploader.list_upload_files(metered=False)}
+    metered = {candidate[1] for candidate in uploader.list_upload_files(metered=True)}
+
+    boot_keys = {key for key in unmetered if key.startswith("boot/")}
+    assert boot_keys, "Expected a boot log to be uploadable on an unmetered connection"
+    assert not (boot_keys & metered), "Boot logs younger than 12h should wait on a metered connection"
+
   def test_no_upload_with_xattr(self):
     f_paths = self.gen_files(lock=False, xattr=UPLOAD_ATTR_VALUE)
     uploader = Uploader("0000000000000000", Paths.log_root())

--- a/openpilot/system/loggerd/uploader.py
+++ b/openpilot/system/loggerd/uploader.py
@@ -116,7 +116,7 @@ class Uploader:
         # limit uploading on metered connections
         if metered:
           dt = datetime.timedelta(hours=12)
-          if logdir in self.immediate_folders and (datetime.datetime.now() - datetime.datetime.fromtimestamp(ctime)) < dt:
+          if f"{logdir}/" in self.immediate_folders and (datetime.datetime.now() - datetime.datetime.fromtimestamp(ctime)) < dt:
             continue
 
           if name == "qcamera.ts" and not any(logdir.startswith(r.split('|')[-1]) for r in requested_routes):


### PR DESCRIPTION
The 12 hour hold off that keeps boot and crash logs off a metered connection has never run. immediate_folders is ["crash/", "boot/"] with trailing slashes, because its other use further down is a substring test against a full key. The check at line 119 is an exact membership test against logdir, which comes from os.listdir and so is "boot" or "crash", never with a slash, so it is always False.

On a metered connection that means a bootlog or crashlog is uploaded immediately over cellular instead of waiting up to 12 hours for a chance at wifi. It has behaved this way since #31045, which is both where the check was added and where the loop variable was renamed from logname to logdir.

Comparing with the slash matches how immediate_folders is defined and leaves the substring use at line 131 alone. I also added a test, since the existing ones only ever call list_upload_files(metered=False), which is why this went unnoticed.
