### PR TITLE
modeld: warp on QCOM, send only the crop over USB

### DIFF
--- a/openpilot/selfdrive/modeld/SConscript
+++ b/openpilot/selfdrive/modeld/SConscript
@@ -40,7 +40,7 @@ tg_devices = { # which device to put jit inputs to at runtime
 
 CHESTNUT = chestnut_present()
 if CHESTNUT:
-  chestnut_tg_flags = 'DEBUG=1 DEV=USB+AMD:LLVM FRAME_DEV=CPU FLOAT16=1 JIT_BATCH_SIZE=0 GMMU=0 TC_OPT=2 TC_MIN_GLOBALS=32'
+  chestnut_tg_flags = f'DEBUG=1 DEV=USB+AMD:LLVM WARP_DEV={tg_backend} FLOAT16=1 JIT_BATCH_SIZE=0 GMMU=0 TC_OPT=2 TC_MIN_GLOBALS=32'
   # the USB+AMD GPU takes an exclusive flock; serialize all targets that touch it
   chestnut_lock = File("models/.chestnut.lock").abspath
 

--- a/openpilot/selfdrive/modeld/compile_modeld.py
+++ b/openpilot/selfdrive/modeld/compile_modeld.py
@@ -37,12 +37,14 @@ from tinygrad.engine.jit import TinyJit
 
 
 NV12Frame = namedtuple("NV12Frame", ['width', 'height', 'stride', 'y_height', 'uv_height', 'size'])
-MODELD_INPUTS = ['img_q', 'big_img_q', 'feat_q', 'desire_q', 'packed_npy_inputs']
+FRAME_INPUTS = ['frame', 'big_frame']
+QUEUE_INPUTS = ['img_q', 'big_img_q', 'feat_q', 'desire_q', 'packed_npy_inputs']
+
+WARP_DEV = os.getenv('WARP_DEV')
 
 
-def nv12_copy_size(stride: int, y_height: int, uv_height: int) -> int:
-  # Retain the padded Y and UV plane storage, but skip the trailing kernel/guard allocation.
-  return stride * (y_height + uv_height)
+def make_random_frames(nv12: NV12Frame):
+  return {k: Tensor.randint(nv12.size, low=0, high=256, dtype='uint8', device=WARP_DEV).realize() for k in FRAME_INPUTS}
 
 
 def warp_perspective_tinygrad(src_flat, M_inv, dst_shape, src_shape, stride_pad, border_fill_val=None):
@@ -94,7 +96,7 @@ def make_frame_prepare(nv12: NV12Frame, model_w, model_h):
 
   def frame_prepare_tinygrad(input_frame, M_inv):
     # UV_SCALE @ M_inv @ UV_SCALE_INV simplifies to elementwise scaling
-    M_inv_uv = M_inv * Tensor([[1.0, 1.0, 0.5], [1.0, 1.0, 0.5], [2.0, 2.0, 1.0]], device=Device.DEFAULT)
+    M_inv_uv = M_inv * Tensor([[1.0, 1.0, 0.5], [1.0, 1.0, 0.5], [2.0, 2.0, 1.0]], device=M_inv.device)
     # deinterleave NV12 UV plane (UVUV... -> separate U, V)
     uv = input_frame[uv_offset:uv_offset + uv_height * stride].reshape(uv_height, stride)
     with Context(SPLIT_REDUCEOP=0):
@@ -124,7 +126,7 @@ def get_policy_npy_shapes(input_shapes):
   return shapes, [math.prod(s) for s in shapes.values()]
 
 
-def make_input_queues(input_shapes, frame_skip, device, frame_copy_size):
+def make_input_queues(input_shapes, frame_skip, device):
   img = input_shapes['img']  # (1, 12, 128, 256)
   fb = input_shapes['features_buffer']  # (1, T-1, ...), past features only; the model appends the current frame's feature
   feat_dim = math.prod(fb[2:])
@@ -135,11 +137,7 @@ def make_input_queues(input_shapes, frame_skip, device, frame_copy_size):
   policy_shapes, _ = get_policy_npy_shapes(input_shapes)
   shapes = {'tfm': (3, 3), 'big_tfm': (3, 3)} | policy_shapes
   sizes = [math.prod(s) for s in shapes.values()]
-  packed_npy_size = sum(sizes) * np.dtype(np.float32).itemsize
-  packed_input = np.zeros(packed_npy_size + 2 * frame_copy_size, dtype=np.uint8)
-  packed_npy_inputs = packed_input[:packed_npy_size].view(np.float32)
-  frames = packed_input[packed_npy_size:]
-  frame_views = {'img': frames[:frame_copy_size], 'big_img': frames[frame_copy_size:]}
+  packed_npy_inputs = np.zeros(sum(sizes), dtype=np.float32)
   # views into the packed inputs, to be refilled at runtime
   npy = {k: v.reshape(s) for (k, s), v in zip(shapes.items(), np.split(packed_npy_inputs, np.cumsum(sizes[:-1])), strict=True)}
   input_queues = {
@@ -147,9 +145,9 @@ def make_input_queues(input_shapes, frame_skip, device, frame_copy_size):
     'big_img_q': Tensor(np.zeros(img_buf_shape, dtype=np.uint8), device=device).contiguous().realize(),
     'feat_q': Tensor(np.zeros((frame_skip * fb[1], fb[0], feat_dim), dtype=np.float32), device=device).contiguous().realize(),
     'desire_q': Tensor(np.zeros((frame_skip * dp[1], dp[0], dp[2]), dtype=np.float32), device=device).contiguous().realize(),
-    'packed_npy_inputs': Tensor(packed_input, device='NPY').realize(),
+    'packed_npy_inputs': Tensor(packed_npy_inputs, device='NPY').realize(),
   }
-  return input_queues, npy, frame_views
+  return input_queues, npy
 
 
 def shift_and_sample(buf, new_val, sample_fn):
@@ -169,12 +167,6 @@ def make_warp(nv12, model_w, model_h):
   frame_prepare = make_frame_prepare(nv12, model_w, model_h)
 
   def warp(tfm, big_tfm, frame, big_frame):
-    tfm = tfm.to(Device.DEFAULT)
-    big_tfm = big_tfm.to(Device.DEFAULT)
-    frame = frame.to(Device.DEFAULT)
-    big_frame = big_frame.to(Device.DEFAULT)
-    Tensor.realize(tfm, big_tfm, frame, big_frame)
-
     warped_frame = frame_prepare(frame, tfm).unsqueeze(0)
     warped_big_frame = frame_prepare(big_frame, big_tfm).unsqueeze(0)
     return Tensor.cat(warped_frame, warped_big_frame)
@@ -189,7 +181,7 @@ def make_run_policy(model_runner, model_metadata, frame_skip):
   model_input_dtypes = {name: spec.dtype for name, spec in model_runner.graph_inputs.items()}
 
   def run_policy(warped, img_q, big_img_q, feat_q, desire_q, packed_npy_inputs):
-    packed_npy_inputs = packed_npy_inputs.to(Device.DEFAULT)
+    warped = warped.to(Device.DEFAULT)
     Tensor.realize(packed_npy_inputs, warped)
 
     img = shift_and_sample(img_q, warped[0:1], sample_skip_fn)
@@ -213,39 +205,34 @@ def make_run_policy(model_runner, model_metadata, frame_skip):
   return run_policy
 
 
-def make_run_model(warp, run_policy, model_metadata, frame_copy_size):
-  _, policy_sizes = get_policy_npy_shapes(model_metadata['input_shapes'])
-  packed_npy_size = (18 + sum(policy_sizes)) * np.dtype(np.float32).itemsize
-
-  def run_model(img_q, big_img_q, feat_q, desire_q, packed_npy_inputs):
-    packed_input = packed_npy_inputs.to(Device.DEFAULT)
-    Tensor.realize(packed_input)
-    packed_npy_inputs = packed_input[:packed_npy_size].bitcast('float32')
-    frame = packed_input[packed_npy_size:packed_npy_size + frame_copy_size]
-    big_frame = packed_input[packed_npy_size + frame_copy_size:]
-    tfm, big_tfm, policy_inputs = packed_npy_inputs.split([9, 9, sum(policy_sizes)])
-    warped = warp(tfm.reshape(3, 3), big_tfm.reshape(3, 3), frame, big_frame)
-    return run_policy(warped, img_q, big_img_q, feat_q, desire_q, policy_inputs)
+def make_run_model(warp, run_policy):
+  def run_model(frame, big_frame, img_q, big_img_q, feat_q, desire_q, packed_npy_inputs):
+    warp_inputs = packed_npy_inputs.to(WARP_DEV)
+    policy_inputs = packed_npy_inputs.to(Device.DEFAULT)
+    Tensor.realize(warp_inputs, policy_inputs)
+    tfm, big_tfm = warp_inputs[:9].reshape(3, 3), warp_inputs[9:18].reshape(3, 3)
+    warped = warp(tfm, big_tfm, frame, big_frame)
+    return run_policy(warped, img_q, big_img_q, feat_q, desire_q, policy_inputs[18:])
   return run_model
 
 
-def compile_jit(jit, input_keys, make_queues, benchmark_runs):
+def compile_jit(jit, nv12, make_queues, benchmark_runs):
   if benchmark_runs < 1:
     raise ValueError("benchmark_runs must be at least 1")
 
   SEED = 42
   def random_inputs_run(fn, seed, n_runs, test_val=None, test_buffers=None, expect_match=True):
-    input_queues, npy, frame_views = make_queues(Device.DEFAULT)
+    input_queues, npy = make_queues(Device.DEFAULT)
     rng = np.random.default_rng(seed)
+    Tensor.manual_seed(seed)
 
     for i in range(n_runs):
       for v in npy.values():
         v[:] = rng.standard_normal(v.shape).astype(v.dtype)
-      for v in frame_views.values():
-        v[:] = rng.integers(0, 256, size=v.shape, dtype=np.uint8)
+      frames = make_random_frames(nv12)
       Device.default.synchronize()
       st = time.perf_counter()
-      outs = fn(**{k: input_queues[k] for k in input_keys})
+      outs = fn(**frames, **{k: input_queues[k] for k in QUEUE_INPUTS})
       mt = time.perf_counter()
       Device.default.synchronize()
       et = time.perf_counter()
@@ -311,21 +298,18 @@ if __name__ == "__main__":
   model_runner = OnnxRunner(model_path)
   out = {
     'metadata': make_metadata_dict(model_path),
-    'input_devices': {'model': Device.DEFAULT},
+    'input_devices': {'model': Device.DEFAULT, 'warp': Device.canonicalize(WARP_DEV)},
     'run_model': {},
   }
 
   run_policy = make_run_policy(model_runner, out['metadata'], args.frame_skip)
+  make_model_queues = partial(make_input_queues, out['metadata']['input_shapes'], args.frame_skip)
 
   for cam_w, cam_h in args.camera_resolutions:
     nv12 = NV12Frame(cam_w, cam_h, *get_nv12_info(cam_w, cam_h))
-    frame_copy_size = nv12_copy_size(nv12.stride, nv12.y_height, nv12.uv_height)
-    make_model_queues = partial(make_input_queues, out['metadata']['input_shapes'], args.frame_skip,
-                                frame_copy_size=frame_copy_size)
     warp = make_warp(nv12, model_w, model_h)
-    run_model_jit = TinyJit(make_run_model(warp, run_policy, out['metadata'], frame_copy_size), prune=True)
-    out['run_model'][(cam_w,cam_h)] = compile_jit(run_model_jit, MODELD_INPUTS, make_model_queues,
-                                                  args.benchmark_runs)
+    run_model_jit = TinyJit(make_run_model(warp, run_policy), prune=True)
+    out['run_model'][(cam_w,cam_h)] = compile_jit(run_model_jit, nv12, make_model_queues, args.benchmark_runs)
 
   with open(args.output, "wb") as f:
     dump_oob(out, f)

--- a/openpilot/selfdrive/modeld/modeld.py
+++ b/openpilot/selfdrive/modeld/modeld.py
@@ -4,6 +4,7 @@ import ctypes
 from functools import cached_property
 import os
 os.environ['GMMU'] = '0' # for chestnut fast loading, noop for qcom
+from tinygrad.tensor import Tensor
 from tinygrad.device import Device
 import usb1
 import struct
@@ -28,7 +29,7 @@ from openpilot.common.transformations.model import get_warp_matrix
 from openpilot.selfdrive.controls.lib.desire_helper import DesireHelper
 from openpilot.selfdrive.controls.lib.drive_helpers import get_accel_from_plan, should_stop, smooth_value, get_curvature_from_plan
 from openpilot.selfdrive.modeld.parse_model_outputs import Parser
-from openpilot.selfdrive.modeld.compile_modeld import make_input_queues, nv12_copy_size, MODELD_INPUTS
+from openpilot.selfdrive.modeld.compile_modeld import make_input_queues, QUEUE_INPUTS
 from openpilot.selfdrive.modeld.fill_model_msg import fill_model_msg, fill_driving_model_data, fill_pose_msg, PublishState
 from openpilot.common.file_chunker import open_file_chunked
 from openpilot.common.hardware.usb import CHESTNUT_USB_IDS
@@ -177,7 +178,7 @@ class ModelState:
   def __init__(self, cam_w: int, cam_h: int, chestnut: bool):
     jits = load_oob(open_file_chunked(modeld_pkl_path(chestnut)))
     input_devices = jits['input_devices']
-    self.model_device = input_devices['model']
+    self.model_device, self.warp_device = input_devices['model'], input_devices['warp']
     metadata = jits['metadata']
     self.input_shapes = metadata['input_shapes']
     self.vision_input_names = [k for k in self.input_shapes if 'img' in k]
@@ -187,9 +188,9 @@ class ModelState:
     self.chestnut = chestnut
 
     self.frame_skip = ModelConstants.MODEL_RUN_FREQ // ModelConstants.MODEL_CONTEXT_FREQ
-    self.frame_copy_size = nv12_copy_size(*get_nv12_info(cam_w, cam_h)[:3])
-    self.input_queues, self.npy, self.frame_views = make_input_queues(
-      self.input_shapes, self.frame_skip, device=self.model_device, frame_copy_size=self.frame_copy_size)
+    self.input_queues, self.npy = make_input_queues(self.input_shapes, self.frame_skip, device=self.model_device)
+    self.frame_size = get_nv12_info(cam_w, cam_h)[3]
+    self._blob_cache: dict[int, Tensor] = {}
     self.parser = Parser()
     self.run_model = jits['run_model'][(cam_w,cam_h)]
 
@@ -199,8 +200,13 @@ class ModelState:
 
   def run(self, bufs: dict[str, VisionBuf], transforms: dict[str, np.ndarray],
           inputs: dict[str, np.ndarray], after_enqueue: Callable[[], None] | None = None) -> dict[str, np.ndarray]:
+    frames = {}
     for key, buf in bufs.items():
-      np.copyto(self.frame_views[key], np.frombuffer(buf.data, dtype=np.uint8, count=self.frame_copy_size))
+      ptr = np.frombuffer(buf.data, dtype=np.uint8).ctypes.data
+      # There is a ringbuffer of imgs, just cache tensors pointing to all of them
+      if ptr not in self._blob_cache:
+        self._blob_cache[ptr] = Tensor.from_blob(ptr, (self.frame_size,), dtype='uint8', device=self.warp_device)
+      frames[key] = self._blob_cache[ptr]
 
     # Model decides when action is completed, so desire input is just a pulse triggered on rising edge
     inputs['desire_pulse'][0] = 0
@@ -211,7 +217,7 @@ class ModelState:
     self.npy['tfm'][:,:] = transforms['img'][:,:]
     self.npy['big_tfm'][:,:] = transforms['big_img'][:,:]
 
-    outs, = self.run_model(**{k: self.input_queues[k] for k in MODELD_INPUTS})
+    outs, = self.run_model(frame=frames['img'], big_frame=frames['big_img'], **{k: self.input_queues[k] for k in QUEUE_INPUTS})
     if after_enqueue is not None:
       after_enqueue()
     model_output = outs.numpy()[0]
@@ -225,13 +231,13 @@ class ModelState:
     return outputs_dict
 
   def warmup(self) -> None:
-    dummy_frames = {k: np.zeros(self.frame_copy_size, dtype=np.uint8) for k in self.vision_input_names}
+    dummy_frames = {k: np.zeros(self.frame_size, dtype=np.uint8) for k in self.vision_input_names}
     eye = np.eye(3, dtype=np.float32)
     dims = {'desire_pulse': ModelConstants.DESIRE_LEN, 'traffic_convention': 2, 'action_t': 2}
     self.run(dummy_frames, dict.fromkeys(self.vision_input_names, eye), {k: np.zeros(v, dtype=np.float32) for k, v in dims.items()})
-    self.input_queues, self.npy, self.frame_views = make_input_queues(
-      self.input_shapes, self.frame_skip, device=self.model_device, frame_copy_size=self.frame_copy_size)
+    self.input_queues, self.npy = make_input_queues(self.input_shapes, self.frame_skip, device=self.model_device)
     self.prev_desire[:] = 0
+    self._blob_cache.clear()
 
 
 def main(demo=False):


### PR DESCRIPTION
Since #38684 the warp runs on the chestnut and therefore both full frames from both cameras get copied over USB every frame. This was okay for comma 4 as the cameras are binning to a quarter of the pixels already (2688x1520 -> 1344x760), but comma 3x does not do this and sends its full resolution of 1928x1208 every frame.

The amount of data required to send over USB for this is about **~3.2MB/frame** for the comma 4, which is just about fine, but for the comma 3x this is **~7.5MB/frame** which takes around 22ms just to copy the frame over which alongside warp and the model execution itself exceeds the 50ms budget in real world conditions causing the "Driving Model Lagging" alert to appear and the chestnut model to be barely usable on a 3x.

This PR gives the best of both worlds, keeps all the cool stuff from #38684 but brings warp back to the QCOM so we send much less data over the wire and significantly reduce latency on the comma 3x (around 18ms savings with real on-road at ~29ms/frame) and on the comma 4 too (around 4.4ms savings on bench) and effectively restores support for the comma 3x + chestnut.

Note that `model_replay` shows a small change count with far lane line / road edge points shifting 1-2cm due to the way QCOM vs chestnut round the warp's nearest neighbour sampling slightly differently. It effectively brings it back to the exact behaviour before #38684 though. Note that the `model_replay` CI ref will need regenerating for this PR as it will go red with this change.

Tests / proof:

<img width="1804" height="650" alt="image" src="https://github.com/user-attachments/assets/14a77f70-0af0-49d9-a067-1ad9a3d0f438" />

This graph was made using the `process_replay` tool through the real `modeld` on a comma 3x with chestnut which shows clearly the improvement in overall latency.

<img width="1874" height="678" alt="onroad_exec" src="https://github.com/user-attachments/assets/a57354d3-dfef-489e-a491-7c1c938cdad2" />

This graph uses data from the routes below to show the real world latency on three short drives on the same route.

Routes:
- Before route 1 (driving model lagging): https://connect.comma.ai/4b3cbd6038d07ca6/000002ef--ef2c549f0a
- Before route 2 (driving model lagging): https://connect.comma.ai/4b3cbd6038d07ca6/000002f0--279c3e8f37
- After route (engages correctly, latency well under 50ms): https://connect.comma.ai/4b3cbd6038d07ca6/000002ee--634333b036

All three routes are based on openpilot/master but include https://github.com/commaai/opendbc/pull/3389 in order to actually drive on road.

Changes restored from before #38684:
- Warp runs on QCOM again and hands the warped crop to the chestnut
- Camera frames are handed to the model in place instead of copied to a transfer buffer first
- Only the small warped crop crosses USB instead of both full frames

Things that were kept from #38684:
- The single fused warp+policy TinyJit 
- Non-frame inputs packed into one buffer to avoid lots of tiny transfers
- Per resolution compile, build-time benchmark, pickle round-trip / correctness checks
- The warp and model math itself

Brand new changes:
- The fused TinyJit is used on both QCOM and chestnut and transferred using `warped.to(Device.DEFAULT)`
- Compiled model now stores which device the frames belong on, runtime just reads it back

Full disclosure: Claude Fable 5.1 wrote these changes with guidance from me but I have made sure I understand and agree with the changes and they have been tested as much as I could both on bench and on road.