### PR TITLE
run MetaDrive sim test in CI

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -182,18 +182,28 @@ jobs:
       (github.event.pull_request.head.repo.full_name == 'commaai/openpilot'))
       && fromJSON('["namespace-profile-amd64-8x16"]')
       || fromJSON('["ubuntu-24.04"]') }}
-    if: false  # FIXME: Started to timeout recently
     steps:
     - uses: actions/checkout@v7
     - run: ./tools/op.sh setup
     - name: Build openpilot
       run: scons
     - name: Driving test
-      timeout-minutes: 2
+      timeout-minutes: 20
       env:
         # MetaDrive renders offscreen through panda3d's EGL pipe on llvmpipe
         EGL_PLATFORM: surfaceless
-      run: python openpilot/tools/sim/tests/test_metadrive_bridge.py
+        # run the logging stack so rlog/qlog/camera files are produced
+        SIM_LOGS: 1
+        LOG_ROOT: ${{ github.workspace }}/.ci_artifacts/sim_logs
+      run: tools/op.sh test openpilot/tools/sim/tests/test_metadrive_bridge.py
+    - name: Upload simulator logs
+      if: always()
+      uses: actions/upload-artifact@v7
+      with:
+        name: simulator-logs-${{ inputs.run_number || '1' }}-${{ github.event_name == 'push' && github.ref == 'refs/heads/master' && 'master' || github.event.number }}
+        path: .ci_artifacts/sim_logs
+        retention-days: 7
+        if-no-files-found: warn
 
   create_ui_report:
     name: Create UI Report

--- a/openpilot/tools/sim/launch_openpilot.sh
+++ b/openpilot/tools/sim/launch_openpilot.sh
@@ -6,10 +6,17 @@ export SIMULATION="1"
 export SKIP_FW_QUERY="1"
 export FINGERPRINT="HONDA_CIVIC_2022"
 
-export BLOCK="${BLOCK},camerad,loggerd,encoderd,micd,logmessaged,manage_athenad"
+# keep camera process blocked (simulator publishes frames), but optionally allow logging stack
+block_list="camerad,micd,logmessaged,manage_athenad"
+if [[ -z "${SIM_LOGS:-}" ]]; then
+  block_list="${block_list},loggerd,encoderd"
+fi
+export BLOCK="${BLOCK},${block_list}"
 if [[ "$CI" ]]; then
   # TODO: offscreen UI should work
   export BLOCK="${BLOCK},ui"
+  # no audio device on CI runners, soundd would crashloop and trip the test's process checks
+  export BLOCK="${BLOCK},soundd"
 fi
 
 python3 -c "from openpilot.selfdrive.test.helpers import set_params_enabled; set_params_enabled()"

--- a/openpilot/tools/sim/lib/camerad.py
+++ b/openpilot/tools/sim/lib/camerad.py
@@ -1,14 +1,23 @@
+import time
+
 import numpy as np
 
 from openpilot.cereal.visionipc import VisionStreamType
 from msgq.visionipc import VisionIpcServer
 from openpilot.cereal import messaging
+from openpilot.system.camerad.cameras.nv12_info import get_nv12_info
 
 from openpilot.tools.sim.lib.common import W, H
 
+# Consumers read the frame straight out of the VisionIPC buffer, so it has to be laid out the way
+# camerad lays it out: rows padded to a 128 byte stride and the plane heights aligned. Packing NV12
+# tightly instead leaves modeld short of the bytes it copies, and it dies on the first frame.
+STRIDE, Y_HEIGHT, UV_HEIGHT, YUV_SIZE = get_nv12_info(W, H)
+UV_OFFSET = STRIDE * Y_HEIGHT
 
-def rgb_to_nv12(rgb):
-  """Convert RGB image to NV12 (YUV420) format using BT.601 coefficients."""
+
+def rgb_to_nv12(rgb, out=None):
+  """Convert an RGB image to a camerad-shaped NV12 buffer using BT.601 coefficients."""
   h, w = rgb.shape[:2]
   r = rgb[:, :, 0].astype(np.int32)
   g = rgb[:, :, 1].astype(np.int32)
