### PR TITLE
qrcode: test alignment pattern positions

### DIFF
--- a/openpilot/common/tests/test_qrcode.py
+++ b/openpilot/common/tests/test_qrcode.py
@@ -1,0 +1,14 @@
+import unittest
+
+from openpilot.common import qrcode as qr
+from openpilot.common.test import OpenpilotTestCase
+
+
+class TestQRCode(OpenpilotTestCase):
+  def test_alignment_positions(self):
+    assert qr._alignment_positions(7) == [6, 22, 38]
+    assert qr._alignment_positions(40) == [6, 30, 58, 86, 114, 142, 170]
+
+  @unittest.expectedFailure  # the step between patterns rounds the wrong way for version 32
+  def test_alignment_positions_v32(self):
+    assert qr._alignment_positions(32) == [6, 34, 60, 86, 112, 138]


### PR DESCRIPTION
Checks versions 7 and 40 against ISO 18004 table E.1. Version 32 is an expected failure; the fix follows in a separate PR.