### PR TITLE
qrcode: fix alignment pattern positions for version 32

### DIFF
--- a/openpilot/common/qrcode.py
+++ b/openpilot/common/qrcode.py
@@ -108,7 +108,7 @@ def _alignment_positions(version: int) -> list[int]:
   if version == 1:
     return []
   count = version // 7 + 2
-  step = ((version * 4 + count * 2 + 1) // (count * 2 - 2)) * 2
+  step = (version * 8 + count * 3 + 5) // (count * 4 - 4) * 2
   return [6] + [version * 4 + 10 - step * i for i in range(count - 1)][::-1]
 
 

--- a/openpilot/common/tests/test_qrcode.py
+++ b/openpilot/common/tests/test_qrcode.py
@@ -1,5 +1,3 @@
-import unittest
-
 from openpilot.common import qrcode as qr
 from openpilot.common.test import OpenpilotTestCase
 
@@ -7,8 +5,5 @@ from openpilot.common.test import OpenpilotTestCase
 class TestQRCode(OpenpilotTestCase):
   def test_alignment_positions(self):
     assert qr._alignment_positions(7) == [6, 22, 38]
-    assert qr._alignment_positions(40) == [6, 30, 58, 86, 114, 142, 170]
-
-  @unittest.expectedFailure  # the step between patterns rounds the wrong way for version 32
-  def test_alignment_positions_v32(self):
     assert qr._alignment_positions(32) == [6, 34, 60, 86, 112, 138]
+    assert qr._alignment_positions(40) == [6, 30, 58, 86, 114, 142, 170]


### PR DESCRIPTION
The closed-form step rounds the wrong way for version 32 (28 instead of 26). The encoder only emits versions 1-20, so its output is unchanged.

Verified: the version 32 case moves from expected failure into the passing test.