### PR TITLE
selfdrived: no localizer alerts from capnp defaults

### DIFF
--- a/openpilot/selfdrive/selfdrived/selfdrived.py
+++ b/openpilot/selfdrive/selfdrived/selfdrived.py
@@ -398,11 +398,12 @@ class SelfdriveD:
       self.logged_comm_issue = None
 
     if not self.CP.notCar and not big_model_settling:  # localization has nothing to work with during the load
-      if not self.sm['deviceMotion'].posenetOK:
+      # the defaults of a message that was never received are not a localizer failure
+      if self.sm.seen['deviceMotion'] and not self.sm['deviceMotion'].posenetOK:
         self.events.add(EventName.posenetInvalid)
-      if not self.sm['deviceMotion'].inputsOK:
+      if self.sm.seen['deviceMotion'] and not self.sm['deviceMotion'].inputsOK:
         self.events.add(EventName.locationdTemporaryError)
-      if (not self.sm['vehicleParameters'].valid and cal_status == log.ExtrinsicsCalibration.Status.calibrated and
+      if (self.sm.seen['vehicleParameters'] and not self.sm['vehicleParameters'].valid and cal_status == log.ExtrinsicsCalibration.Status.calibrated and
           not TESTING_CLOSET and (not SIMULATION or REPLAY)):
         self.events.add(EventName.paramsdTemporaryError)
 


### PR DESCRIPTION
If `modeld` goes down, `locationd` and `paramsd` never publish...
This causes `posenetInvalid`, `locationdTemporaryError `and `paramsdTemporaryError ` to be raised off the capnp defaults for messages that didn't actually arive. the posenet one in particular renders a `nan speed error` and can hide the process not running alert that names `modeld`.

I noticed this when SunnyPilot had the wrong model pkl in a prebuilt. modeld died on a KeyError before its first frame, and alerted `Posenet Speed Invalid / Speed Error: nan m/s`, which is misleading. 

same guard as #38500.