### PR TITLE
test_runner: collect parameterized_class tests instead of skipping them with their base

### DIFF
--- a/tools/test_runner.py
+++ b/tools/test_runner.py
@@ -170,7 +170,7 @@ def collect(targets, keyword):
       cls = type(test)
       if cls.__name__ == "_FailedTest":
         continue
-      if getattr(cls, "__unittest_skip_why__", "") == "parameterized base class":
+      if cls.__dict__.get("__unittest_skip_why__", "") == "parameterized base class":
         continue
       if not keyword or keyword.lower() in test.id().lower():
         tests.append(test)


### PR DESCRIPTION
collect() drops every test generated by parameterized_class, so none of them run under tools/op.sh test, which is what CI runs for unit tests.

parameterized_class builds each variant as a subclass of the decorated class and sets __unittest_skip__ = False on it, then marks the base with __unittest_skip_why__ = "parameterized base class". The filter here reads that attribute with getattr, which finds it on the subclasses too because they inherit it from the base, so the variants are skipped along with the base they came from.

Reading it off the class's own __dict__ keeps the base excluded and lets the variants through. On a file with one parameterized_class of four variants and two test methods, collect() returns 0 tests before this change and 8 after, with no collection errors in either case, so the tests are dropped silently.

This affects test_cruise_speed.py, test_following_distance.py and test_longitudinal.py.
