### PR TITLE
remove old manifest before rebuild

### DIFF
--- a/openpilot/common/file_chunker.py
+++ b/openpilot/common/file_chunker.py
@@ -24,6 +24,7 @@ def chunk_file(path, targets):
   manifest_path, *chunk_paths = targets
   actual_num_chunks = max(1, math.ceil(os.path.getsize(path) / CHUNK_SIZE))
   assert len(chunk_paths) >= actual_num_chunks, f"Allowed {len(chunk_paths)} chunks but needs at least {actual_num_chunks}, for path {path}"
+  Path(manifest_path).unlink(missing_ok=True)
   with open(path, 'rb') as f:
     for chunk_path in chunk_paths:
       with open(chunk_path, 'wb') as out:


### PR DESCRIPTION
Remove old manifest before rewriting model chunks so an interrupted rebuild cannot leave partially written chunks marked as complete.