@@ -27,12 +36,16 @@ def rgb_to_nv12(rgb):
   u = np.clip((b_sub * 56 - g_sub * 37 - r_sub * 19 + 0x8080) >> 8, 0, 255).astype(np.uint8)
   v = np.clip((r_sub * 56 - g_sub * 47 - b_sub * 9 + 0x8080) >> 8, 0, 255).astype(np.uint8)
 
-  # Interleave UV for NV12 format
-  uv = np.empty((h // 2, w), dtype=np.uint8)
-  uv[:, 0::2] = u
-  uv[:, 1::2] = v
+  if out is None:
+    out = np.zeros(YUV_SIZE, dtype=np.uint8)
 
-  return np.concatenate([y.ravel(), uv.ravel()]).tobytes()
+  # Write into the padded planes, leaving the alignment padding zeroed
+  out[:UV_OFFSET].reshape(Y_HEIGHT, STRIDE)[:h, :w] = y
+  uv = out[UV_OFFSET:UV_OFFSET + STRIDE * UV_HEIGHT].reshape(UV_HEIGHT, STRIDE)
+  uv[:h // 2, 0:w:2] = u
+  uv[:h // 2, 1:w:2] = v
+
+  return out
 
 
 class Camerad:
@@ -44,11 +57,15 @@ class Camerad:
     self.frame_wide_id = 0
     self.vipc_server = VisionIpcServer("camerad")
 
-    self.vipc_server.create_buffers(VisionStreamType.VISION_STREAM_NARROW_ROAD, 5, W, H)
+    self.vipc_server.create_buffers_with_sizes(VisionStreamType.VISION_STREAM_NARROW_ROAD, 5, W, H, YUV_SIZE, STRIDE, UV_OFFSET)
     if dual_camera:
-      self.vipc_server.create_buffers(VisionStreamType.VISION_STREAM_WIDE_ROAD, 5, W, H)
+      self.vipc_server.create_buffers_with_sizes(VisionStreamType.VISION_STREAM_WIDE_ROAD, 5, W, H, YUV_SIZE, STRIDE, UV_OFFSET)
 
     self.vipc_server.start_listener()
+
+    # one scratch buffer per stream, these are 4.8MB each
+    self.yuv_bufs = {t: np.zeros(YUV_SIZE, dtype=np.uint8) for t in
+                     (VisionStreamType.VISION_STREAM_NARROW_ROAD, VisionStreamType.VISION_STREAM_WIDE_ROAD)}
 
   def cam_send_yuv_road(self, yuv):
     self._send_yuv(yuv, self.frame_road_id, 'narrowRoadCameraState', VisionStreamType.VISION_STREAM_NARROW_ROAD)
@@ -58,14 +75,16 @@ class Camerad:
     self._send_yuv(yuv, self.frame_wide_id, 'wideRoadCameraState', VisionStreamType.VISION_STREAM_WIDE_ROAD)
     self.frame_wide_id += 1
 
-  def rgb_to_yuv(self, rgb):
+  def rgb_to_yuv(self, rgb, yuv_type=VisionStreamType.VISION_STREAM_NARROW_ROAD):
     """Convert RGB to NV12 YUV format."""
     assert rgb.shape == (H, W, 3), f"{rgb.shape}"
     assert rgb.dtype == np.uint8
-    return rgb_to_nv12(rgb)
+    return rgb_to_nv12(rgb, self.yuv_bufs[yuv_type])
 
   def _send_yuv(self, yuv, frame_id, pub_type, yuv_type):
-    eof = int(frame_id * 0.05 * 1e9)
+    # same clock as logMonoTime, otherwise locationd rejects the camera odometry these frames
+    # produce as out of range and never gets a valid pose
+    eof = int(time.monotonic() * 1e9)
     self.vipc_server.send(yuv_type, yuv, frame_id, eof, eof)
 
     dat = messaging.new_message(pub_type, valid=True)

--- a/openpilot/tools/sim/lib/simulated_sensors.py
+++ b/openpilot/tools/sim/lib/simulated_sensors.py
@@ -4,6 +4,7 @@ from openpilot.cereal import log
 import openpilot.cereal.messaging as messaging
 
 from openpilot.common.realtime import DT_DMON
+from openpilot.cereal.visionipc import VisionStreamType
 from openpilot.tools.sim.lib.camerad import Camerad
 
 from typing import TYPE_CHECKING
@@ -97,11 +98,11 @@ class SimulatedSensors:
 
   def send_camera_images(self, world: 'World'):
     world.image_lock.acquire()
-    yuv = self.camerad.rgb_to_yuv(world.road_image)
+    yuv = self.camerad.rgb_to_yuv(world.road_image, VisionStreamType.VISION_STREAM_NARROW_ROAD)
     self.camerad.cam_send_yuv_road(yuv)
 
     if world.dual_camera:
-      yuv = self.camerad.rgb_to_yuv(world.wide_road_image)
+      yuv = self.camerad.rgb_to_yuv(world.wide_road_image, VisionStreamType.VISION_STREAM_WIDE_ROAD)
       self.camerad.cam_send_yuv_wide_road(yuv)
 
   def update(self, simulator_state: 'SimulatorState', world: 'World'):

--- a/openpilot/tools/sim/tests/test_sim_bridge.py
+++ b/openpilot/tools/sim/tests/test_sim_bridge.py
@@ -21,7 +21,6 @@ class TestSimBridgeBase(OpenpilotTestCase):
   def setup_method(self):
     self.processes = []
 
-  @unittest.skip("TODO: re-enable simulator bridge test")
   def test_driving(self):
     # Startup manager and bridge.py. Check processes are running, then engage and verify.
     p_manager = subprocess.Popen("./launch_openpilot.sh", cwd=SIM_DIR)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,8 +68,7 @@ tools = [
   "comma-deps-libusb",
   "comma-deps-ncurses",
 
-  # this can be added back once it's stripped down some more
-  #"metadrive-simulator @ git+https://github.com/commaai/metadrive.git@minimal ; (platform_machine != 'aarch64')",
+  "metadrive-simulator @ git+https://github.com/commaai/metadrive.git@minimal ; (platform_machine != 'aarch64')",
 ]
 
 submodules = [

--- a/uv.lock
+++ b/uv.lock
@@ -503,6 +503,16 @@ wheels = [
 ]
 
 [[package]]
+name = "metadrive-simulator"
+version = "0.4.2.3"
+source = { git = "https://github.com/commaai/metadrive.git?rev=minimal#2716f55a9c7b928ce957a497a15c2c19840c08bc" }
+dependencies = [
+    { name = "numpy" },
+    { name = "panda3d" },
+    { name = "panda3d-gltf" },
+]
+
+[[package]]
 name = "mpmath"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -637,6 +647,7 @@ tools = [
     { name = "comma-deps-libusb" },
     { name = "comma-deps-ncurses" },
     { name = "matplotlib" },
+    { name = "metadrive-simulator", marker = "platform_machine != 'aarch64'" },
 ]
 
 [package.dev-dependencies]
@@ -664,6 +675,7 @@ requires-dist = [
     { name = "inputs" },
     { name = "jeepney" },
     { name = "matplotlib", marker = "extra == 'tools'" },
+    { name = "metadrive-simulator", marker = "platform_machine != 'aarch64' and extra == 'tools'", git = "https://github.com/commaai/metadrive.git?rev=minimal" },
     { name = "msgq", marker = "extra == 'submodules'", editable = "msgq_repo" },
     { name = "numpy", specifier = ">=2.0" },
     { name = "opendbc", marker = "extra == 'submodules'", editable = "opendbc_repo" },
@@ -696,6 +708,45 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/7d/fa/3944b40b07da9ce895c0e6303a5ab7d53da063554f534556b134a54d6093/packaging-26.3.tar.gz", hash = "sha256:94edc256424af38762eb31306eed28beb9f0efc50a8837492c9d6fd6004aed79", size = 313412, upload-time = "2026-08-04T18:15:28.737Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/63/34/ba1c580383c9eada3711951fef0795c80b829a078d72188184bcab9dd527/packaging-26.3-py3-none-any.whl", hash = "sha256:d7193f7c8e4e93f444fde0262bf90af30e16fa0ad0ad44cb553c87339b23cd1c", size = 129956, upload-time = "2026-08-04T18:15:27.159Z" },
+]
+
+[[package]]
+name = "panda3d"
+version = "1.10.14"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/d4/90e98993b1a3f3c9fae83267f8c51186e676a8c1365c4180dfc65cd7ba62/panda3d-1.10.14-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:1bfbcee77779f12ecce6a3d5a856e573b25d6343f8c4b107e814d9702e70a65d", size = 67839196, upload-time = "2024-01-08T19:01:00.417Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/e5/862821575073863ce49cc57b8349b47cb25ce11feae0e419b3d023ac1a69/panda3d-1.10.14-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:bc6540c5559d7e14a8992eff7de0157b7c42406b7ba221941ed224289496841c", size = 119271341, upload-time = "2024-01-08T19:01:09.455Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/20/f16d91805777825e530037177d9075c83da7384f12b778b133e3164a31f3/panda3d-1.10.14-cp312-cp312-manylinux2014_aarch64.whl", hash = "sha256:143daab1ce6bedcba711ea3f6cab0ebe5082f22c5f43e7178fadd2dd01209da7", size = 47604077, upload-time = "2024-05-28T20:25:37.118Z" },
+    { url = "https://files.pythonhosted.org/packages/11/69/806dcdbaee3e8deee1956abeea0d3d3e504315d2e9814de82a44809a8617/panda3d-1.10.14-cp312-cp312-manylinux2014_x86_64.whl", hash = "sha256:3c4399a286a142de7ff86f9356d7e526bbbd38892d7f7d39fecb5c33064972bc", size = 55539594, upload-time = "2024-01-08T19:01:15.979Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/25/005de5e2b6d0acd546f8b3f2b547cd29e308cdd04a397f0ea68046e26571/panda3d-1.10.14-cp312-cp312-win32.whl", hash = "sha256:e92e0dd907e2af33085a2c31ca2263dc8023b1b7bc70ce1b9fbc84631e130e51", size = 53479813, upload-time = "2024-01-08T19:01:20.923Z" },
+    { url = "https://files.pythonhosted.org/packages/74/bb/cb57563855da994614a33f57bd5691fbcd69f12e5ccddd30d387d0be287f/panda3d-1.10.14-cp312-cp312-win_amd64.whl", hash = "sha256:a5f2defd822d38848f8ae1956115adcb6cc7f464f03a67e73681cc72df125ef4", size = 64893222, upload-time = "2024-01-08T19:01:26.347Z" },
+]
+
+[[package]]
+name = "panda3d-gltf"
+version = "0.13"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "panda3d" },
+    { name = "panda3d-simplepbr" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/07/7f/9f18fc3fa843a080acb891af6bcc12262e7bdf1d194a530f7042bebfc81f/panda3d-gltf-0.13.tar.gz", hash = "sha256:d06d373bdd91cf530909b669f43080e599463bbf6d3ef00c3558bad6c6b19675", size = 25573, upload-time = "2021-05-21T05:46:32.738Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/70/94/98ed1f81ca0f5daf6de80533805cc1e98ac162abe4e3e1d382caa7ba5c3c/panda3d_gltf-0.13-py3-none-any.whl", hash = "sha256:02d1a980f447bb1895ff4b48c667f289ba78f07a28ef308d8839b665a621efe2", size = 25568, upload-time = "2021-05-21T05:46:31.28Z" },
+]
+
+[[package]]
+name = "panda3d-simplepbr"
+version = "0.13.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "panda3d" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0d/be/c4d1ded04c22b357277cf6e6a44c1ab4abb285a700bd1991460460e05b99/panda3d_simplepbr-0.13.1.tar.gz", hash = "sha256:c83766d7c8f47499f365a07fe1dff078fc8b3054c2689bdc8dceabddfe7f1a35", size = 6216055, upload-time = "2025-03-30T16:57:41.087Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/11/5d/3744c6550dddf933785a37cdd4a9921fe13284e6d115b5a2637fe390f158/panda3d_simplepbr-0.13.1-py3-none-any.whl", hash = "sha256:cda41cb57cff035b851646956cfbdcc408bee42511dabd4f2d7bd4fbf48c57a9", size = 2457097, upload-time = "2025-03-30T16:57:39.729Z" },
 ]
 
 [[package]]
@@ -1112,6 +1163,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/9a/0d/f5e5a50322e9c45865e7b7a428ba6cd6527387cf0f2472492ac3cf746243/ty-0.0.72-py3-none-win32.whl", hash = "sha256:f25f72a67bd36cd247707c4784e52fad0b6b4f42a1b7dd14804110fa95c486ed", size = 11939708, upload-time = "2026-08-14T21:35:36.006Z" },
     { url = "https://files.pythonhosted.org/packages/3f/4e/8af3534b2e4214e6184a5a59c34101e94a68d578f081f97b995866bab1bf/ty-0.0.72-py3-none-win_amd64.whl", hash = "sha256:cdeee869341717e1736cea2e2d7856738c6957c320f584ed2f68c8f90100d2f5", size = 12643876, upload-time = "2026-08-14T21:35:38.141Z" },
     { url = "https://files.pythonhosted.org/packages/ff/ea/a2606e654c7276bd08586391a2525b0af3f3bf60228a8c57b2d248f273f9/ty-0.0.72-py3-none-win_arm64.whl", hash = "sha256:1bd3ac3ed4424a6d6990a85dc388556aea012bd752de21349a84b685951de0d8", size = 12394857, upload-time = "2026-08-14T21:35:40.277Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Takes a shot at #30693.

While wiring this up I ran into five separate things that break the test on CI, each traceable to comments in the issue or recent PRs:

1. VisionIPC buffer mismatch — camerad now builds its buffers with the packed NV12 layout while modeld expects padded stride, so modeld dies on the first frame (miniquinox hit this on 09-08, PR #38815). Switched to get_nv12_info + create_buffers_with_sizes.
2. eof timestamps used frame_id math instead of monotonic clock, so locationd rejects the camera odometry and livePose never goes valid (matches what JPL11 saw). Now int(time.monotonic()*1e9), same clock as messaging.
3. The test itself was @unittest.skip'd (#38480). Removed.
4. The old CI step ran the module directly — no __main__, zero tests, silent exit 0. Now goes through tools/op.sh test so the runner actually collects it.
5. soundd crashloops on runners with no audio device. Blocked under CI, same as #38740 did elsewhere.

Also fixed a hard blocker: uv.lock had no metadrive entries, so uv sync --frozen would fail outright. Regenerated (+60 lines, metadrive-simulator pinned to the commaai fork).

Logs: SIM_LOGS=1 lets loggerd/encoderd through (camerad stays blocked, the sim's VIPC server takes over), LOG_ROOT points at .ci_artifacts/sim_logs, and the upload step uses if:always() so you get qlog/rlog/camera files even when the test fails. Same pattern as the ui-report job.

One thing I can't fix from here: on the free 4-vCPU fork runners, model inference runs at ~2-3 Hz against a 20 Hz budget — this matches what was measured independently in the issue comments, and it may prevent engage on fork PRs. On commaai's own 8-core runners the numbers look workable. Distilled model or a CI-specific inference path would be a maintainer call; happy to rebase once there's a direction.